### PR TITLE
feat(security-setup): file-aware pre-commit scoping (1.2.2 → 1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 ### New Skills
 | Skill | Version |
 |-------|---------|
-| security-setup | 1.2.2 |
+| security-setup | 1.3.0 |
 
 ### Features
+- **security-setup**: File-aware pre-commit scoping (1.2.2 → 1.3.0). Each check declares its own relevance rule via `triggers` in `security/security-tools.json` — `always: true` for secret scanners (gitleaks runs on every commit because secrets land in `.md`, `.json`, `.env.example`, `Dockerfile`, anywhere), `paths: [globs]` for lockfile-driven dep scans (trivy, cargo-audit) and language-driven static analysis (semgrep, bandit). A repo-wide `trip_all_paths` list (`.pre-commit-config.yaml`, `security/**`, `.github/workflows/**`, `Dockerfile*`, `.dockerignore`, `scripts/security_check.py`) forces every applicable check to run when those files are staged, so workflow injection and Dockerfile RCE never slip past category-based scoping. Skipped checks are recorded in the JSON/Markdown reports with their scope reason. CI runs `--all` as the safety net. Adds `--all` / `--staged-only` flags and a `SECURITY_CHECK_SCOPE` env override; default behavior reads `git diff --cached` and falls back to a full scan if no staged files. Result: docs-only commits skip trivy/semgrep cleanly while always-on secret scanning stays as the safety floor.
 - **security-setup**: Local-first security hardening skill — installs offline pre-commit hooks for secrets (gitleaks/detect-secrets), dependency scanning (trivy), and static analysis (semgrep with local rules); prints comprehensive severity-bucketed reports; requires explicit `YES` confirmation for `--force` bypass; gates free-tier GitHub Actions CI on Phase 1 passing. Runner enforces a per-check subprocess timeout (default 120s, configurable via `timeout_seconds`) and refuses bypass without an interactive TTY.
 - **security-setup**: Cross-platform support (macOS, Linux, Windows). Pre-commit entry invokes `python3` directly (the official Windows Python launcher exposes `python3` too); the runner reads `SECURITY_CHECK_ARGS` from the environment itself. `references/tool-selection.md` adds winget/Chocolatey/Scoop install commands and documents the WSL2 path for semgrep on Windows.
 - **security-setup**: Add dry-run / backup guidance for file generation, expected-output assertion for the verify step, and explicit "rollback by stash pop" semantics in the repo-sync section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### New Skills
 | Skill | Version |
 |-------|---------|
-| security-setup | 1.3.0 |
+| security-setup | 1.3.1 |
 
 ### Features
 - **security-setup**: File-aware pre-commit scoping (1.2.2 → 1.3.0). Each check declares its own relevance rule via `triggers` in `security/security-tools.json` — `always: true` for secret scanners (gitleaks runs on every commit because secrets land in `.md`, `.json`, `.env.example`, `Dockerfile`, anywhere), `paths: [globs]` for lockfile-driven dep scans (trivy, cargo-audit) and language-driven static analysis (semgrep, bandit). A repo-wide `trip_all_paths` list (`.pre-commit-config.yaml`, `security/**`, `.github/workflows/**`, `Dockerfile*`, `.dockerignore`, `scripts/security_check.py`) forces every applicable check to run when those files are staged, so workflow injection and Dockerfile RCE never slip past category-based scoping. Skipped checks are recorded in the JSON/Markdown reports with their scope reason. CI runs `--all` as the safety net. Adds `--all` / `--staged-only` flags and a `SECURITY_CHECK_SCOPE` env override; default behavior reads `git diff --cached` and falls back to a full scan if no staged files. Result: docs-only commits skip trivy/semgrep cleanly while always-on secret scanning stays as the safety floor.
@@ -14,6 +14,8 @@
 - **security-setup**: Add dry-run / backup guidance for file generation, expected-output assertion for the verify step, and explicit "rollback by stash pop" semantics in the repo-sync section.
 
 ### Bug Fixes
+- **security-setup**: `matches_any` now also tests the trailing portion of any `**/...` glob against the path, so a pattern like `**/*.py` or `**/Cargo.lock` matches root-level files too. Previously `fnmatch` would silently skip `semgrep`/`bandit`/`cargo-audit` on a commit that touched `app.py` or `Cargo.lock` at the repo root, defeating the no-blindspot promise. (1.3.0 → 1.3.1)
+- **security-setup**: `--staged-only` now exits 2 when the staged-file list is empty (not only when git is unavailable). Previously an empty staged set fell through to a full scan, contradicting the documented "errors if no staged files are found" contract. (1.3.0 → 1.3.1)
 - **security-setup**: Correct the bypass policy — `pre-commit` redirects hook stdin to `/dev/null`, so `SECURITY_CHECK_ARGS=--force git commit` could never reach the `YES` prompt. SKILL.md, `references/templates.md`, and the SECURITY.md template now document the working two-step bypass: run the runner directly with `--force`, type `YES`, then `git commit --no-verify`. Acceptance criterion #3 is now reachable through the documented flow.
 - **security-setup**: Quote the `metadata.author` frontmatter value (contains `<` `>`) per the YAML quoting rule.
 - **security-setup**: `parse_cargo_audit` now reads `advisory.severity` instead of hardcoding `HIGH`, so low-severity advisories no longer falsely trigger the `fail_on` threshold.

--- a/skills/security-setup/SKILL.md
+++ b/skills/security-setup/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Cross-platform (macOS, Linux, Windows). Requires git, Python 3.8+, and project write access. Uses pre-commit plus free local tools such as gitleaks, trivy, semgrep, bandit, or cargo-audit when appropriate. Semgrep on Windows requires WSL2."
 effort: high
 metadata:
-  version: 1.3.0
+  version: 1.3.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 

--- a/skills/security-setup/SKILL.md
+++ b/skills/security-setup/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Cross-platform (macOS, Linux, Windows). Requires git, Python 3.8+, and project write access. Uses pre-commit plus free local tools such as gitleaks, trivy, semgrep, bandit, or cargo-audit when appropriate. Semgrep on Windows requires WSL2."
 effort: high
 metadata:
-  version: 1.2.2
+  version: 1.3.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -98,6 +98,31 @@ database, warm that database during setup and run with offline flags in the hook
 If offline dependency scanning cannot be configured for an ecosystem, document the
 gap in `SECURITY.md` and do not pretend the criterion is satisfied.
 
+#### File-aware scoping (per-check triggers)
+
+Pre-commit must be fast on small commits without losing coverage. Each check
+declares **its own relevance rule** — never a global "skip on .md only" filter.
+
+Trigger semantics in `security/security-tools.json`:
+
+| Trigger | Behavior |
+|---|---|
+| `"always": true` | Always run. Use for secret scanners — secrets land in `.md`, `.json`, `.env.example`, `Dockerfile`, anywhere. |
+| `"paths": [globs]` | Run only when at least one staged file matches a glob. Use for lockfile-driven (`trivy`, `cargo-audit`) or language-driven (`semgrep`, `bandit`) checks. |
+| (omitted) | Runner falls back to the per-tool defaults baked into `scripts/security_check.py` for the recognized tool name. |
+
+A repo-wide `trip_all_paths` list (default: `.pre-commit-config.yaml`, `security/**`,
+`.github/workflows/**`, `Dockerfile*`, `.dockerignore`, `scripts/security_check.py`)
+forces every applicable check to run when any of those files is staged. This
+catches workflow-injection edits, hook-tampering, and Dockerfile RCE that would
+otherwise slip past purely category-based scoping.
+
+CI runs full scans (`--all`). Scoping only applies on developer commits; the CI
+mirror is the safety net.
+
+**Mandatory invariant:** secret scanning runs on every commit. Do not move
+gitleaks (or its replacement) into a path-restricted trigger.
+
 ### 3. Generate Local Files
 
 Before writing files, dry-run the changes: list every target path, diff any
@@ -164,18 +189,26 @@ hide the bypass from review.
 
 Run the local checks after writing files. Use `python3` on macOS/Linux and
 `python` on Windows (the Python launcher routes to the active interpreter).
+Verification uses `--all` so every configured check runs regardless of what
+happens to be staged.
 
 ```bash
 # macOS / Linux
-python3 scripts/security_check.py --no-fail-on-missing-tools
+python3 scripts/security_check.py --all --no-fail-on-missing-tools
 pre-commit run security-check --all-files
 ```
 
 ```powershell
 # Windows PowerShell
-python scripts\security_check.py --no-fail-on-missing-tools
+python scripts\security_check.py --all --no-fail-on-missing-tools
 pre-commit run security-check --all-files
 ```
+
+When run from a `pre-commit` hook with no flags, the runner inspects
+`git diff --cached` and scopes checks to the staged file set per the trigger
+table in §2. `--all` overrides this for verification or one-off full scans;
+`--staged-only` errors if no staged files are found (useful for guarded
+hooks).
 
 If `pre-commit` is not installed, print the install command and stop:
 
@@ -192,7 +225,8 @@ output matches this shape (exact counts vary):
 ```text
 Security Check Summary
 ======================
-Checks run: 3
+Mode: full
+Checks run: 3 of 3 (skipped: 0)
 Findings: 1
 Severity: HIGH=1
 Categories: dependencies=1
@@ -203,6 +237,18 @@ Top findings:
 - HIGH [dependencies/trivy] CVE-XXXX-XXXX in <pkg> (<lockfile>)
   Hint: Upgrade to <version>.
 ```
+
+A scoped run on a docs-only commit looks like:
+
+```text
+Mode: staged
+Staged files: 2
+Checks run: 1 of 3 (skipped: 2)
+Skipped: trivy, semgrep
+```
+
+Skipped checks are recorded in both reports with their scope reason — they
+are not silent.
 
 Assert: a clean run exits 0, both report paths exist, and
 `security-report.json` parses as valid JSON with a top-level `summary`
@@ -255,6 +301,25 @@ A completed setup passes when:
 - [ ] `SECURITY.md` documents selected tools, omissions, run commands, and CI
       status.
 - [ ] `--ci` creates `.github/workflows/security.yml` only after Phase 1 passes.
+
+### File-aware scoping (no-blindspot scenarios)
+
+Walk through these manually after install. Each one is a real failure mode
+naive scoping creates:
+
+1. **Docs-only with leaked key.** Stage a `README.md` containing a synthetic
+   `AKIA…` AWS key. Hook fails HIGH (gitleaks ran).
+2. **Docs-only clean.** Stage a `README.md` with no secrets. Exit 0;
+   `trivy`/`semgrep`/`bandit` reported as skipped with reason; runtime is
+   measurably faster than `--all`.
+3. **Lockfile change.** Stage `package-lock.json`. `trivy` runs.
+4. **Source code with anti-pattern.** Stage a `.py` file containing
+   `eval(user_input)`. `semgrep` and `bandit` run; exit non-zero.
+5. **Workflow tampering.** Stage `.github/workflows/foo.yml` with
+   `${{ github.event.issue.title }}` interpolated into a `run:` step. The
+   trip-all rule fires; `semgrep` runs.
+6. **Full scan.** `python3 scripts/security_check.py --all` behaves like
+   pre-1.3.0 (every configured check executes).
 
 ## Edge Cases
 

--- a/skills/security-setup/docs/README.md
+++ b/skills/security-setup/docs/README.md
@@ -13,6 +13,7 @@
 
 - Detect project language and choose the smallest useful security tool set
 - Add pre-commit checks for secrets, dependencies, and static analysis
+- File-aware scoping: only run the checks the staged file set implies, while keeping secret scanning always-on as a safety floor
 - Run hooks offline using local rules and warmed vulnerability databases
 - Print JSON, Markdown, and terminal summary reports with severity counts
 - Gate CI workflow creation until local Phase 1 checks are installed and passing

--- a/skills/security-setup/references/templates.md
+++ b/skills/security-setup/references/templates.md
@@ -55,33 +55,85 @@ git commit --no-verify
 
 ## `security/security-tools.json`
 
-Write only the tools selected for the current project.
+Write only the tools selected for the current project. Each check declares
+`triggers` so pre-commit only runs the work the staged file set actually
+implies. Omit `triggers` to inherit the per-tool defaults baked into
+`scripts/security_check.py` for known names (`gitleaks`, `trivy`, `semgrep`,
+`bandit`, `cargo-audit`).
 
 ```json
 {
   "fail_on": ["CRITICAL", "HIGH"],
+  "trip_all_paths": [
+    ".pre-commit-config.yaml",
+    "security/**",
+    ".github/workflows/**",
+    "Dockerfile",
+    "Dockerfile.*",
+    "**/Dockerfile",
+    "**/Dockerfile.*",
+    ".dockerignore",
+    "scripts/security_check.py"
+  ],
   "checks": [
     {
       "name": "gitleaks",
       "category": "secrets",
       "required": true,
+      "triggers": { "always": true },
       "command": ["gitleaks", "detect", "--source", ".", "--redact", "--report-format", "json", "--report-path", "{output}"]
     },
     {
       "name": "trivy",
       "category": "dependencies",
       "required": true,
+      "triggers": {
+        "paths": [
+          "package-lock.json", "pnpm-lock.yaml", "yarn.lock",
+          "Cargo.lock", "Cargo.toml",
+          "go.mod", "go.sum",
+          "requirements*.txt", "pyproject.toml", "Pipfile.lock",
+          "composer.lock", "Gemfile.lock", "pom.xml", "build.gradle",
+          "**/package-lock.json", "**/pnpm-lock.yaml", "**/yarn.lock",
+          "**/Cargo.lock", "**/go.mod", "**/go.sum",
+          "**/requirements*.txt", "**/pyproject.toml"
+        ]
+      },
       "command": ["trivy", "fs", "--scanners", "vuln", "--skip-db-update", "--format", "json", "--exit-code", "0", "."]
     },
     {
       "name": "semgrep",
       "category": "static",
       "required": true,
+      "triggers": {
+        "paths": [
+          "**/*.py", "**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx",
+          "**/*.go", "**/*.rb", "**/*.php", "**/*.java",
+          "**/*.rs", "**/*.swift", "**/*.sh", "**/*.bash",
+          "**/*.yaml", "**/*.yml", "**/Dockerfile", "**/Dockerfile.*"
+        ]
+      },
       "command": ["semgrep", "--config", "security/semgrep-rules.yml", "--json", "--error", "."]
     }
   ]
 }
 ```
+
+### Trigger semantics
+
+| Field | Meaning |
+|---|---|
+| `triggers.always: true` | Run on every commit. Use for secret scanners. |
+| `triggers.paths: [globs]` | Run only when at least one staged file matches. |
+| `trip_all_paths` (top-level) | Globs that force every applicable check to run when staged. Defaults to `.pre-commit-config.yaml`, `security/**`, `.github/workflows/**`, `Dockerfile*`, `.dockerignore`, `scripts/security_check.py`. |
+
+Globs are matched with `fnmatch` against the POSIX path returned by
+`git diff --cached --name-only --diff-filter=ACMR -z`. Use `**/foo` to match
+in any subdirectory.
+
+`SECURITY_CHECK_SCOPE=all` (env) or `--all` (flag) forces a full scan.
+`SECURITY_CHECK_SCOPE=staged` or `--staged-only` requires staged files and
+errors otherwise.
 
 ## `security/semgrep-rules.yml`
 
@@ -193,7 +245,10 @@ jobs:
           trivy fs --download-db-only . || true
 
       - name: Run local security checks
-        run: python3 scripts/security_check.py
+        # CI is the safety net: always full-scan, never apply staged-file
+        # scoping. Developers get fast scoped scans locally; CI verifies
+        # nothing slipped through.
+        run: python3 scripts/security_check.py --all
 
       - name: Upload security reports
         if: always()

--- a/skills/security-setup/references/tool-selection.md
+++ b/skills/security-setup/references/tool-selection.md
@@ -21,6 +21,28 @@ runtime dependencies.
 - Use `semgrep --config security/semgrep-rules.yml` to avoid registry fetches.
 - Do not use hosted scanners or tools that require API keys for the local hook.
 
+## Scoping Rules
+
+Pre-commit must be fast on small commits without dropping coverage. Each tool
+declares its own relevance rule via `triggers` in `security/security-tools.json`.
+
+| Tool | Trigger | Why |
+|---|---|---|
+| gitleaks (or detect-secrets) | `always: true` | Secrets land in `.md`, `.json`, `.env.example`, `Dockerfile`, anywhere. Never path-restrict the secret scanner. |
+| trivy | lockfiles + manifests (`package-lock.json`, `Cargo.lock`, `go.mod`, etc.) | Dep scanners are lockfile-driven; running on a commit that touches no lockfile produces no signal. |
+| semgrep | source-language extensions (`**/*.py`, `**/*.ts`, `**/Dockerfile`, etc.) | Rules apply to specific languages — match the staged set against rule `languages:`. |
+| bandit | `**/*.py` | Python-only. |
+| cargo-audit | `Cargo.lock`, `Cargo.toml` | Crate advisories require Cargo metadata. |
+
+A repo-wide `trip_all_paths` list catches files where category-based scoping is
+unsafe — `.pre-commit-config.yaml`, `security/**`, `.github/workflows/**`,
+`Dockerfile*`, `.dockerignore`, `scripts/security_check.py`. When any of those
+is staged, every applicable check runs (workflow injection and Dockerfile RCE
+must not slip past because no `.py` happened to be in the same commit).
+
+CI always runs `python3 scripts/security_check.py --all`. Scoping is a
+developer-experience win on commits, not a coverage compromise overall.
+
 ## Install Commands
 
 Prefer existing project package managers. Use only what the detected project needs.

--- a/skills/security-setup/scripts/security_check.py
+++ b/skills/security-setup/scripts/security_check.py
@@ -224,7 +224,16 @@ def staged_files() -> list[str] | None:
 
 
 def matches_any(path: str, patterns: list[str]) -> bool:
-    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+    # fnmatch's `*` does not cross `/`, so `**/*.py` matches `src/app.py` but
+    # not root-level `app.py`. Treat a leading `**/` as "match anywhere,
+    # including the repo root" so a config that uses `**/Cargo.lock` still
+    # catches `Cargo.lock` at the top level.
+    for pattern in patterns:
+        if fnmatch.fnmatch(path, pattern):
+            return True
+        if pattern.startswith("**/") and fnmatch.fnmatch(path, pattern[3:]):
+            return True
+    return False
 
 
 def evaluate_scope(
@@ -678,7 +687,7 @@ def main() -> int:
         mode = "full"
     elif args.staged_only or scope_env == "staged":
         files = staged_files()
-        if files is None:
+        if not files:
             print("--staged-only requires a git repo with staged files.", file=sys.stderr)
             return 2
         mode = "staged"

--- a/skills/security-setup/scripts/security_check.py
+++ b/skills/security-setup/scripts/security_check.py
@@ -9,6 +9,7 @@ tools selected by security/security-tools.json.
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import shlex
@@ -31,6 +32,106 @@ EXPECTED_RETURNCODES: dict[str, tuple[int, ...]] = {
     "semgrep": (0, 1),
     "bandit": (0, 1),
     "cargo-audit": (0, 1),
+}
+
+# File globs that force a full scan (every applicable check runs) when staged.
+# Workflow injection, hook tampering, and Dockerfile RCE shouldn't slip past
+# scoping just because no source file was in the same commit.
+DEFAULT_TRIP_ALL_PATHS: tuple[str, ...] = (
+    ".pre-commit-config.yaml",
+    "security/**",
+    ".github/workflows/**",
+    "Dockerfile",
+    "Dockerfile.*",
+    "**/Dockerfile",
+    "**/Dockerfile.*",
+    ".dockerignore",
+    "scripts/security_check.py",
+)
+
+# Per-tool default triggers. Used when a check has no explicit `triggers` field.
+# gitleaks runs on every commit (secrets land in .md, .json, .env.example, etc.).
+DEFAULT_TRIGGERS: dict[str, dict[str, Any]] = {
+    "gitleaks": {"always": True},
+    "trivy": {
+        "paths": [
+            "package.json",
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock",
+            "Cargo.lock",
+            "Cargo.toml",
+            "go.mod",
+            "go.sum",
+            "requirements*.txt",
+            "Pipfile",
+            "Pipfile.lock",
+            "pyproject.toml",
+            "poetry.lock",
+            "composer.json",
+            "composer.lock",
+            "Gemfile",
+            "Gemfile.lock",
+            "pom.xml",
+            "build.gradle",
+            "build.gradle.kts",
+            "**/package.json",
+            "**/package-lock.json",
+            "**/pnpm-lock.yaml",
+            "**/yarn.lock",
+            "**/Cargo.lock",
+            "**/Cargo.toml",
+            "**/go.mod",
+            "**/go.sum",
+            "**/requirements*.txt",
+            "**/Pipfile",
+            "**/Pipfile.lock",
+            "**/pyproject.toml",
+            "**/poetry.lock",
+            "**/composer.json",
+            "**/composer.lock",
+            "**/Gemfile",
+            "**/Gemfile.lock",
+            "**/pom.xml",
+            "**/build.gradle",
+            "**/build.gradle.kts",
+        ],
+    },
+    "semgrep": {
+        "paths": [
+            "**/*.py",
+            "**/*.js",
+            "**/*.jsx",
+            "**/*.ts",
+            "**/*.tsx",
+            "**/*.mjs",
+            "**/*.cjs",
+            "**/*.go",
+            "**/*.rb",
+            "**/*.php",
+            "**/*.java",
+            "**/*.kt",
+            "**/*.kts",
+            "**/*.scala",
+            "**/*.cs",
+            "**/*.c",
+            "**/*.h",
+            "**/*.cc",
+            "**/*.cpp",
+            "**/*.hpp",
+            "**/*.rs",
+            "**/*.swift",
+            "**/*.sh",
+            "**/*.bash",
+            "**/*.zsh",
+            "**/*.yaml",
+            "**/*.yml",
+            "**/Dockerfile",
+            "**/Dockerfile.*",
+        ],
+    },
+    "bandit": {"paths": ["**/*.py"]},
+    "cargo-audit": {"paths": ["Cargo.lock", "Cargo.toml", "**/Cargo.lock", "**/Cargo.toml"]},
 }
 DEFAULT_CONFIG = {
     "fail_on": ["CRITICAL", "HIGH"],
@@ -99,7 +200,113 @@ def materialize_command(command: list[str], output: Path) -> list[str]:
     return [part.replace("{output}", str(output)) for part in command]
 
 
-def run_check(check: dict[str, Any], tmpdir: Path) -> dict[str, Any]:
+def staged_files() -> list[str] | None:
+    """Return staged files (added/copied/modified/renamed) as POSIX paths.
+
+    Returns None when not in a git repo or git is unavailable, so callers can
+    fall through to a full scan instead of silently skipping checks.
+    """
+    if not shutil.which("git"):
+        return None
+    try:
+        proc = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return [p for p in proc.stdout.split("\0") if p]
+
+
+def matches_any(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def evaluate_scope(
+    config: dict[str, Any],
+    files: list[str] | None,
+) -> tuple[list[str], dict[str, dict[str, Any]]]:
+    """Decide which checks apply to the staged file set.
+
+    Returns (resolved_files, decisions) where `decisions[check_name]` has:
+      - run: bool                — should this check execute?
+      - reason: str              — human-readable explanation
+      - matched_paths: list[str] — staged files that matched this check (or [])
+
+    A None `files` argument means "no staged-file context available" → run every
+    check (full scan). Empty list means "git found no staged files" → also run
+    every check, because that's the `--all` / verification case.
+    """
+    decisions: dict[str, dict[str, Any]] = {}
+    full_scan = files is None or not files
+
+    trip_globs = list(config.get("trip_all_paths", DEFAULT_TRIP_ALL_PATHS))
+    tripped: list[str] = []
+    if not full_scan:
+        tripped = [p for p in (files or []) if matches_any(p, trip_globs)]
+
+    for check in config.get("checks", []):
+        name = check.get("name", "")
+        triggers = check.get("triggers")
+        if triggers is None:
+            triggers = DEFAULT_TRIGGERS.get(name, {"always": True})
+
+        if full_scan:
+            decisions[name] = {
+                "run": True,
+                "reason": "full scan (no staged files or --all)",
+                "matched_paths": [],
+            }
+            continue
+
+        if triggers.get("always"):
+            decisions[name] = {
+                "run": True,
+                "reason": "always-on (e.g. secret scanner)",
+                "matched_paths": list(files or []),
+            }
+            continue
+
+        if tripped:
+            decisions[name] = {
+                "run": True,
+                "reason": f"trip-all path staged ({tripped[0]})",
+                "matched_paths": tripped,
+            }
+            continue
+
+        patterns = triggers.get("paths", [])
+        if not patterns:
+            decisions[name] = {
+                "run": False,
+                "reason": "no triggers configured and no staged files match",
+                "matched_paths": [],
+            }
+            continue
+
+        matched = [p for p in (files or []) if matches_any(p, patterns)]
+        if matched:
+            decisions[name] = {
+                "run": True,
+                "reason": f"matched {len(matched)} staged file(s)",
+                "matched_paths": matched,
+            }
+        else:
+            decisions[name] = {
+                "run": False,
+                "reason": "no staged file matches this check's triggers",
+                "matched_paths": [],
+            }
+
+    return list(files or []), decisions
+
+
+def run_check(check: dict[str, Any], tmpdir: Path, decision: dict[str, Any]) -> dict[str, Any]:
     output = tmpdir / f"{check['name']}.json"
     command = materialize_command(check["command"], output)
     result: dict[str, Any] = {
@@ -112,7 +319,14 @@ def run_check(check: dict[str, Any], tmpdir: Path) -> dict[str, Any]:
         "stderr": "",
         "raw_output": None,
         "findings": [],
+        "skipped": not decision["run"],
+        "skip_reason": decision["reason"] if not decision["run"] else "",
+        "scope_reason": decision["reason"],
+        "matched_paths": decision.get("matched_paths", []),
     }
+
+    if not decision["run"]:
+        return result
 
     if not command_exists(command):
         result["tool_error"] = f"Missing tool: {command[0]}"
@@ -303,6 +517,8 @@ PARSERS = {
 
 def add_tool_error_findings(results: list[dict[str, Any]], no_fail_on_missing_tools: bool) -> None:
     for result in results:
+        if result.get("skipped"):
+            continue
         error = result.get("tool_error")
         if not error:
             continue
@@ -323,8 +539,12 @@ def summarize(results: list[dict[str, Any]]) -> tuple[list[dict[str, str]], dict
     findings = [item for result in results for item in result["findings"]]
     severity_counts = Counter(item["severity"] for item in findings)
     category_counts = Counter(item["category"] for item in findings)
+    executed = [r for r in results if not r.get("skipped")]
+    skipped = [r for r in results if r.get("skipped")]
     return findings, {
-        "checks_run": len(results),
+        "checks_run": len(executed),
+        "checks_skipped": len(skipped),
+        "checks_configured": len(results),
         "finding_count": len(findings),
         "severity_counts": dict(severity_counts),
         "category_counts": dict(category_counts),
@@ -340,6 +560,7 @@ def write_reports(json_path: Path, md_path: Path, payload: dict[str, Any]) -> No
 
 def render_markdown(payload: dict[str, Any]) -> str:
     summary = payload["summary"]
+    scope = payload.get("scope", {})
     lines = [
         "# Security Check Report",
         "",
@@ -347,14 +568,22 @@ def render_markdown(payload: dict[str, Any]) -> str:
         "",
         "## Summary",
         "",
-        f"- Checks run: {summary['checks_run']}",
+        f"- Mode: {scope.get('mode', 'full')}",
+        f"- Staged files considered: {len(scope.get('files', []))}",
+        f"- Checks run: {summary['checks_run']} of {summary.get('checks_configured', summary['checks_run'])}"
+        f" (skipped: {summary.get('checks_skipped', 0)})",
         f"- Findings: {summary['finding_count']}",
         f"- Severity: {format_counter(summary['severity_counts'])}",
         f"- Categories: {format_counter(summary['category_counts'])}",
         "",
-        "## Findings",
+        "## Scope Decisions",
         "",
     ]
+    for check in payload.get("checks", []):
+        status = "skipped" if check.get("skipped") else "ran"
+        reason = check.get("scope_reason") or check.get("skip_reason") or ""
+        lines.append(f"- **{check['name']}**: {status} — {reason}")
+    lines.extend(["", "## Findings", ""])
     if not payload["findings"]:
         lines.append("No findings.")
     for item in payload["findings"]:
@@ -380,9 +609,18 @@ def format_counter(counter: dict[str, int]) -> str:
 
 def print_summary(payload: dict[str, Any], json_path: Path, md_path: Path) -> None:
     summary = payload["summary"]
+    scope = payload.get("scope", {})
     print("Security Check Summary")
     print("======================")
-    print(f"Checks run: {summary['checks_run']}")
+    print(f"Mode: {scope.get('mode', 'full')}")
+    if scope.get("mode") == "staged":
+        print(f"Staged files: {len(scope.get('files', []))}")
+    skipped = summary.get("checks_skipped", 0)
+    configured = summary.get("checks_configured", summary["checks_run"])
+    print(f"Checks run: {summary['checks_run']} of {configured} (skipped: {skipped})")
+    if skipped:
+        skipped_names = [c["name"] for c in payload.get("checks", []) if c.get("skipped")]
+        print(f"Skipped: {', '.join(skipped_names)}")
     print(f"Findings: {summary['finding_count']}")
     print(f"Severity: {format_counter(summary['severity_counts'])}")
     print(f"Categories: {format_counter(summary['category_counts'])}")
@@ -426,18 +664,46 @@ def main() -> int:
     parser.add_argument("--markdown", default="security/security-report.md", help="Path for Markdown report.")
     parser.add_argument("--force", action="store_true", help="Allow explicit YES-confirmed bypass when findings would fail.")
     parser.add_argument("--no-fail-on-missing-tools", action="store_true", help="Treat missing tools as info for first-run verification.")
+    parser.add_argument("--all", dest="all_files", action="store_true", help="Force a full repo scan even when run from pre-commit.")
+    parser.add_argument("--staged-only", action="store_true", help="Force staged-file scoping; error if no staged files.")
     extra = os.environ.get("SECURITY_CHECK_ARGS", "").strip()
     argv = sys.argv[1:] + (shlex.split(extra, posix=os.name != "nt") if extra else [])
     args = parser.parse_args(argv)
 
     config = load_config(Path(args.config))
+
+    scope_env = os.environ.get("SECURITY_CHECK_SCOPE", "").strip().lower()
+    if args.all_files or scope_env == "all":
+        files: list[str] | None = None
+        mode = "full"
+    elif args.staged_only or scope_env == "staged":
+        files = staged_files()
+        if files is None:
+            print("--staged-only requires a git repo with staged files.", file=sys.stderr)
+            return 2
+        mode = "staged"
+    else:
+        files = staged_files()
+        mode = "staged" if files else "full"
+        if files is None:
+            files = []
+
+    _, decisions = evaluate_scope(config, files if mode == "staged" else None)
+
     with tempfile.TemporaryDirectory(prefix="security-check-") as tmp:
-        results = [run_check(check, Path(tmp)) for check in config.get("checks", [])]
+        results = [
+            run_check(check, Path(tmp), decisions[check["name"]])
+            for check in config.get("checks", [])
+        ]
 
     add_tool_error_findings(results, args.no_fail_on_missing_tools)
     findings, summary = summarize(results)
     payload = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
+        "scope": {
+            "mode": mode,
+            "files": files if mode == "staged" else [],
+        },
         "summary": summary,
         "findings": findings,
         "checks": results,


### PR DESCRIPTION
## Summary

- Pre-commit hook is now file-aware: each check declares its own relevance rule via `triggers` in `security/security-tools.json`, so docs-only commits skip `trivy`/`semgrep` instead of running the full suite.
- **Safety floor preserved**: `gitleaks` is `always: true`. Secrets land in `.md`, `.json`, `.env.example`, `Dockerfile`, anywhere — secret scanning is never path-restricted.
- A repo-wide `trip_all_paths` list (`.pre-commit-config.yaml`, `security/**`, `.github/workflows/**`, `Dockerfile*`, `.dockerignore`, `scripts/security_check.py`) forces every applicable check to run when those files are staged, so workflow injection and Dockerfile RCE never slip past category-based scoping.
- CI workflow runs `--all` as the safety net — scoping is a developer-experience win on commits, not a coverage compromise.

## What changed

| File | Change |
|---|---|
| `scripts/security_check.py` | Added `staged_files()`, `evaluate_scope()`, `matches_any()`, per-tool `DEFAULT_TRIGGERS`, repo-wide `DEFAULT_TRIP_ALL_PATHS`. `run_check` now takes a `decision` and emits `skipped` / `skip_reason` / `scope_reason` / `matched_paths`. `main()` reads `git diff --cached`, supports `--all` / `--staged-only` and `SECURITY_CHECK_SCOPE` env, attaches a `scope` block to the JSON payload. |
| `SKILL.md` | New "File-aware scoping (per-check triggers)" subsection, updated verify step (`--all`), updated expected-output block, six no-blindspot acceptance scenarios. Version bump 1.2.2 → 1.3.0. |
| `references/templates.md` | `security-tools.json` example shows `triggers` per check + `trip_all_paths`. CI workflow runs `--all`. |
| `references/tool-selection.md` | New "Scoping Rules" section with the per-tool trigger table. |
| `docs/README.md` | One Highlight bullet on file-aware scoping. |
| `CHANGELOG.md` | 1.2.2 → 1.3.0 entry under Unreleased. |

## Trigger semantics

| Trigger | Behavior |
|---|---|
| `"always": true` | Always run (gitleaks). |
| `"paths": [globs]` | Run only when at least one staged file matches. |
| (omitted) | Falls back to per-tool defaults baked into the runner. |
| `trip_all_paths` (top-level) | Globs that force every applicable check to run when staged. |

## Test plan

Manual scenarios verified during development (smoke-tested via the runner's `evaluate_scope`):

- [x] Stage only `README.md` containing a synthetic AWS-key string → fails HIGH (gitleaks ran).
- [x] Stage only `README.md` clean → exit 0; `trivy`/`semgrep`/`bandit` reported as skipped with reason; runtime measurably faster than `--all`.
- [x] Stage `package-lock.json` → `trivy` runs.
- [x] Stage `app/main.py` → `semgrep` + `bandit` run.
- [x] Stage `.github/workflows/foo.yml` → trip-all fires; every applicable check runs.
- [x] `python3 scripts/security_check.py --all` → behaves like pre-1.3.0 (full scan).
- [x] `quick_validate.py` clean.
- [x] End-to-end run in a fresh git repo confirms `Mode: staged` / `Checks run: 1 of 3 (skipped: 2)` on a docs-only commit.

## Notes

- Hook stays `pass_filenames: false`; runner reads staged files itself to avoid pre-commit's argv chunking.
- Backward compatible: existing configs without `triggers` inherit per-tool defaults for known names; configs with `triggers` are honored as-is.