### PR TITLE
feat(skills): add website-clone-report skill (#30)

### DIFF
--- a/skills/website-clone-report/SKILL.md
+++ b/skills/website-clone-report/SKILL.md
@@ -4,7 +4,7 @@ description: "Convert website analyzer output into a comprehensive plain-languag
 license: MIT
 effort: high
 metadata:
-  version: 1.0.0
+  version: 1.0.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -160,17 +160,12 @@ Do **not** persist the file until explicit approval.
 
 ## Step 6: Persist Final Report
 
-Once approved, write the report to the output path:
+Once approved, persist the report using the `Write` tool — do not shell out to `echo` or `cat` redirection.
 
-```bash
-echo "$REPORT_CONTENT" > "$OUTPUT_PATH"
-```
+- **Path:** the value passed via `--output <path>`. If absent, fall back to `$PROJECT_DIR/report.md` when the orchestrator set `$PROJECT_DIR`, otherwise to `report.md` in the current working directory.
+- **Content:** the approved markdown report assembled in Step 3, with any edits from Step 5 applied.
 
-Default output path: `$PROJECT_DIR/report.md` or `~/workspace/clones/YYYY_MM_DD_slug/report.md`.
-
-If `$ARGUMENTS` includes `--output <path>`, use that path. Otherwise use the default.
-
-After writing, confirm:
+After the `Write` call returns, confirm to the user:
 
 ```
 Report saved to: <absolute-path>

--- a/skills/website-clone-report/SKILL.md
+++ b/skills/website-clone-report/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: website-clone-report
+description: "Convert website analyzer output into a comprehensive plain-language report for non-technical users. Prompts for validation before persisting. Use when asked to report on a website analysis, create an end-user report, or translate technical metrics into plain language. Don't use for technical audit reports targeting developers, raw SEO audits, or penetration testing. Approval gate: never saves without explicit user approval."
+license: MIT
+effort: high
+metadata:
+  version: 1.0.0
+  author: Luong NGUYEN <luongnv89@gmail.com>
+---
+
+# Website Clone Report
+
+Converts structured website analysis into a comprehensive, plain-language report for non-technical readers. Approval gate: persists only after explicit user validation.
+
+## When to Use
+
+Trigger when the user asks to:
+- Create a report from website analysis results
+- Translate technical website metrics into plain language
+- Produce an end-user summary of a site assessment
+
+Do **not** use for technical audit reports targeting developers — those belong to the analyzer skill.
+
+## Workflow
+
+```
+1. Read the analyzer output (JSON)
+2. Translate each dimension into plain language
+3. Draft the report for non-technical readers
+4. Present to user for review
+5. Incorporate edits (loop until approved)
+6. Persist final report to file
+```
+
+## Report Structure
+
+Write the report in plain language. Technical metrics are translated, not just listed.
+
+```markdown
+# Website Analysis Report: <site name>
+**URL:** <url>
+**Date:** <date>
+
+---
+
+## At a Glance
+
+A plain-language summary: what this site is, who it's for, and its overall health.
+Example: "This is a SaaS landing page targeting small businesses. It looks polished and modern,
+but loads slowly on mobile connections and is missing key SEO elements that would help it
+rank in search results."
+
+## How It Looks and Works
+
+Translate UI/UX findings into plain language:
+- Layout style (e.g., "clean single-column layout with a large hero image")
+- What draws attention first
+- Any friction points (e.g., "the sign-up button is hidden below the fold")
+- Responsive behavior
+
+## What Kind of Site This Is
+
+Category description in plain terms:
+- "This is an e-commerce store selling handcrafted furniture"
+- "This is a documentation site for a developer tool"
+
+## Design and Style
+
+Describe the visual identity accessibly:
+- Typography feel (e.g., "modern sans-serif fonts that feel clean and professional")
+- Color palette (e.g., "cool blues and grays with orange accents for calls to action")
+- Spacing and density
+- Motion and interactivity feel
+
+## Performance
+
+Translate metrics to plain language:
+- **How fast content appears:** "The main content takes about X seconds to appear.
+  For comparison, sites that load in under 2 seconds tend to keep visitors engaged."
+- **Visual stability:** "The page layout is mostly stable while loading.
+  You're unlikely to notice elements jumping around."
+- **How much data it uses:** "The page weighs about X KB, roughly equivalent to
+  loading Y average-sized images."
+- **Number of resources:** "The page makes about X requests to load."
+
+## Security Overview
+
+Surface-level observations only, in plain language:
+- "The site uses HTTPS, which means data between your browser and the site is encrypted."
+- "The site sends a few security signals to browsers, but could strengthen them."
+
+Always note this is not a full security audit.
+
+## Search Engine Visibility
+
+SEO findings translated:
+- Overall score with context: "SEO score: X/100 — [excellent/good/fair/poor]"
+- "The page has a title and description that search engines can read."
+- "The heading structure could be improved to help search engines understand the content."
+- "Images are missing alternative text, which helps with accessibility and search."
+
+## Summary and Next Steps
+
+A brief section with actionable takeaways:
+- What's working well (2–3 points)
+- What needs attention (2–3 points)
+- What could be improved (2–3 points)
+
+---
+
+*This report was generated from automated analysis. All findings are based on a single-page crawl
+and may not reflect the full site.*
+```
+
+## Step 1: Read Analyzer Output
+
+Read the JSON analysis file (or content passed via stdin/argument):
+
+```
+Read file <path-to-analysis.json>
+```
+
+If no file is provided and `$ARGUMENTS` contains a URL, note that this skill requires pre-existing analysis output (produced by `website-analyzer`), not raw URLs. The orchestrator should have already run Phase 1.
+
+## Step 2: Translate to Plain Language
+
+For each dimension:
+- **UI/UX**: Describe layout and friction in terms a non-technical person understands. Avoid jargon like "visual hierarchy" — say "what catches the eye first."
+- **Category**: Explain what kind of site it is in plain terms.
+- **Style**: Describe the feel and look without needing CSS knowledge.
+- **Performance**: Translate numbers to relatable comparisons:
+  - LCP: "how fast the main content appears"
+  - CLS: "how stable the page feels while loading"
+  - Page weight: "how much data the page uses"
+  - Request count: "how many pieces the page needs to load"
+- **Security**: Surface-level observations only, no technical headers jargon.
+- **SEO**: Explain each finding in terms of "helping people find this site on Google."
+
+## Step 3: Draft the Report
+
+Assemble the translated content into the report structure above.
+
+## Step 4: Present for Review
+
+Present the draft report to the user. Ask:
+
+"Here is the analysis report. Please review it and let me know:
+1. **Approve** — it looks good, save it
+2. **Edit** — I'd like to change something (specify what)
+3. **Regenerate** — start over with different focus"
+
+## Step 5: Incorporate Edits (loop)
+
+If the user requests edits:
+- Update the report accordingly
+- Re-present for review
+- Repeat until approved
+
+Do **not** persist the file until explicit approval.
+
+## Step 6: Persist Final Report
+
+Once approved, write the report to the output path:
+
+```bash
+echo "$REPORT_CONTENT" > "$OUTPUT_PATH"
+```
+
+Default output path: `$PROJECT_DIR/report.md` or `~/workspace/clones/YYYY_MM_DD_slug/report.md`.
+
+If `$ARGUMENTS` includes `--output <path>`, use that path. Otherwise use the default.
+
+After writing, confirm:
+
+```
+Report saved to: <absolute-path>
+```
+
+## Error Handling
+
+| Failure | Behavior |
+|---|---|
+| No analyzer input provided | Ask for the analysis JSON file path |
+| Invalid JSON | Report error and ask for valid input |
+| User never approves | Keep the loop going; do not auto-save |
+
+## Acceptance Criteria
+
+- [ ] The skill consumes the website-analyzer output without re-scraping the original site
+- [ ] The report is written in plain language; technical metrics are translated
+- [ ] The skill explicitly prompts the user to validate or edit the report before persisting
+- [ ] The final report is written to a known file path only after user approval
+- [ ] If the user requests edits, the skill incorporates them and re-prompts for approval
+- [ ] When run inside website-cloner, the orchestrator does not advance until "approved"

--- a/skills/website-clone-report/docs/README.md
+++ b/skills/website-clone-report/docs/README.md
@@ -1,0 +1,34 @@
+<!--
+  DO NOT READ THIS FILE — This README.md is for human catalog browsing only.
+  It ships inside the .skill package but is NEVER auto-loaded into agent context.
+  The runtime loader only reads SKILL.md + references/ + scripts/ + agents/ when the skill triggers.
+  If you're an AI agent, read the SKILL.md file instead for skill instructions.
+-->
+
+# Website Clone Report
+
+> Converts website analysis JSON into a comprehensive plain-language report for non-technical users. Approval gate: saves only after explicit user validation.
+
+## Highlights
+
+- Translates technical metrics (LCP, CLS, SEO scores) into plain language
+- Non-technical audience: jargon-free with relatable comparisons
+- Approval gate: never persists report without explicit user approval
+- Edit loop: incorporates user changes and re-prompts until approved
+
+## When to Use
+
+| Say this... | Skill will... |
+|---|---|
+| "create a report from the analysis" | Translate JSON analysis into plain-language report |
+| "summarize the website scan for a non-technical audience" | Produce accessible report with relatable comparisons |
+
+## Usage
+
+```
+/website-clone-report <path-to-analysis.json>
+```
+
+## Output
+
+Plain-language `report.md` — written only after explicit user approval.

--- a/skills/website-clone-report/references/api_reference.md
+++ b/skills/website-clone-report/references/api_reference.md
@@ -1,0 +1,34 @@
+# Reference Documentation for Website Clone Report
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices

--- a/skills/website-clone-report/references/api_reference.md
+++ b/skills/website-clone-report/references/api_reference.md
@@ -1,34 +1,107 @@
-# Reference Documentation for Website Clone Report
+# Analyzer JSON Schema and Translation Guide
 
-This is a placeholder for detailed reference documentation.
-Replace with actual reference content or delete if not needed.
+This skill consumes the JSON output produced by `website-analyzer` (Phase 1 of the website-cloner suite). Use this reference to map each analyzer field to a plain-language report section.
 
-Example real reference docs from other skills:
-- product-management/references/communication.md - Comprehensive guide for status updates
-- product-management/references/context_building.md - Deep-dive on gathering context
-- bigquery/references/ - API references and query examples
+## Input Shape
 
-## When Reference Docs Are Useful
+The skill expects JSON in this shape (see `skills/website-analyzer/SKILL.md` for the canonical definition):
 
-Reference docs are ideal for:
-- Comprehensive API documentation
-- Detailed workflow guides
-- Complex multi-step processes
-- Information too lengthy for main SKILL.md
-- Content that's only needed for specific use cases
+```json
+{
+  "url": "https://example.com",
+  "timestamp": "2026-05-07T12:00:00Z",
+  "ui_ux": {
+    "layout": "single-column | two-column | grid | ...",
+    "visual_hierarchy": "what draws attention first",
+    "components": ["nav", "hero", "cta", "footer"],
+    "responsive": "desktop-first | mobile-first | adaptive | unknown",
+    "friction_points": ["slow nav", "missing CTA"]
+  },
+  "category": "saas-landing | portfolio | e-commerce | blog | docs | dashboard",
+  "category_confidence": 0.9,
+  "style": {
+    "typography": "brief description",
+    "palette": ["#hex"],
+    "spacing": "compact | comfortable | spacious",
+    "motion": "minimal | moderate | heavy",
+    "aesthetic": "vibe description"
+  },
+  "performance": {
+    "lcp_estimate": 2.5,
+    "cls_estimate": 0.05,
+    "ttfb_estimate": 0.3,
+    "total_page_weight_kb": 1200,
+    "request_count": 45,
+    "notes": "estimated from static analysis"
+  },
+  "security": {
+    "https": true,
+    "mixed_content": false,
+    "security_headers": ["strict-transport-security"],
+    "exposed_metadata": [],
+    "note": "Surface-level check only. Not a full security audit."
+  },
+  "seo": {
+    "score": 72,
+    "title_tag": "present | missing | duplicate",
+    "meta_description": "present | missing | too-short",
+    "heading_structure": "h1:N h2:N",
+    "alt_text_coverage": 0.85,
+    "structured_data": "present | missing",
+    "canonical_url": "present | missing",
+    "robots_sitemap": "robots=ok | sitemap=found",
+    "dimension_scores": {
+      "meta_tags": 80,
+      "heading_structure": 60,
+      "image_alt_text": 90,
+      "structured_data": 50,
+      "crawlability": 75
+    }
+  }
+}
+```
 
-## Structure Suggestions
+Error variant (skill should report and stop, not produce a report):
 
-### API Reference Example
-- Overview
-- Authentication
-- Endpoints with examples
-- Error codes
-- Rate limits
+```json
+{"url": "<url>", "error": "unreachable", "detail": "<error>"}
+```
 
-### Workflow Guide Example
-- Prerequisites
-- Step-by-step instructions
-- Common patterns
-- Troubleshooting
-- Best practices
+## Field-to-Section Mapping
+
+| Analyzer field | Report section | Translation rule |
+|---|---|---|
+| `ui_ux.layout` | How It Looks and Works | Spell out the layout name — "single-column" → "a single column down the page". |
+| `ui_ux.visual_hierarchy` | How It Looks and Works | Restate as "what catches the eye first". Avoid the term "visual hierarchy". |
+| `ui_ux.friction_points` | How It Looks and Works | Convert each to a concrete observation: "slow nav" → "the navigation is slow to respond". |
+| `ui_ux.responsive` | How It Looks and Works | "mobile-first" → "designed for phones first; works well on small screens". |
+| `category` + `category_confidence` | What Kind of Site This Is | Use confidence to soften: < 0.6 → "appears to be"; ≥ 0.9 → state plainly. |
+| `style.typography` | Design and Style | Replace font-family jargon with feel: "modern sans-serif fonts that feel clean". |
+| `style.palette` | Design and Style | Translate hex to color families: "cool blues and grays with orange accents". |
+| `style.spacing` | Design and Style | "compact" → "densely packed"; "spacious" → "lots of breathing room". |
+| `style.motion` | Design and Style | "heavy" → "lots of animation"; "minimal" → "very little movement". |
+| `performance.lcp_estimate` | Performance | "How fast content appears". Benchmarks: < 2.5s good, 2.5–4s fair, > 4s slow. |
+| `performance.cls_estimate` | Performance | "How stable the page feels while loading". < 0.1 stable, ≥ 0.25 jumpy. |
+| `performance.total_page_weight_kb` | Performance | "How much data the page uses". Compare to images: "≈ N average photos worth". |
+| `performance.request_count` | Performance | "Number of pieces the page needs to load". |
+| `security.https` / `mixed_content` | Security Overview | HTTPS + no mixed content → "encrypted from end to end". |
+| `security.security_headers` | Security Overview | Translate to "the site sends a few security signals to browsers" — never list header names. |
+| `security.note` | Security Overview | Always include the "not a full security audit" caveat. |
+| `seo.score` | Search Engine Visibility | Bucket: ≥ 90 excellent, 70–89 good, 50–69 fair, < 50 poor. |
+| `seo.dimension_scores.*` | Search Engine Visibility | Translate each: low `image_alt_text` → "Images are missing alternative text, which helps search and accessibility". |
+| `seo.title_tag` / `meta_description` | Search Engine Visibility | "missing" → "no title/description for search engines to read". |
+| `seo.heading_structure` | Search Engine Visibility | If h1 ≠ 1 → "the heading structure could be improved". |
+
+## Null Handling
+
+Any analyzer field may be `null` when the metric couldn't be computed. Translation rule: omit the corresponding line from the report rather than writing "unknown" or "N/A". Note in the *Summary and Next Steps* section that some metrics were unavailable, if the omission affects the conclusions.
+
+## Output Path
+
+The orchestrator (`website-cloner`) invokes this skill with `--output "$PROJECT_DIR/report.md"`. Honor that path. If invoked standalone without `--output`, default to `report.md` in the current working directory and print the absolute path on save.
+
+## Cross-References
+
+- `skills/website-analyzer/SKILL.md` — upstream producer; canonical schema definition.
+- `skills/website-cloner/SKILL.md` — orchestrator; defines `$PROJECT_DIR` and the approval-gate contract.
+- `skills/website-improvement-prd/SKILL.md` — downstream consumer of the approved report.


### PR DESCRIPTION
## Summary

- Adds `website-clone-report` skill — plain-language report from analyzer JSON
- Non-technical audience: jargon-free with relatable metric comparisons
- Approval gate: never persists report without explicit user validation
- Edit loop: incorporates changes and re-prompts until approved

## Acceptance

- [x] Consumes website-analyzer output without re-scraping
- [x] Report in plain language; technical metrics translated
- [x] Explicitly prompts user to validate or edit before persisting
- [x] Final report written only after user approval
- [x] Edits incorporated and re-prompted
- [x] Orchestrator does not advance until "approved"

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Consumes analyzer output without re-scraping | pass | SKILL.md Step 1 reads the analyzer JSON file; no fetch logic |
| 2 | Plain language; technical metrics translated | pass | SKILL.md Step 2 + references/api_reference.md translation table (LCP → "how fast main content appears", CLS → "how stable the page feels", etc.) |
| 3 | Explicitly prompts user to validate or edit | pass | SKILL.md Step 4 ("Present for Review") with three explicit options |
| 4 | Final report written only after approval | pass | SKILL.md Step 5 ("Do not persist until explicit approval") and Step 6 ordering |
| 5 | Edits incorporated and re-prompted | pass | SKILL.md Step 5 ("Repeat until approved") |
| 6 | Orchestrator does not advance until "approved" | pass | File-existence gate: orchestrator (website-cloner) waits on `$PROJECT_DIR/report.md`; Step 6 only writes after approval |

## Context

Part of the `website-cloner-suite` — Phase 2: Report (approval gate). Upstream: `website-analyzer`. Downstream: `website-improvement-prd`.

## Decision Record

**Root cause:** Phase 2 of the website-cloner suite was missing — there was no skill to translate the analyzer's structured JSON into a non-technical, end-user report with an approval gate before persistence.

**Options considered:**
1. Add the report skill with an approval gate enforced via prompts inside the skill (selected).
2. Have the orchestrator render the report directly without a dedicated skill.
3. Auto-persist the report on first draft and let the user edit the file post-hoc.

**Options rejected:**
- Option 2 conflates orchestration with content generation; the orchestrator stays thin and delegates to phase skills.
- Option 3 violates the explicit-approval-before-persist contract from the parent issue, and removes the natural file-existence gate the orchestrator relies on.

**Selected option:** Option 1. The skill drafts in memory, prompts for approval, loops on edits, and only calls `Write` after the user approves. The orchestrator gate falls out for free: it can poll for `report.md` existence to advance to Phase 3.

**Residual risk:** AC #6 (orchestrator advance gate) is satisfied by file existence rather than an explicit return signal. If a future orchestrator rewrite stops checking for the file and instead expects a structured handshake, the skill will need a return-value contract added.

Closes #30