### PR TITLE
feat: add openspec-task-loop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ _* Skills marked with * can be used repeatedly during development iterations._
 | **code-optimizer** | 1.0.0 | Analyze code for performance issues and optimizations |
 | **code-review** | 1.0.0 | Review code for smells and pragmatic programming violations |
 | **devops-pipeline** | 1.0.0 | Setup pre-commit hooks and GitHub Actions for CI/CD |
+| **openspec-task-loop** | 1.0.0 | Execute OpenSpec in strict one-task-per-change loops with archive/verify gates |
 | **ollama-optimizer** | 1.0.0 | Optimize Ollama configuration for maximum local LLM performance |
 | **install-script-generator** | 1.0.0 | Generate cross-platform installation scripts with environment detection |
 | **note-taker** | 1.0.0 | Capture notes (text, voice, image) into a git-backed repo with task extraction |
@@ -119,6 +120,7 @@ Skills trigger automatically based on your requests:
 | "push my changes" | auto-push |
 | "optimize this code" | code-optimizer |
 | "setup CI/CD" | devops-pipeline |
+| "run one OpenSpec task at a time" | openspec-task-loop |
 | "evaluate my idea" | idea-validator |
 | "create a PRD" | prd-generator |
 | "make this open source" | oss-ready |

--- a/skills/openspec-task-loop/SKILL.md
+++ b/skills/openspec-task-loop/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: openspec-task-loop
+version: 1.0.0
+description: Apply OpenSpec OPSX in a strict one-task-at-a-time loop. Use when the user asks to execute work as single-task changes, wants spec-first implementation per task, or says to use OpenSpec method for each task from a task list. Supports both native /opsx command environments and manual fallback by creating OpenSpec artifact files directly.
+---
+
+# OpenSpec Task Loop
+
+## Overview
+
+Run OpenSpec as **one task = one change**. Keep scope tight, generate artifacts, implement, verify, and archive before moving to the next task.
+
+## Workflow Decision
+
+1. **If `/opsx:*` commands are supported in the current coding tool**: use native OPSX flow.
+2. **If not supported**: use manual fallback by creating files under `openspec/changes/<change-id>/`.
+
+## Core Loop (Single Task)
+
+For each selected task from `tasks.md`:
+
+1. **Select exactly one task**
+   - Keep one atomic unit of value (usually 1–3 dev days).
+   - If too large, split before proceeding.
+
+2. **Create a task-scoped change**
+   - Use change id format: `task-<task-id>-<short-slug>` (example: `task-2-3-pin-crud`).
+
+3. **Plan with OpenSpec artifacts**
+   - `proposal.md`: intent, scope, acceptance criteria, out-of-scope.
+   - `specs/.../spec.md`: requirements and GIVEN/WHEN/THEN scenarios.
+   - `design.md`: implementation approach and tradeoffs.
+   - `tasks.md`: implementation checklist for this single task.
+
+4. **Implement only this task scope**
+   - Do not include unrelated refactors.
+   - Update checkboxes as work completes.
+
+5. **Verify before archive**
+   - Validate completeness, correctness, coherence.
+   - Fix critical mismatches before archive.
+
+6. **Archive and sync**
+   - Merge delta specs if needed.
+   - Archive change folder.
+   - Mark the parent project task complete.
+
+## Native OPSX Command Path
+
+Use this sequence per task:
+
+```text
+/opsx:new task-<task-id>-<slug>
+/opsx:ff <change-id>          # or /opsx:continue for stepwise control
+/opsx:apply <change-id>
+/opsx:verify <change-id>
+/opsx:archive <change-id>
+```
+
+Rules:
+- Prefer `/opsx:continue` when requirements are still unclear.
+- Prefer `/opsx:ff` when scope is clear and small.
+- If implementation reveals drift, update artifacts before continuing.
+
+## Manual Fallback Path (No /opsx Support)
+
+If slash commands are unavailable:
+
+1. Ensure OpenSpec tree exists (`openspec/changes`, `openspec/specs`).
+2. Scaffold one change folder with:
+   - `proposal.md`
+   - `design.md`
+   - `tasks.md`
+   - `specs/<capability>/spec.md`
+3. Use templates from `references/openspec-task-templates.md`.
+4. Implement task and update checkboxes.
+5. Run local validation/tests.
+6. Merge spec deltas into `openspec/specs/` and move change to `openspec/changes/archive/<date>-<change-id>/`.
+
+## Quality Gate (must pass before archive)
+
+- [ ] Scope remained single-task and atomic
+- [ ] Acceptance criteria satisfied
+- [ ] Spec scenarios reflected in tests or executable checks
+- [ ] No unrelated files changed
+- [ ] Parent `tasks.md` updated with completion state
+- [ ] Archive note includes what changed and why
+
+## Output Format for Updates
+
+When reporting progress, use:
+
+```markdown
+Task: <id + title>
+Change: <openspec change id>
+Status: planning | implementing | verifying | archived
+Done:
+- ...
+Next:
+- ...
+Risks/Notes:
+- ...
+```
+
+## Resources
+
+- `references/openspec-task-templates.md` — proposal/spec/design/tasks templates for manual mode.
+- `scripts/new_task_change.sh` — optional scaffold script for manual mode.

