### PR TITLE
refactor(skills): add negative-trigger clauses and fix frontmatter

### DIFF
--- a/skills/agent-config/SKILL.md
+++ b/skills/agent-config/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: agent-config
-description: Create or update CLAUDE.md and AGENTS.md files following official best practices. Use when asked to create, update, audit, or improve project configuration files for AI agents, or when users mention "CLAUDE.md", "AGENTS.md", "agent config", or "agent instructions".
+description: "Create or update CLAUDE.md and AGENTS.md files following official best practices. Use when asked to create, update, audit, or improve project configuration files for AI agents, or when users mention CLAUDE.md, AGENTS.md, agent config, or agent instructions. Don't use for editing README/contributor docs, writing generic prompts, or configuring non-Claude IDE plugins."
 effort: medium
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 ## Repo Sync Before Edits (mandatory)

--- a/skills/appstore-review-checker/SKILL.md
+++ b/skills/appstore-review-checker/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: appstore-review-checker
-description: Audit iOS/macOS app projects against Apple App Store Review Guidelines to catch rejection risks before submission, with per-guideline PASS/FAIL/WARNING verdicts and fix suggestions.
+description: "Audit iOS/macOS app projects against Apple App Store Review Guidelines to catch rejection risks before submission, with per-guideline PASS/FAIL/WARNING verdicts and fix suggestions. Don't use for Google Play/Android submissions, general code review, or post-rejection appeal drafting."
 effort: high
-version: 1.1.1
+license: MIT
+metadata:
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # App Store Review Checker

--- a/skills/aso-marketing/SKILL.md
+++ b/skills/aso-marketing/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: aso-marketing
-description: Optimize App Store and Google Play listings with keyword strategy, metadata, and localization. Use when asked to improve app store visibility, ASO, or app discoverability.
+description: "Optimize App Store and Google Play listings with keyword strategy, metadata, and localization. Use when asked to improve app store visibility, ASO, or app discoverability. Don't use for web SEO, paid UA/ad campaigns, or pre-submission compliance/review audits."
 effort: max
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 ## Environment Check

--- a/skills/auto-push/SKILL.md
+++ b/skills/auto-push/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: auto-push
-description: Stage all changes, commit with a generated message, and push to remote — with safety checks for secrets, large files, and protected branches. Executes immediately after checks pass; no extra confirmation needed.
+description: "Stage all changes, commit with a generated message, and push to remote — with safety checks for secrets, large files, and protected branches. Executes immediately after checks pass; no extra confirmation needed. Don't use for opening PRs, performing code review, or cutting releases/tags."
 effort: low
 license: MIT
 metadata:
-  version: 1.0.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Commit and Push Everything

--- a/skills/cli-builder/SKILL.md
+++ b/skills/cli-builder/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: cli-builder
-description: "Build a production-quality CLI tool for any module or application. Auto-detects language, recommends CLI libraries, and follows a 5-step approval-gated workflow: Analyze, Design, Plan, Execute, Summarize."
+description: "Build a production-quality CLI tool for any module or application. Auto-detects language, recommends CLI libraries, and follows a 5-step approval-gated workflow: Analyze, Design, Plan, Execute, Summarize. Don't use for building GUI/TUI apps, web APIs, or authoring one-off shell scripts."
 effort: high
 license: MIT
 metadata:
-  version: 1.0.2
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.3
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # CLI Builder

--- a/skills/code-optimizer/SKILL.md
+++ b/skills/code-optimizer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: code-optimizer
-description: Analyze code for performance issues and suggest optimizations. Use when users ask to "optimize this code", "find performance issues", "improve performance", "check for memory leaks", "review code efficiency", or want to identify bottlenecks, algorithmic improvements, caching opportunities, or concurrency problems.
+description: "Analyze code for performance issues and suggest optimizations. Use when users ask to optimize this code, find performance issues, improve performance, check for memory leaks, review code efficiency, or want to identify bottlenecks, algorithmic improvements, caching opportunities, or concurrency problems. Don't use for bug-hunting code review, security audits, or general refactoring without a perf goal."
 effort: medium
 license: MIT
 metadata:
