### PR TITLE
chore(website-cloner): roll persist + AC cleanup across suite (#42)

### DIFF
--- a/skills/website-cloner/SKILL.md
+++ b/skills/website-cloner/SKILL.md
@@ -4,7 +4,7 @@ description: "6-phase website cloning and improvement orchestrator. Takes a URL 
 license: MIT
 effort: high
 metadata:
-  version: 1.1.0
+  version: 1.1.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -252,11 +252,3 @@ This skill produces a before/after comparison covering performance, SEO, securit
 - **Missing sibling skill**: If a sibling skill is not available, skip that phase and note it in the report. Continue with remaining phases if possible.
 - **Partial Phase 1 results**: If the analyzer returns partial data (e.g., no SEO score), proceed to Phase 2 with a note that the missing dimension was not evaluated.
 
-## Acceptance Criteria
-
-- [ ] Invoking `/website-cloner <url>` runs the six phases in order, calling each sibling skill at the right step
-- [ ] After phases 2, 3, and 4 the orchestrator stops and waits for explicit user approval before advancing
-- [ ] Phase 3 produces a `prd.md` file and phase 4 produces a `tasks.md` file, both in the project directory
-- [ ] Phases can also be invoked individually (by calling the sibling skill directly with the right inputs)
-- [ ] The final phase emits a comparison report covering performance deltas, UI/UX changes, SEO score change, and the GitHub Pages URL
-- [ ] The skill description and trigger phrases make it discoverable ("clone this site", "rebuild this website", "make a better version of <url>")

--- a/skills/website-cloner/website-analyzer/SKILL.md
+++ b/skills/website-cloner/website-analyzer/SKILL.md
@@ -4,7 +4,7 @@ description: "Analyze any website URL across 6 dimensions: UI/UX, category, styl
 license: MIT
 effort: high
 metadata:
-  version: 1.0.1
+  version: 1.0.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -172,12 +172,3 @@ When a sub-score cannot be computed (e.g. `robots.txt` unreachable), record the 
 | Redirect loop | `{"error": "redirect-loop"}` — stop |
 | Empty page | `{"error": "empty"}` — stop |
 
-## Acceptance Criteria
-
-- [ ] `/website-analyzer <url>` accepts a single URL and runs without further prompting
-- [ ] Output covers all six dimensions: UI/UX, category, style, performance, security, SEO
-- [ ] Performance includes LCP, CLS, total page weight, request count
-- [ ] Security results are labelled as surface-level check
-- [ ] SEO includes overall score (0–100) plus per-dimension breakdown
-- [ ] Output is structured JSON consumable by downstream skills
-- [ ] Handles common failure modes with clear error output

--- a/skills/website-cloner/website-builder/SKILL.md
+++ b/skills/website-cloner/website-builder/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute the approved tasks.md to build a Vite + React + shadcn/ui 
 license: MIT
 effort: high
 metadata:
-  version: 1.0.1
+  version: 1.0.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -199,16 +199,6 @@ Write a JSON metadata file for the final report phase:
 ```
 
 Write to: `$PROJECT_DIR/builder-metadata.json`
-
-## Acceptance Criteria
-
-- [ ] Consumes approved tasks.md and prd.md without additional spec input
-- [ ] Uses Vite + React + shadcn/ui + Tailwind CSS
-- [ ] Produced site is serverless, front-end only, deployable to GitHub Pages
-- [ ] Landing/home page built first and independently usable
-- [ ] Asset collection and creation follow tasks.md plan
-- [ ] GitHub Pages URL reported on completion
-- [ ] Builder metadata emitted for website-clone-final-report
 
 ## Step Completion Reports
 

--- a/skills/website-cloner/website-clone-report/SKILL.md
+++ b/skills/website-cloner/website-clone-report/SKILL.md
@@ -4,7 +4,7 @@ description: "Convert website analyzer output into a comprehensive plain-languag
 license: MIT
 effort: high
 metadata:
-  version: 1.0.1
+  version: 1.0.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -179,11 +179,3 @@ Report saved to: <absolute-path>
 | Invalid JSON | Report error and ask for valid input |
 | User never approves | Keep the loop going; do not auto-save |
 
-## Acceptance Criteria
-
-- [ ] The skill consumes the website-analyzer output without re-scraping the original site
-- [ ] The report is written in plain language; technical metrics are translated
-- [ ] The skill explicitly prompts the user to validate or edit the report before persisting
-- [ ] The final report is written to a known file path only after user approval
-- [ ] If the user requests edits, the skill incorporates them and re-prompts for approval
-- [ ] When run inside website-cloner, the orchestrator does not advance until "approved"

--- a/skills/website-cloner/website-improvement-prd/SKILL.md
+++ b/skills/website-cloner/website-improvement-prd/SKILL.md
@@ -4,7 +4,7 @@ description: "Turn approved end-user report into a full improvement proposal wit
 license: MIT
 effort: high
 metadata:
-  version: 1.1.0
+  version: 1.1.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -160,7 +160,7 @@ Do **not** persist until explicit approval.
 Write to output path:
 
 ```bash
-echo "$PRD_CONTENT" > "$OUTPUT_PATH"
+printf '%s\n' "$PRD_CONTENT" > "$OUTPUT_PATH"
 ```
 
 Default: `$PROJECT_DIR/prd.md` or `~/workspace/clones/YYYY_MM_DD_slug/prd.md`.
@@ -197,11 +197,3 @@ still holds: no approval, no `prd.md`.
 | Invalid input format | Report error and ask for valid files |
 | User never approves | Keep looping; do not auto-save |
 
-## Acceptance Criteria
-
-- [ ] Proposal generated from approved Phase-2 report and Phase-1 analysis, not re-scraping
-- [ ] Every change includes what, why, and measurable expected-value statement
-- [ ] Explicitly prompts for user validation before writing prd.md
-- [ ] prd.md written to known location only after approval
-- [ ] Edits incorporated and re-prompted
-- [ ] prd.md structured cleanly for website-implementation-plan to consume


### PR DESCRIPTION
## Summary

Closes #42.

PR #39 (`website-implementation-plan`) and PR #34 (`website-clone-final-report`) landed two cleanup fixes that turned out to be project-wide conventions inherited from the `init_skill` scaffold rather than defects unique to those skills:

1. Persisted markdown should use `printf '%s\n' "$X" > path` instead of `echo "$X" > path` (echo interprets backslash escapes and silently mangles content starting with `-e` / `-n`).
2. The runtime `## Acceptance Criteria` section in `SKILL.md` duplicates the linked issue's criteria — adds drift risk, no runtime value. The issue tracker is the canonical home, and the PR body's Acceptance Criteria Verification block per the issue #36 contract is the durable verification trail.

This rolls both fixes across the remaining `website-*` skills now that #43 has consolidated them under `skills/website-cloner/`.

## Approach

Single bundled commit since the two fixes share a rationale and they overlap on `website-improvement-prd`. Each touched `SKILL.md` gets one patch version bump per CLAUDE.md rule #1.

## Decision Record

- **Persist hardening pattern:** `printf '%s\n' "$VAR" > "$PATH"` — drop-in, POSIX-portable, no escape interpretation, no `-e` / `-n` swallowing. Same pattern already in use in `website-implementation-plan` Step 8 (PR #39).
- **AC removal scope:** Five `SKILL.md` files held a trailing `## Acceptance Criteria` block. `website-builder`'s block sat just before `## Step Completion Reports` rather than truly trailing — removed it anyway because the issue's spirit (and its own AC line) is "no website-* skill ships a runtime `## Acceptance Criteria` section duplicating the linked issue."
- **Why one commit, not two:** the two fixes share the same rationale (consistency rollout from PR #39 review notes 5 + 6) and `website-improvement-prd` would have needed a split-by-hunk commit otherwise. Single commit keeps each file's diff cohesive while still respecting the one-version-bump-per-file rule.
- **Skipped skills:** `website-implementation-plan` (already fixed in #39) and `website-clone-final-report` (already fixed in #34) — neither persist line nor AC section present.

## Changes

| File | Persist fix | AC removal | Version bump |
|---|---|---|---|
| `skills/website-cloner/SKILL.md` | n/a | ✓ trailing | 1.1.0 → 1.1.1 |
| `skills/website-cloner/website-analyzer/SKILL.md` | n/a | ✓ trailing | 1.0.1 → 1.0.2 |
| `skills/website-cloner/website-builder/SKILL.md` | n/a | ✓ pre-Step Completion Reports | 1.0.1 → 1.0.2 |
| `skills/website-cloner/website-clone-report/SKILL.md` | n/a (already uses Write tool) | ✓ trailing | 1.0.1 → 1.0.2 |
| `skills/website-cloner/website-improvement-prd/SKILL.md` | ✓ Step 7 echo→printf | ✓ trailing | 1.1.0 → 1.1.1 |

## Test Results

`python3 ~/.claude/skills/skill-creator/scripts/quick_validate.py skills/website-cloner/<skill>` — all 7 website-* skills (5 changed + 2 reference) pass:

```
=== website-cloner ===                       Skill is valid!
=== website-cloner/website-analyzer ===       Skill is valid!
=== website-cloner/website-builder ===        Skill is valid!
=== website-cloner/website-clone-report ===   Skill is valid!
=== website-cloner/website-improvement-prd === Skill is valid!
=== website-cloner/website-implementation-plan === Skill is valid!
=== website-cloner/website-clone-final-report === Skill is valid!
```

Final consistency sweep:

```
$ grep -rEn "echo .* > " skills/website-cloner/        # → (none)
$ grep -rEn "^## Acceptance Criteria" skills/website-cloner/  # → (none)
```

## Acceptance Criteria Verification

| AC | Status | Evidence |
|---|---|---|
| All website-* skills use `printf '%s\n'` (or another safe pattern) for the persist step | ✓ | `website-improvement-prd` Step 7 migrated; `website-implementation-plan` already on `printf` (#39); `website-clone-report` and `website-clone-final-report` use Write tool with explicit "no `echo > path`" prose. No other website-* skill has a persist redirection. |
| No website-* skill ships a runtime `## Acceptance Criteria` section duplicating the linked issue | ✓ | Removed from 5 SKILL.md files; final grep returns none. |
| `metadata.version` bumped on every touched `SKILL.md` | ✓ | 5 patch bumps, one per touched file. |
| `quick_validate.py` passes for each touched skill | ✓ | See Test Results. |
| One PR per fix or one bundled PR — implementer's call; either way, each touched `SKILL.md` gets exactly one version bump | ✓ | One bundled PR; 5 files × 1 bump each. |

## Test plan

- [x] `quick_validate.py` clean on all 7 website-* skills
- [x] No remaining `echo "$VAR" > path` persist patterns under `skills/website-cloner/`
- [x] No remaining `## Acceptance Criteria` headers under `skills/website-cloner/`
- [x] Each touched `SKILL.md` shows exactly one `metadata.version` line in the diff