--- a/skills/openspec-task-loop/references/openspec-task-templates.md
+++ b/skills/openspec-task-loop/references/openspec-task-templates.md
@@ -1,0 +1,124 @@
+# OpenSpec Single-Task Templates
+
+Use these templates when `/opsx:*` commands are unavailable and you need to apply OpenSpec manually.
+
+## Folder Layout
+
+```text
+openspec/
+  changes/
+    <change-id>/
+      .openspec.yaml
+      proposal.md
+      design.md
+      tasks.md
+      specs/
+        <capability>/
+          spec.md
+```
+
+---
+
+## `.openspec.yaml`
+
+```yaml
+schema: spec-driven
+createdAt: <ISO-8601>
+changeId: <change-id>
+sourceTask: <parent task id>
+```
+
+---
+
+## `proposal.md`
+
+```markdown
+# Proposal: <change-id>
+
+## Why
+<Problem and user impact>
+
+## Scope
+- In scope:
+  - <single-task scope>
+- Out of scope:
+  - <explicitly excluded items>
+
+## Acceptance Criteria
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+## Risks
+- <risk + mitigation>
+```
+
+---
+
+## `specs/<capability>/spec.md`
+
+```markdown
+# <capability> Specification Delta
+
+### Requirement: <name>
+- The system SHALL <required behavior>.
+
+#### Scenario: <happy path>
+- GIVEN <state>
+- WHEN <trigger>
+- THEN <expected result>
+
+#### Scenario: <edge/error path>
+- GIVEN <state>
+- WHEN <trigger>
+- THEN <expected result>
+```
+
+---
+
+## `design.md`
+
+```markdown
+# Design: <change-id>
+
+## Approach
+<How this task is implemented>
+
+## Files Affected
+- <path>: <reason>
+
+## Decisions
+- Decision: <what>
+- Rationale: <why>
+- Tradeoff: <cost>
+
+## Validation Plan
+- Unit/integration checks:
+  - <check 1>
+  - <check 2>
+```
+
+---
+
+## `tasks.md`
+
+```markdown
+# Tasks: <change-id>
+
+- [ ] 1. Implement <first concrete step>
+- [ ] 2. Add/adjust tests for <scenario>
+- [ ] 3. Run validation checks
+- [ ] 4. Update docs/spec delta if behavior changed during implementation
+```
+
+---
+
+## Archive Note (recommended)
+
+Add to parent project log:
+
+```markdown
+- <date> Archived `<change-id>` for task `<task-id>`
+  - Outcome: <what shipped>
+  - Spec impact: <which capability/spec updated>
+  - Verification: <tests/checks passed>
+```

--- a/skills/openspec-task-loop/scripts/new_task_change.sh
+++ b/skills/openspec-task-loop/scripts/new_task_change.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <change-id> <capability> [task-id]"
+  echo "Example: $0 task-2-3-pin-crud dashboard 2.3"
+  exit 1
+fi
+
+CHANGE_ID="$1"
+CAPABILITY="$2"
+TASK_ID="${3:-unknown}"
+ROOT="openspec/changes/${CHANGE_ID}"
+SPEC_DIR="${ROOT}/specs/${CAPABILITY}"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+mkdir -p "${SPEC_DIR}"
+
+cat > "${ROOT}/.openspec.yaml" <<YAML
+schema: spec-driven
+createdAt: ${NOW}
+changeId: ${CHANGE_ID}
+sourceTask: ${TASK_ID}
+YAML
+
+cat > "${ROOT}/proposal.md" <<MD
+# Proposal: ${CHANGE_ID}
+
+## Why
+TODO
+
+## Scope
+- In scope:
+  - TODO
+- Out of scope:
+  - TODO
+
+## Acceptance Criteria
+- [ ] TODO
+- [ ] TODO
+
+## Risks
+- TODO
+MD
+
+cat > "${ROOT}/design.md" <<MD
+# Design: ${CHANGE_ID}
+
+## Approach
+TODO
+
+## Files Affected
+- TODO
+
+## Decisions
+- Decision: TODO
+- Rationale: TODO
+- Tradeoff: TODO
+
+## Validation Plan
+- TODO
+MD
+
+cat > "${ROOT}/tasks.md" <<MD
+# Tasks: ${CHANGE_ID}
+
+- [ ] 1. TODO
+- [ ] 2. TODO
+- [ ] 3. Run validation checks
+- [ ] 4. Update docs/spec delta if needed
+MD
+
+cat > "${SPEC_DIR}/spec.md" <<MD
+# ${CAPABILITY} Specification Delta
+
+### Requirement: TODO
+- The system SHALL TODO.
+
+#### Scenario: Happy path
+- GIVEN TODO
+- WHEN TODO
+- THEN TODO
+
+#### Scenario: Edge case
+- GIVEN TODO
+- WHEN TODO
+- THEN TODO
+MD
+
+echo "Created OpenSpec task change scaffold: ${ROOT}"


### PR DESCRIPTION
## Summary
- add new `openspec-task-loop` skill under `skills/`
- include reusable references template and scaffold script for manual OpenSpec mode
- update README skill catalog and usage trigger table to include the new skill

## Files added
- `skills/openspec-task-loop/SKILL.md`
- `skills/openspec-task-loop/references/openspec-task-templates.md`
- `skills/openspec-task-loop/scripts/new_task_change.sh`

## README updates
- Added `openspec-task-loop` row in **Development Workflow** skills table
- Added usage mapping example: "run one OpenSpec task at a time"

## Notes
- Skill version set to `1.0.0` for consistency with repository conventions.