-  version: 1.2.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Code Optimization

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: code-review
-description: Review code changes for bugs, security vulnerabilities, and code quality issues — producing prioritized findings with specific fix suggestions.
+description: "Review code changes for bugs, security vulnerabilities, and code quality issues — producing prioritized findings with specific fix suggestions. Don't use for performance tuning, writing new features from scratch, or generating test cases."
 effort: medium
 license: MIT
 metadata:
-  version: 1.1.2
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.3
+  author: Luong NGUYEN <luongnv89@gmail.com>
   architecture: "subagent (Pattern B+C: Parallel Workers + Review Loop)"
 ---
 

--- a/skills/context-hub/SKILL.md
+++ b/skills/context-hub/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: context-hub
-description: Fetch up-to-date third-party API/SDK docs via `chub` before writing or reviewing integration code — so method names, payload fields, and auth headers are always sourced from live docs, not stale training data.
+description: "Fetch up-to-date third-party API/SDK docs via chub before writing or reviewing integration code — so method names, payload fields, and auth headers are always sourced from live docs, not stale training data. Don't use for first-party project docs, generic programming questions, or when the user only wants a conceptual answer rather than integration code."
 effort: low
 license: MIT
 metadata:
-  version: 1.0.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Context Hub

--- a/skills/devops-pipeline/SKILL.md
+++ b/skills/devops-pipeline/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: devops-pipeline
-description: Implement pre-commit hooks and lean GitHub Actions for shift-left quality assurance — maximizing local test coverage and minimizing CI cost.
+description: "Implement pre-commit hooks and lean GitHub Actions for shift-left quality assurance — maximizing local test coverage and minimizing CI cost. Don't use for cloud infrastructure provisioning (Terraform, K8s), application deployment pipelines, or non-GitHub CI providers (GitLab, CircleCI)."
 effort: medium
 license: MIT
 metadata:
-  version: 2.0.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 2.0.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # DevOps Pipeline

--- a/skills/docs-generator/SKILL.md
+++ b/skills/docs-generator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: docs-generator
-description: Generate and restructure project documentation into a clear, accessible hierarchy. Use when asked to "organize docs", "generate documentation", "improve doc structure", or "restructure README".
+description: "Generate and restructure project documentation into a clear, accessible hierarchy. Use when asked to organize docs, generate documentation, improve doc structure, or restructure README. Don't use for API reference generation from code (JSDoc/Sphinx), authoring a landing page, or agent-config files like CLAUDE.md."
 effort: low
 license: MIT
 metadata:
-  version: 1.2.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Documentation Generator

--- a/skills/dont-make-me-think/SKILL.md
+++ b/skills/dont-make-me-think/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dont-make-me-think
-description: Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code.
+description: "Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code. Don't use for visual/brand design critique, accessibility (WCAG) audits, or backend/API review."
 effort: medium
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Don't Make Me Think — Usability Review & Redesign

--- a/skills/drawio-generator/SKILL.md
+++ b/skills/drawio-generator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: drawio-generator
-description: Generate professional diagrams as valid draw.io XML files — flowcharts, architecture, C4 models, ER diagrams, sequence diagrams, mind maps, and swimlanes.
+description: "Generate professional diagrams as valid draw.io XML files — flowcharts, architecture, C4 models, ER diagrams, sequence diagrams, mind maps, and swimlanes. Don't use for Excalidraw or Mermaid output, hand-drawn sketch styles, or slide decks/presentations."
 effort: high
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Draw.io Diagram Generator

--- a/skills/excalidraw-generator/SKILL.md
+++ b/skills/excalidraw-generator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: excalidraw-generator
-description: "Generate professional diagrams as valid Excalidraw JSON files — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Understands text, code, schemas, or verbal descriptions."
+description: "Generate professional diagrams as valid Excalidraw JSON files — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Understands text, code, schemas, or verbal descriptions. Don't use for draw.io/Mermaid output, polished production slide decks, or pixel-perfect brand graphics."
 effort: high
 license: MIT
 metadata:
-  version: 1.2.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Excalidraw Diagram Generator

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: frontend-design
-description: Design and implement production-grade frontend interfaces with distinctive aesthetics and working code. Use when asked to build a UI, component, page, or frontend feature.
+description: "Design and implement production-grade frontend interfaces with distinctive aesthetics and working code. Use when asked to build a UI, component, page, or frontend feature. Don't use for backend/API work, usability-only audits, or reskinning an existing theme to a cyberpunk/dark variant."
 effort: high
 license: MIT
 metadata:
