### PR TITLE
chore: ignore per-vendor AI tool config/scratch folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,35 @@ PHASE_1_SUMMARY.md
 # Skill auto-improver iteration artifacts
 .asm-improver/
 SKILL.md.bak
+
+# AI tool config/scratch folders (per-vendor, not part of the catalog)
+.ai-tools/
+.adal/
+.augment/
+.codebuddy/
+.codex/
+.commandcode/
+.continue/
+.crush/
+.factory/
+.gemini/
+.goose/
+.hermes/
+.iflow/
+.junie/
+.kilocode/
+.kiro/
+.kode/
+.mcpjam/
+.mux/
+.neovate/
+.opencode/
+.openhands/
+.pi/
+.pochi/
+.qoder/
+.qwen/
+.roo/
+.trae/
+.vibe/
+.zencoder/


### PR DESCRIPTION
## Summary

Adds `.ai-tools/` plus the per-vendor AI-tool dotfolders that show up untracked at the repo root to `.gitignore`, so they stop polluting `git status`.

## What's ignored

`.ai-tools/` and the 29 vendor scratch/config dirs observed at the root:

```
.adal .augment .codebuddy .codex .commandcode .continue .crush .factory
.gemini .goose .hermes .iflow .junie .kilocode .kiro .kode .mcpjam .mux
.neovate .opencode .openhands .pi .pochi .qoder .qwen .roo .trae .vibe .zencoder
```

## Deliberately NOT ignored

- `.claude/` — backs real skill content/symlinks (`.claude/skills/…`)
- `.agents/` — backs the stripe skill symlinks
- `.gitissue/` — issue tooling, not third-party AI-tool scratch

## Verification

```
$ git check-ignore .ai-tools/ .codex/ .gemini/ .roo/ .zencoder/   # all IGNORED
```
After the change, the only untracked root dot-entries left are `.agents/`, `.claude/skills/…`, and `.gitissue/` (all intentionally excluded above).

One file changed: `.gitignore` (+32).