-  version: 1.2.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Frontend Design

--- a/skills/github-issue-creator/SKILL.md
+++ b/skills/github-issue-creator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: github-issue-creator
-description: "Create or update GitHub issues from screenshots, emails, messages, or any visual/text input. Extracts structured data, redacts PII, detects issue templates, proposes issues for approval, then files them via gh CLI."
+description: "Create or update GitHub issues from screenshots, emails, messages, or any visual/text input. Extracts structured data, redacts PII, detects issue templates, proposes issues for approval, then files them via gh CLI. Don't use for GitLab/Jira tickets, opening pull requests, or fixing the bug described in the issue."
 effort: medium
 license: MIT
 metadata:
-  version: 1.0.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # GitHub Issue Creator

--- a/skills/idea-validator/SKILL.md
+++ b/skills/idea-validator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: idea-validator
-description: Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea.
+description: "Evaluate app ideas and startup concepts across market viability, technical feasibility, and competitive landscape. Use when asked to validate, review, or score a product idea. Don't use for writing a PRD, detailed go-to-market plans, or financial/investor pitch decks."
 effort: max
 license: MIT
 metadata:
-  version: 1.3.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.3.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Idea Validator

--- a/skills/install-script-generator/SKILL.md
+++ b/skills/install-script-generator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: install-script-generator
-description: Generate cross-platform installation scripts for any software, library, or module. Produces a standalone install.sh runnable via a single curl/wget one-liner, with automatic OS, architecture, and package manager detection.
+description: "Generate cross-platform installation scripts for any software, library, or module. Produces a standalone install.sh runnable via a single curl/wget one-liner, with automatic OS, architecture, and package manager detection. Don't use for authoring Dockerfiles, CI/CD pipelines, or one-off local shell scripts."
 effort: high
 license: MIT
 metadata:
-  version: 2.0.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 2.0.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Install Script Generator

--- a/skills/logo-designer/SKILL.md
+++ b/skills/logo-designer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: logo-designer
-description: "Design professional SVG logos by analyzing project context and generating 7 brand asset variants — mark, full, wordmark, icon, favicon, white, and black — plus a brand showcase HTML page."
+description: "Design professional SVG logos by analyzing project context and generating 7 brand asset variants — mark, full, wordmark, icon, favicon, white, and black — plus a brand showcase HTML page. Don't use for raster-only logos, product illustration/marketing graphics, or full brand-guideline documents."
 effort: medium
 license: MIT
 metadata:
-  version: 1.2.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 ## Environment Check

--- a/skills/name-checker/SKILL.md
+++ b/skills/name-checker/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: name-checker
-description: Check product and brand names for conflicts across trademarks, domains, social media handles, and package registries (npm, PyPI, Homebrew, apt). Delivers a risk assessment and actionable Proceed, Modify, or Abandon recommendation.
+description: "Check product and brand names for conflicts across trademarks, domains, social media handles, and package registries (npm, PyPI, Homebrew, apt). Delivers a risk assessment and actionable Proceed, Modify, or Abandon recommendation. Don't use for brainstorming name ideas from scratch, logo design, or filing/registering a trademark."
 effort: max
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Name Checker

--- a/skills/note-taker/SKILL.md
+++ b/skills/note-taker/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: note-taker
-description: Capture chat notes (text, voice, image, video, file) into a git-backed notes repo, summarize and organize them, and extract tasks into KANBAN.md. Use when user says they want to take a note, save a note, capture this, or manage their notes/backlog.
+description: "Capture chat notes (text, voice, image, video, file) into a git-backed notes repo, summarize and organize them, and extract tasks into KANBAN.md. Use when user says they want to take a note, save a note, capture this, or manage their notes/backlog. Don't use for editing project source code, writing documentation inside the current repo, or issue/PR creation on GitHub."
 effort: low
 argument-hint: "[optional title or tags]"
 disable-model-invocation: true
 license: MIT
 metadata:
-  version: 1.4.2
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.4.4
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Note Taker (Git-managed)

--- a/skills/ollama-optimizer/SKILL.md
+++ b/skills/ollama-optimizer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ollama-optimizer
-description: Optimize Ollama configuration for maximum performance on the current machine. Use when asked to "optimize Ollama", "configure Ollama", "speed up Ollama", "tune LLM performance", "setup local LLM", "fix Ollama performance", "Ollama running slow", or when users want to maximize inference speed, reduce memory usage, or select appropriate models for their hardware. Analyzes system hardware (GPU, RAM, CPU) and provides tailored recommendations.
+description: "Optimize Ollama configuration for maximum performance on the current machine. Use when asked to optimize Ollama, configure Ollama, speed up Ollama, tune LLM performance, setup local LLM, fix Ollama performance, Ollama running slow, or when users want to maximize inference speed, reduce memory usage, or select appropriate models for their hardware. Analyzes system hardware (GPU, RAM, CPU) and provides tailored recommendations. Don't use for LM Studio, llama.cpp, vLLM, or hosted-API LLM providers (OpenAI, Anthropic)."
 effort: medium
 license: MIT
 metadata:
-  version: 1.0.2
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.3
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Ollama Optimizer

--- a/skills/opencode-runner/SKILL.md
+++ b/skills/opencode-runner/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: opencode-runner
-description: Delegate coding tasks to opencode using free cloud models. Use when asked to run a task with opencode, use a free model, or offload coding work to opencode.ai.
+description: "Delegate coding tasks to opencode using free cloud models. Use when asked to run a task with opencode, use a free model, or offload coding work to opencode.ai. Don't use for running local models (Ollama/LM Studio), Claude/OpenAI-hosted calls, or when the user wants Claude itself to do the work."
 effort: medium
 license: MIT
 metadata:
-  version: 1.2.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # OpenCode Runner

--- a/skills/openspec-task-loop/SKILL.md
+++ b/skills/openspec-task-loop/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: openspec-task-loop
-description: Execute a spec-first one-task-at-a-time loop using OpenSpec OPSX. Use when asked to implement tasks from a list with single-task scope, spec artifacts, and sequential verification before archiving.
+description: "Execute a spec-first one-task-at-a-time loop using OpenSpec OPSX. Use when asked to implement tasks from a list with single-task scope, spec artifacts, and sequential verification before archiving. Don't use for ad-hoc multi-task implementation, non-OpenSpec task trackers, or writing the specs themselves from scratch."
 effort: medium
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # OpenSpec Task Loop

--- a/skills/oss-ready/SKILL.md
+++ b/skills/oss-ready/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oss-ready
-description: Transform projects into professional open-source repositories with standard components. Use when users ask to "make this open source", "add open source files", "setup OSS standards", "create contributing guide", "add license", or want to prepare a project for public release with README, CONTRIBUTING, LICENSE, and GitHub templates.
+description: "Transform projects into professional open-source repositories with standard components. Use when users ask to make this open source, add open source files, setup OSS standards, create contributing guide, add license, or want to prepare a project for public release with README, CONTRIBUTING, LICENSE, and GitHub templates. Don't use for documentation structure overhauls, landing-page generation, or releasing/publishing to registries."
 effort: low
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # OSS Ready

--- a/skills/prd-generator/SKILL.md
+++ b/skills/prd-generator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: prd-generator
-description: Generate comprehensive Product Requirements Documents (PRD) from idea validation files. Use when users ask to "create a PRD", "generate product requirements", "write a PRD", or want to turn validated ideas into actionable product specs. Works with idea.md and validate.md files.
+description: "Generate comprehensive Product Requirements Documents (PRD) from idea validation files. Use when users ask to create a PRD, generate product requirements, write a PRD, or want to turn validated ideas into actionable product specs. Works with idea.md and validate.md files. Don't use for technical architecture design (TAD), sprint/task breakdown, or raw idea validation."
 effort: max
 license: MIT
 metadata:
-  version: 1.2.3
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.4
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # PRD Generator

--- a/skills/readme-to-landing-page/SKILL.md
+++ b/skills/readme-to-landing-page/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: readme-to-landing-page
-description: "Transform a project README.md into a conversion-optimized landing page using PAS, AIDA, or StoryBrand frameworks — hero, value prop, how it works, quick start, and CTA in pure GitHub-renderable markdown."
+description: "Transform a project README.md into a conversion-optimized landing page using PAS, AIDA, or StoryBrand frameworks — hero, value prop, how it works, quick start, and CTA in pure GitHub-renderable markdown. Don't use for full HTML/CSS marketing sites, rewriting the README itself, or general blog copy."
 effort: high
 license: MIT
 metadata:
-  version: 2.0.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 2.0.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # README to Landing Page

--- a/skills/release-manager/SKILL.md
+++ b/skills/release-manager/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: release-manager
-description: Automate the full release lifecycle — version bump, changelog, README update, git tag, GitHub release, and PyPI/npm publishing. Use this skill whenever the user wants to cut a release, bump a version, tag and push, create a GitHub release, generate release notes or a changelog, publish to PyPI or npm, or asks what changed since the last release. Even if the user just says "ship it", "make a release", or "tag this version" — this skill should handle it.
+description: "Automate the full release lifecycle — version bump, changelog, README update, git tag, GitHub release, and PyPI/npm publishing. Use this skill whenever the user wants to cut a release, bump a version, tag and push, create a GitHub release, generate release notes or a changelog, publish to PyPI or npm, or asks what changed since the last release. Even if the user just says ship it, make a release, or tag this version — this skill should handle it. Don't use for routine commit/push, opening PRs, or publishing to VS Code Marketplace/App Store (use the dedicated skills)."
 effort: max
 license: MIT
 metadata:
-  version: 2.4.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 2.4.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Release Manager

--- a/skills/seo-ai-optimizer/SKILL.md
+++ b/skills/seo-ai-optimizer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: seo-ai-optimizer
-description: Audit and optimize website codebases for technical SEO, content SEO, and AI bot accessibility. Fixes meta tags, sitemaps, robots.txt, structured data, llms.txt, and GPTBot/ClaudeBot directives across any web framework.
+description: "Audit and optimize website codebases for technical SEO, content SEO, and AI bot accessibility. Fixes meta tags, sitemaps, robots.txt, structured data, llms.txt, and GPTBot/ClaudeBot directives across any web framework. Don't use for App Store/Play Store ASO, paid search campaigns, or writing blog content from scratch."
 effort: high
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # SEO & AI Bot Optimizer

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -4,8 +4,8 @@ description: "Create new skills, modify and improve existing skills, and measure
 effort: max
 license: MIT
 metadata:
-  version: 1.3.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.3.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Skill Creator

--- a/skills/skill-inventory-auditor/SKILL.md
+++ b/skills/skill-inventory-auditor/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: skill-inventory-auditor
-description: Audit all installed agent skills across global and project scopes to find and remove duplicate skills. Use when asked to "audit my skills", "deduplicate skills", "clean up skills", or "find duplicate skill installations".
+description: "Audit all installed agent skills across global and project scopes to find and remove duplicate skills. Use when asked to audit my skills, deduplicate skills, clean up skills, or find duplicate skill installations. Don't use for creating or improving a single skill, running skill evals, or packaging/publishing skills."
 effort: low
 license: MIT
 metadata:
-  version: 1.0.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Skill Inventory Auditor

--- a/skills/slop-code/SKILL.md
+++ b/skills/slop-code/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: slop-code
-description: "Clean up a codebase by removing AI slop, dead code, weak types, duplication, defensive over-engineering, and legacy cruft using 8 parallel specialized subagents across two cleanup waves."
+description: "Clean up a codebase by removing AI slop, dead code, weak types, duplication, defensive over-engineering, and legacy cruft using 8 parallel specialized subagents across two cleanup waves. Don't use for adding new features, performance tuning, or security-only audits."
 effort: high
 license: MIT
 metadata:
-  version: 1.0.0
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
   architecture: "subagent (Pattern B: Parallel Workers, 8 specialized cleaners)"
 ---
 

--- a/skills/system-design/SKILL.md
+++ b/skills/system-design/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: system-design
-description: Generate Technical Architecture Documents (TAD) from PRD files. Use when users ask to "design the architecture", "create a TAD", "system design", or want to define how a product will be built. Creates/updates tad.md and always reports GitHub links to changed files.
+description: "Generate Technical Architecture Documents (TAD) from PRD files. Use when users ask to design the architecture, create a TAD, system design, or want to define how a product will be built. Creates/updates tad.md and always reports GitHub links to changed files. Don't use for writing the PRD itself, generating sprint tasks, or implementing code from the architecture."
 effort: max
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # System Design

--- a/skills/tasks-generator/SKILL.md
+++ b/skills/tasks-generator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: tasks-generator
-description: Generate development tasks from a PRD file with sprint-based planning. Use when users ask to "create tasks from PRD", "break down the PRD", "generate sprint tasks", or want to convert product requirements into actionable development tasks. Creates/updates tasks.md and always reports GitHub links to changed files.
+description: "Generate development tasks from a PRD file with sprint-based planning. Use when users ask to create tasks from PRD, break down the PRD, generate sprint tasks, or want to convert product requirements into actionable development tasks. Creates/updates tasks.md and always reports GitHub links to changed files. Don't use for writing a PRD, authoring a TAD, or executing tasks (see openspec-task-loop)."
 effort: max
 license: MIT
 metadata:
-  version: 1.1.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Tasks Generator

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: test-coverage
-description: Expand unit test coverage by targeting untested branches and edge cases in any language. Identifies coverage gaps, writes new tests using the project's existing framework, and verifies measurable improvement.
+description: "Expand unit test coverage by targeting untested branches and edge cases in any language. Identifies coverage gaps, writes new tests using the project's existing framework, and verifies measurable improvement. Don't use for integration/E2E test suites, migrating between test frameworks, or fixing bugs in production code."
 effort: low
 license: MIT
 metadata:
-  version: 1.2.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Test Coverage Expander

--- a/skills/theme-transformer/SKILL.md
+++ b/skills/theme-transformer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: theme-transformer
-description: Transform an existing website/app UI into a futuristic cyberpunk, neon, space, or digital-dark theme with user-adjustable colors. Use when asked to "reskin the UI", "dark theme", "cyberpunk style", or "make the interface futuristic".
+description: "Transform an existing website/app UI into a futuristic cyberpunk, neon, space, or digital-dark theme with user-adjustable colors. Use when asked to reskin the UI, dark theme, cyberpunk style, or make the interface futuristic. Don't use for building a UI from scratch, pure light/minimal themes, or backend/API changes."
 effort: medium
 license: MIT
 metadata:
-  version: 1.0.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Theme Transformer

--- a/skills/vscode-extension-publisher/SKILL.md
+++ b/skills/vscode-extension-publisher/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: vscode-extension-publisher
-description: Publish VS Code extensions to the Visual Studio Marketplace. Use when asked to "publish my extension", "setup VS Code marketplace publishing", "package vscode extension", "create a publisher", "setup PAT for vsce", "automate extension releases with GitHub Actions", or need help with vsce commands.
+description: "Publish VS Code extensions to the Visual Studio Marketplace. Use when asked to publish my extension, setup VS Code marketplace publishing, package vscode extension, create a publisher, setup PAT for vsce, automate extension releases with GitHub Actions, or need help with vsce commands. Don't use for building the extension features themselves, publishing to Open VSX (different marketplace), or PyPI/npm package release."
 effort: high
 license: MIT
 metadata:
-  version: 1.0.1
-  creator: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.2
+  author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # VS Code Extension Publisher


### PR DESCRIPTION
## Summary

- Add "Don't use for X, Y, Z" negative-trigger clauses to **33 skill descriptions** to reduce false-positive triggering between adjacent skills (e.g., prd-generator vs. tasks-generator, ASO vs. SEO).
- Fix `appstore-review-checker` frontmatter: moved top-level `version` into `metadata.version`, added `license` and `author` to match the house style.
- Quote descriptions containing colons/quotes to prevent YAML parse regressions (per skill-creator's YAML safety rule).
- Picks up pending `creator` → `author` field rename and version bumps from the in-flight quality sweep across all 36 skills.

## Validation

`quick_validate.py` on all 36 skills:

- **35 / 36** pass with zero warnings.
- **note-taker** retains `disable-model-invocation: true` and `argument-hint` in frontmatter — these are valid Claude Code keys used to make this skill manual-only (`/note-taker`), but skill-creator's validator doesn't yet recognize them. Removing them would regress the skill's intended behavior, so the validator's warning is accepted as a false positive on its side.

## Test plan

- [ ] Confirm descriptions still read naturally in the marketplace / catalog UI.
- [ ] Spot-check 2–3 skills to verify YAML parses correctly (e.g., cli-builder, code-review — previously bitten by unquoted colons).
- [ ] Verify note-taker still triggers only via explicit `/note-taker` invocation.