### PR TITLE
feat(etf-evaluator): deliver self-contained HTML report with professional design

### DIFF
--- a/skills/etf-evaluator/SKILL.md
+++ b/skills/etf-evaluator/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: "etf-evaluator"
+description: "Vet, review, or compare an ETF / index fund before investing: cite its TER, AUM, tracking, replication, domicile, then score it Invest / Consider / Avoid as an HTML report. Not for individual stocks, active funds, crypto, bonds, or rebalancing."
+license: MIT
+effort: high
+metadata:
+  version: 1.2.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
+---
+
+# ETF Evaluator
+
+Evaluate an index fund / ETF against a 10-point checklist and produce a **goal-relative** scored
+report with a clear **Invest / Consider / Avoid** verdict, rendered as a **single self-contained
+HTML file** (no external dependencies). Research every figure from a live source, cite it, and mark
+anything you cannot verify as `Unverified` — never guess.
+
+## When to Use
+
+Trigger when the user wants to:
+- Evaluate, vet, review, or score an ETF / index fund before buying it
+- Decide whether a specific ETF (by name or ISIN) is worth investing in
+- Compare similar ETFs tracking the same index (TER, AUM, replication, performance)
+- Build a scorecard / due-diligence report for an index fund
+
+Do **not** use for: picking individual stocks, evaluating active (stock-picking) mutual funds or
+hedge funds, crypto tokens, single-bond analysis, or rebalancing an existing portfolio. This skill
+evaluates **one passive index fund at a time** and reports; it does not place trades or give
+personalized financial advice.
+
+## Data Integrity Policy (read first — this is the spine of the skill)
+
+The output drives real money decisions. A fabricated TER, AUM, or domicile can cost the user real
+losses. Therefore:
+
+1. **Every figure must come from a live source and be cited.** Acceptable sources: the provider's
+   official factsheet / KIID / KID / annual report, justETF, Morningstar, ETF.com, or the exchange
+   listing page. No number reaches the scorecard without a source link or document name. **When
+   sources conflict, trust them in this order:** provider official document > justETF / Morningstar >
+   secondary blogs/forums. A stale snippet that disagrees with the primary source loses — cite the
+   primary value and note the discrepancy.
+2. **`Unverified` is a valid, expected value.** If you cannot find or confirm a figure, write
+   `Unverified` (or `Not found`) in that cell. Admitting a gap is correct; guessing is a defect.
+3. **Your training knowledge is stale and off-limits for live figures.** TER, AUM, spreads, and
+   holdings drift over time. Do not fill any live figure from memory — fetch it. **Date-stamp every
+   data pull** ("as of YYYY-MM-DD") so the user knows the snapshot's age.
+4. **Anchor on the ISIN, not the marketing name.** Names like "Amundi MSCI World Financials" are
+   ambiguous across share classes (accumulating vs distributing), currencies, and listings. Confirm
+   the exact ISIN and share class before evaluating, or you may score the wrong instrument.
+5. **Not financial advice.** End every report with the one-line disclaimer (see scorecard template).
+
+If web research tools are unavailable in the current environment, say so plainly and ask the user to
+paste the factsheet / KIID text rather than inventing figures.
+
+## Pipeline
+
+Follow these six phases in order. Emit a Step Completion Report after each phase (see "Step Reports").
+
+### Phase 1 — Capture Goal
+
+Establish how the ETF will be used, because the rubric is **goal-relative** (a core holding is judged
+on ultra-low cost and liquidity; a thematic/sector bet tolerates higher cost with a capped position).
+
+Ask the user (via AskUserQuestion) — but if they just want a quick read, **default to "core holding"**
+and proceed rather than blocking:
+- **Role:** core broad-market holding, or satellite / sector / thematic / factor bet?
+- **Horizon & risk tolerance:** how long, how much volatility can they stomach?
+- **Context:** their broker/platform, base currency, and tax domicile (affects withholding tax &
+  which fund domicile is efficient — e.g. Ireland/Luxembourg for many EU investors).
+
+Record the goal; it sets the rating thresholds in Phase 4.
+
+### Phase 2 — Identify the Exact Instrument
+
+- Get the **ISIN** (ask if only a name was given, or resolve it via search and confirm with the user).
+- Confirm: full fund name, share class (acc / dist), fund currency, and the exchange/listing the user
+  will trade on.
+- State what index it tracks and confirm it matches the user's intent (e.g. MSCI World ≠ MSCI World
+  Financials). Misidentification here invalidates everything downstream.
+
+### Phase 3 — Acquire & Cite Data
+
+Research the web and pull figures for the 10-point checklist. Read `references/checklist.md` for the
+full list of what each point requires. For each data point: fetch from a real source, record the
+**value + source + as-of date**, or mark `Unverified`. Prioritise the official factsheet/KIID, then
+justETF / Morningstar, then the provider site and exchange page.
+
+Minimum to gather: TER, AUM, replication method (physical full/sampled vs synthetic), fund domicile &
+structure (e.g. UCITS), distribution policy (acc/dist), index name + holdings count + top-10
+concentration, tracking difference/error if published, 1/3/5-yr & since-inception performance vs
+benchmark, bid-ask spread / average volume, provider, and inception date.
+
+Several fields are **routinely not on free pages** — tracking *difference* (vs tracking error),
+max drawdown, explicit fund-vs-benchmark return columns, and broker/savings-plan availability. Marking
+these `Unverified` is **expected, not a failure**; only the official annual report or a paid data
+service usually carries them. Don't let a few expected gaps make Phase 3 look like it failed.
+
+### Phase 4 — Evaluate Against the 10-Point Checklist
+
+Rate each criterion **Good / Fair / Poor / Unverified** using the goal-relative thresholds in
+`references/checklist.md` (e.g. core broad-market TER < 0.20% = Good; AUM > €100M healthy, > €500M
+closure-safe). Note the reasoning and the source for each rating. Apply the Phase-1 goal: the same TER
+can be "Good" for a niche thematic ETF and "Fair" for a core index fund.
+
+### Phase 5 — Compare Similar ETFs
+
+Surface **1–2 alternatives tracking the same (or near-identical) index** and compare them on TER, AUM,
+replication, domicile, and tracking. This is often the highest-value section — a cheaper, larger,
+better-domiciled twin can flip the decision. Cite each alternative's figures too.
+
+### Phase 6 — Score, Decide & Deliver
+
+- Fill the scorecard data model in `references/scorecard-template.md` (this defines **what** to
+  collect; it is not the output format).
+- Give a clear verdict: **Invest / Consider / Avoid**, justified by the goal and the ratings.
+- For thematic/sector ETFs, recommend a position-size cap (e.g. 5–15% of portfolio) when conviction is
+  required.
+- Include the data-as-of date, source list, and the not-financial-advice disclaimer.
+- **Render the full report as a single self-contained HTML file** using the template in
+  `references/html-output-template.md`. Follow every rule in that template (no external deps, escape
+  all dynamic text, use verdict/rating CSS classes, replace every placeholder).
+- Save the file to `~/etf-evaluations/<ISIN>_etf_evaluation.html` (or `~/etf-evaluations/<TICKER>_etf_evaluation.html`
+  if no ISIN was confirmed). Create the directory if it does not exist.
+- Echo the absolute file path to the user. Do not render the Markdown in chat — the HTML file is
+  the deliverable.
+
+## Step Reports
+
+After each phase, emit a Step Completion Report so the user can follow the due-diligence trail:
+
+```
+◆ [Phase Name] (step N of 6)
+··································································
+  [Check 1]:          √ pass
+  [Check 2]:          √ pass (note)
+  [Check 3]:          × fail — [reason]
+  ____________________________
+  Result:             PASS | PARTIAL | FAIL
+```
+
+Suggested checks per phase — **Capture Goal:** `Role defined`, `Horizon/tax captured`; **Identify:**
+`ISIN confirmed`, `Index matches intent`, `Share class confirmed`; **Acquire Data:** `Sources cited`,
+`As-of dates recorded`, `Gaps marked Unverified`; **Evaluate:** `All 10 rated`, `Thresholds applied`,
+`Goal-relative`; **Compare:** `≥1 alternative cited`; **Deliver:** `Verdict given`, `Disclaimer
+present`, `HTML file saved`, `Path echoed`.
+
+## Reference Files
+
+- `references/checklist.md` — the 10-point checklist in full, plus the Good/Fair/Poor rating
+  thresholds (read this in Phase 3 and Phase 4).
+- `references/scorecard-template.md` — the data model for the scorecard (what to collect).
+- `references/html-output-template.md` — the HTML rendering contract (how to present it). Read this
+  in Phase 6.

--- a/skills/etf-evaluator/docs/README.md
+++ b/skills/etf-evaluator/docs/README.md
@@ -1,0 +1,61 @@
+<!--
+  DO NOT READ THIS FILE — This README.md is for human catalog browsing only.
+  It ships inside the .skill package but is NEVER auto-loaded into agent context.
+  The runtime loader only reads SKILL.md + references/ + scripts/ + agents/ when the skill triggers.
+  If you're an AI agent, read the SKILL.md file instead for skill instructions.
+-->
+
+# ETF Evaluator
+
+> Research, score, and decide on an index fund / ETF before you invest — with every figure cited and a clear Invest / Consider / Avoid verdict.
+
+## Highlights
+
+- **Data-integrity first** — every TER, AUM, tracking number, and domicile is fetched from a live source (factsheet/KIID, justETF, Morningstar) and cited. Anything it can't verify is marked `Unverified`, never guessed.
+- **Goal-relative scoring** — a core MSCI World holding is judged on ultra-low cost and liquidity; a thematic/sector bet is held to peer-relevant thresholds and gets a position-size cap.
+- **10-point checklist** — Tracking, TER, AUM/liquidity, replication/structure, index quality, performance/risk, dividend & tax efficiency, provider stability, portfolio fit, trading costs.
+- **Same-index comparison** — surfaces 1–2 alternatives so a cheaper, larger, better-domiciled twin can flip the decision.
+- **Auditable report** — scorecard with sources and as-of dates, rendered in chat and optionally saved to Markdown.
+
+## When to Use
+
+| Say this...                                          | Skill will...                                                       |
+| ---------------------------------------------------- | ------------------------------------------------------------------- |
+| "Is VWCE a good ETF to buy?"                          | Identify the ISIN, research and cite its figures, score it, give a verdict |
+| "Evaluate the Amundi MSCI World Financials ETF"       | Confirm the exact share class, rate all 10 points, cap it as a satellite |
+| "Compare IWDA vs SWDA for a core holding"             | Compare same-index twins on TER, AUM, replication, domicile         |
+| "Should I add this S&P 500 ETF to my portfolio?"      | Check overlap/fit, score, and recommend Invest / Consider / Avoid   |
+
+Not for: picking individual stocks, active mutual funds, crypto, single-bond analysis, or portfolio rebalancing.
+
+## How It Works
+
+```mermaid
+graph TD
+    A["Capture Goal<br/>(core vs thematic, horizon, tax)"] --> B["Identify Instrument<br/>(ISIN, share class, index)"]
+    B --> C["Acquire & Cite Data<br/>(factsheet, justETF, Morningstar)"]
+    C --> D["Evaluate 10-Point Checklist<br/>(goal-relative thresholds)"]
+    D --> E["Compare Similar ETFs<br/>(same-index twins)"]
+    E --> F["Score, Decide & Deliver<br/>(Invest / Consider / Avoid)"]
+    style A fill:#4CAF50,color:#fff
+    style F fill:#1976D2,color:#fff
+```
+
+## Output
+
+A **single self-contained HTML file** (no external dependencies) saved to `~/etf-evaluations/<ISIN>_etf_evaluation.html`. The report features:
+
+- Dark navy header with fund name, ISIN, and index tracked
+- Color-coded verdict card (green = Invest, amber = Consider, red = Avoid)
+- 10-row scorecard table with rating badges, source citations, and as-of dates
+- Same-index comparison table (this fund vs 1–2 alternatives)
+- Key risks section, bottom line, and source list
+- Professional disclaimer footer
+
+The HTML is responsive, print-friendly, and uses only embedded CSS — no CDN links, no JavaScript, no external fonts.
+
+## Notes
+
+- **Educational, not advice.** The report is a structured due-diligence aid, not a recommendation to buy or sell.
+- **Needs web access** to research live figures. If research tools are unavailable, it asks you to paste the factsheet/KIID rather than inventing numbers.
+- **Verify before you trade.** Figures drift; always confirm the final numbers on the official factsheet.

--- a/skills/etf-evaluator/evals/evals.json
+++ b/skills/etf-evaluator/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "etf-evaluator",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Is VWCE a good ETF to buy as the core of my long-term portfolio? I'm an EU investor on Trade Republic, base currency EUR.",
+      "expected_output": "Captures goal = core holding (long horizon, EUR, EU/Trade Republic). Identifies the exact instrument by ISIN (IE00BK5BQT80, Vanguard FTSE All-World UCITS, Acc) and confirms the index. Researches and CITES each figure (TER, AUM, replication, domicile, tracking) from live sources with as-of dates; marks anything unfound as Unverified, never guesses. Rates all 10 points against CORE thresholds (e.g. TER judged strictly vs <0.20% Good). Surfaces 1-2 same-index alternatives (e.g. VWRL dist, or FTSE All-World twins). Produces a single self-contained HTML file at ~/etf-evaluations/IE00BK5BQT80_etf_evaluation.html with embedded CSS, no external deps. HTML includes: navy header, color-coded verdict card, 10-row scorecard with rating badges, comparison table, risks, sources, disclaimer. Echoes the absolute file path.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Evaluate the Amundi MSCI World Financials ETF before I put money in.",
+      "expected_output": "Notes the name is ambiguous and anchors on the ISIN + share class (acc/dist, currency, listing) before evaluating, asking the user to confirm if needed. Treats it as a THEMATIC/sector bet, so rates TER/volatility against sector-peer thresholds (not core thresholds) and recommends a position-size cap (e.g. 5-15% of portfolio, satellite only). Flags synthetic replication counterparty risk if applicable and sector concentration. Every figure cited or marked Unverified with an as-of date. Produces a single self-contained HTML file (no external deps) with embedded CSS, color-coded verdict, 10-row scorecard, comparison table, risks, and disclaimer. Echoes the absolute file path.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "Should I pick IWDA or SWDA for my MSCI World allocation? Which is better?",
+      "expected_output": "Recognizes these track the same index (MSCI World) and confirms each ISIN/share class (IWDA = IE00B4L5Y983 acc; SWDA is the same fund/ISIN on the LSE GBP line) before scoring. Researches and cites TER, AUM, replication, domicile, and tracking for both with as-of dates. Compares them head-to-head in the comparison table on cost/size/domicile/listing/currency rather than scoring them as different funds, and explains that the choice is largely about exchange/currency. Produces a single self-contained HTML file (no external deps) with embedded CSS, verdict card, scorecard, comparison table, and disclaimer. Echoes the absolute file path. Does not fabricate figures.",
+      "files": []
+    }
+  ]
+}

--- a/skills/etf-evaluator/references/checklist.md
+++ b/skills/etf-evaluator/references/checklist.md
@@ -1,0 +1,131 @@
+# ETF Evaluation — 10-Point Checklist & Rating Thresholds
+
+Read this in **Phase 3** (to know what to gather) and **Phase 4** (to know how to rate it). Every
+figure must be cited or marked `Unverified` — see the Data Integrity Policy in SKILL.md.
+
+The thresholds below are **goal-relative**. "Core" = broad-market core holding (MSCI World, FTSE
+All-World, S&P 500). "Thematic" = sector / single-country / factor / niche bet. When a row gives both,
+rate against the column that matches the Phase-1 goal. Thresholds are heuristics for consistency, not
+hard law — note when a fund is a borderline or special case.
+
+---
+
+## Core 5 (most important)
+
+### 1. Tracking Error & Tracking Difference
+- **What it is:** Tracking *difference* = the fund's return minus the index return over a period (the
+  figure that actually costs you; can be negative or, rarely, positive). Tracking *error* = the
+  volatility/std-dev of that gap (consistency). Together they tell you how faithfully the fund
+  delivers the index.
+- **Gather:** published tracking difference / error from the factsheet, justETF "tracking difference"
+  table, or annual report. If not published, infer roughly from fund-vs-benchmark return columns and
+  say so. **Tracking *difference* is frequently absent from free pages while tracking *error* is
+  shown — that gap is expected;** mark the missing one `Unverified` rather than forcing a number.
+- **Rate (use whichever metric you actually have):**
+  - **Good** — tracking difference within roughly ±(TER) of the index; *or*, if only tracking error is
+    available, a small (≈≤ TER) and stable error. Rate on the metric you have and say which one.
+  - **Fair** — difference a few tenths of a % worse than TER, only one year available, or a noticeably
+    elevated error.
+  - **Poor** — persistent large drag well beyond TER, or erratic year-to-year.
+  - `Unverified` — neither metric found and nothing can be inferred. (Having error but not difference
+    is **not** `Unverified` — rate on the error and mark the difference unverified in the value cell.)
+
+### 2. Expense Ratio (TER / OCF) & Total Cost
+- **What it is:** Annual ongoing charge. The single most reliable predictor of long-run net return for
+  a passive fund. Total cost also includes spread + brokerage + tax drag (covered in #10 and #7).
+- **Gather:** TER / OCF from KIID/KID or factsheet.
+- **Rate (core):** **Good** < 0.20% · **Fair** 0.20–0.40% · **Poor** > 0.40%.
+- **Rate (thematic):** **Good** < 0.35% · **Fair** 0.35–0.60% · **Poor** > 0.60%.
+  (Thematic/active-ish ETFs run pricier; judge against peers on the *same* theme.)
+
+### 3. Assets Under Management (AUM) & Liquidity
+- **What it is:** Fund size. Small funds are likelier to be closed/merged (forcing a taxable exit) and
+  often have wider spreads. Liquidity = how easily you can trade at a fair price.
+- **Gather:** AUM (note currency and whether it's the share-class or whole-fund figure), fund age,
+  average daily volume.
+- **Rate:** **Good** > €/$500M (closure-safe) · **Fair** €/$100–500M (healthy but watch) · **Poor** <
+  €/$100M, especially if also > ~3–5 yrs old and still tiny (closure risk). A brand-new fund from a
+  major issuer with fast inflows can be "Fair" despite low AUM — note the trajectory.
+
+### 4. Replication Method & Fund Structure
+- **What it is:** *Physical full* (holds all index constituents), *physical sampled/optimised* (holds
+  a representative subset), or *synthetic* (swap-based — introduces counterparty risk but can track
+  tightly and access hard markets). Structure = legal wrapper (e.g. **UCITS** = EU-regulated, strong
+  investor protections; US-domiciled ≠ UCITS).
+- **Gather:** replication method, UCITS yes/no, fund structure from factsheet/KIID.
+- **The common middle case:** providers label the same fund inconsistently — "physical full" vs
+  "optimized sampling" — for a broad index where the fund holds the top ~85–95% of constituents and
+  skips the micro-cap tail. **Resolve it with the holdings ratio, not the label:** report "holds X of Y
+  index stocks" and treat ≳85% physical coverage as effectively full replication (no counterparty
+  risk). Only call it true "sampled" when coverage is materially lower. This is **not** synthetic.
+- **Rate:** **Good** — physical full or well-run sampled (≳85% coverage), UCITS (for EU investors).
+  **Fair** — synthetic from a reputable issuer with disclosed swap counterparties / collateral, or
+  heavy sampling (low coverage). **Poor** — opaque synthetic, undisclosed counterparty, or a structure
+  that doesn't fit the user's jurisdiction. Synthetic is not "bad" per se — flag the counterparty risk
+  and let the goal decide.
+
+### 5. Index Quality & Fund Characteristics
+- **What it is:** What the index actually tracks, its methodology, breadth, and concentration. A
+  100-stock cap-weighted tech index behaves very differently from a 1,500-stock world index.
+- **Gather:** index name + provider (MSCI, FTSE, S&P, Solactive…), number of holdings, top-10 weight,
+  sector/country weights, rebalancing frequency.
+- **Rate:** **Good** — broad, transparent, rules-based, well-diversified for its mandate, low
+  single-name concentration. **Fair** — narrower or more concentrated but still rules-based. **Poor** —
+  tiny holdings count, extreme single-name/sector concentration the user isn't aware of, or an opaque
+  proprietary index. (For a *thematic* fund, concentration is expected — judge whether it's reasonable
+  for the theme, not against a world index.)
+
+---
+
+## Bonus 5 (important context)
+
+### 6. Historical Performance & Risk Metrics
+Returns vs benchmark over 1/3/5-yr and since inception; volatility, max drawdown, Sharpe if available;
+behaviour in past stress (2008, 2020 COVID, 2022 bear). **Past performance ≠ future returns** — use it
+to check tracking and risk character, not to predict. **Explicit fund-vs-benchmark return columns and
+max drawdown are often not on free pages** — if you only have *absolute* returns, say so and rate on
+tracking faithfulness rather than dressing absolute returns up as benchmark-relative data; mark the
+missing pieces `Unverified`. **Good** — tracks benchmark closely with risk in line with the asset
+class. **Poor** — large unexplained underperformance or risk far above peers.
+
+### 7. Dividend Policy & Tax Efficiency
+**Accumulating** (reinvests dividends — simpler compounding, often better for growth/EU investors) vs
+**Distributing** (pays out — useful for income). Check **domicile** (Ireland/Luxembourg are often most
+tax-efficient for Europeans via favourable US withholding-tax treaties) and how the user's residence
+taxes the chosen structure. **Good** — domicile + distribution type fit the user's goal and tax
+situation. **Poor** — tax-inefficient domicile for this investor (e.g. a US-domiciled fund triggering
+extra withholding/estate exposure for an EU resident).
+
+### 8. Provider Reputation & ETF Stability
+Issuer track record (Vanguard, iShares/BlackRock, Amundi, SPDR/State Street, Invesco, Xtrackers…),
+history of closures/mergers, reporting quality. **Good** — large, established issuer, clean record.
+**Fair** — smaller/newer issuer, thin history. **Poor** — issuer with frequent closures or poor
+disclosure.
+
+### 9. Portfolio Fit & Diversification Impact
+How this ETF overlaps with what the user already holds (sector/country/single-name overlap),
+correlation, and its marginal risk contribution. A second S&P 500 fund adds little; a world ex-US fund
+might fill a gap. Flag overlap and concentration the addition would create. (If the user shared no
+existing holdings, note this is assessed in isolation.)
+
+### 10. Trading Costs & Accessibility
+Bid-ask spread, availability on the user's broker, exchange/currency (and whether a **hedged** vs
+**unhedged** share class fits their currency view), minimum investment, and savings-plan eligibility.
+**Broker / savings-plan availability has no neutral primary source** — no factsheet publishes it; you'll
+only find secondary blogs or the in-app catalog. Cite what you can and tell the user to **confirm in
+their broker app** — that's the honest answer, not a defect.
+**Good** — tight spread, available on their broker in their currency, savings-plan compatible. **Poor**
+— wide spread, not on their platform, or wrong-currency-only.
+
+---
+
+## Putting it together
+
+- Weight the **Core 5** more heavily than the **Bonus 5** in the verdict.
+- A single **Poor** on a Core item (e.g. closure-risk AUM, or a tax-toxic domicile for this investor)
+  can justify **Avoid** or **Consider** even if everything else is Good.
+- **Core holdings:** prioritise ultra-low TER + high liquidity + faithful tracking + efficient
+  domicile. Be strict.
+- **Thematic/sector holdings:** accept higher cost/volatility *only* with genuine conviction, and
+  recommend a position cap (typically 5–15% of portfolio). Be explicit that it's a satellite, not a
+  core.

--- a/skills/etf-evaluator/references/html-output-template.md
+++ b/skills/etf-evaluator/references/html-output-template.md
@@ -1,0 +1,327 @@
+# ETF Evaluator — HTML Output Template
+
+Use this template as the **rendering contract** for Phase 6. The scorecard data model stays in `references/scorecard-template.md`; this file defines how that data is presented.
+
+## Rules
+
+1. **Single self-contained file.** All CSS lives in a `<style>` block in `<head>`. No CDN links, no external fonts, no JS libraries, no images.
+2. **No JavaScript.** The report is static HTML + CSS only.
+3. **Escape all dynamic text.** Fund names, source URLs, notes, and any user-provided text must be HTML-escaped (`&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`, `'` → `&#39;`). Never insert raw unescaped text.
+4. **Replace every `{{PLACEHOLDER}}`** with actual data. Leave **no** `{{...}}` tokens in the final file.
+5. **File naming:** `~/etf-evaluations/{{ISIN}}_etf_evaluation.html` (sanitize ISIN/ticker for filesystem safety).
+6. **Verdict class:** apply exactly one of `verdict-invest`, `verdict-consider`, or `verdict-avoid` to the verdict card.
+7. **Rating classes:** apply exactly one of `rating-good`, `rating-fair`, `rating-poor`, or `rating-unverified` to each rating badge.
+
+## Design System
+
+- **Palette:** navy header (`#1e293b`), white cards, light gray background (`#f8fafc`), semantic accents — green `#16a34a` (Good/Invest), amber `#d97706` (Fair/Consider), red `#dc2626` (Poor/Avoid), slate `#64748b` (Unverified).
+- **Typography:** system font stack (`-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif`). Tabular numbers for all financial values.
+- **Layout:** max-width `960px`, centered. Card-based sections with subtle shadow.
+- **Tables:** full-width within cards, striped rows, scrollable on mobile (`overflow-x: auto` wrapper).
+- **Print:** remove shadows, ensure black text on white background, avoid page breaks inside sections.
+
+## Template
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ETF Evaluation — {{FUND_NAME}} ({{TICKER}})</title>
+<style>
+  /* ===== Design tokens ===== */
+  :root{
+    --bg:#f8fafc; --card:#ffffff; --header:#1e293b; --header-text:#f1f5f9;
+    --line:#e2e8f0; --line-soft:#f1f5f9;
+    --ink:#0f172a; --ink-soft:#475569; --ink-faint:#94a3b8;
+    --green:#16a34a; --green-bg:#f0fdf4; --green-border:#bbf7d0;
+    --amber:#d97706; --amber-bg:#fffbeb; --amber-border:#fde68a;
+    --red:#dc2626; --red-bg:#fef2f2; --red-border:#fecaca;
+    --slate:#64748b; --slate-bg:#f8fafc; --slate-border:#e2e8f0;
+    --radius:10px; --shadow:0 1px 3px rgba(0,0,0,.06), 0 1px 2px rgba(0,0,0,.04);
+    --maxw:960px;
+  }
+  *, *::before, *::after{box-sizing:border-box}
+  body{margin:0; background:var(--bg); color:var(--ink); font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Arial,sans-serif; line-height:1.6; -webkit-font-smoothing:antialiased}
+  a{color:var(--green); text-decoration:none} a:hover{text-decoration:underline}
+  .wrap{max-width:var(--maxw); margin:0 auto; padding:0 20px}
+
+  /* ===== Header ===== */
+  header{background:var(--header); color:var(--header-text); padding:40px 0 36px}
+  header .wrap{display:flex; flex-wrap:wrap; align-items:flex-end; justify-content:space-between; gap:16px}
+  header h1{margin:0; font-size:clamp(1.6rem,4vw,2.2rem); font-weight:700; letter-spacing:-.02em; line-height:1.15}
+  header .subtitle{font-size:14px; color:var(--ink-faint); margin-top:6px}
+  header .meta{font-size:13px; color:var(--ink-faint); text-align:right; line-height:1.7}
+  header .meta span{display:block}
+
+  /* ===== Verdict card ===== */
+  .verdict-card{margin:-20px auto 32px; position:relative; z-index:1; max-width:var(--maxw); padding:0 20px}
+  .verdict{border-radius:var(--radius); padding:28px 32px; box-shadow:var(--shadow)}
+  .verdict-invest{background:var(--green-bg); border:1.5px solid var(--green-border)}
+  .verdict-consider{background:var(--amber-bg); border:1.5px solid var(--amber-border)}
+  .verdict-avoid{background:var(--red-bg); border:1.5px solid var(--red-border)}
+  .verdict .badge{display:inline-block; font-size:13px; font-weight:700; letter-spacing:.06em; text-transform:uppercase; padding:4px 14px; border-radius:999px}
+  .verdict-invest .badge{background:var(--green); color:#fff}
+  .verdict-consider .badge{background:var(--amber); color:#fff}
+  .verdict-avoid .badge{background:var(--red); color:#fff}
+  .verdict .rationale{margin:14px 0 0; font-size:15px; color:var(--ink-soft); line-height:1.65}
+  .verdict .rationale strong{color:var(--ink)}
+
+  /* ===== Section ===== */
+  section{margin-bottom:28px}
+  .sec-head{display:flex; align-items:baseline; gap:12px; margin-bottom:16px; padding-bottom:10px; border-bottom:2px solid var(--header)}
+  .sec-head h2{margin:0; font-size:1.25rem; font-weight:700; color:var(--header)}
+  .sec-head .n{font-family:monospace; font-size:11px; color:var(--ink-faint); background:var(--line-soft); padding:2px 8px; border-radius:4px}
+
+  /* ===== Card ===== */
+  .card{background:var(--card); border-radius:var(--radius); box-shadow:var(--shadow); padding:24px 28px; margin-bottom:16px}
+
+  /* ===== Info grid ===== */
+  .info-grid{display:grid; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); gap:1px; background:var(--line); border:1px solid var(--line); border-radius:var(--radius); overflow:hidden}
+  .info-grid div{background:var(--card); padding:14px 18px}
+  .info-grid dt{font-size:10.5px; letter-spacing:.1em; text-transform:uppercase; color:var(--ink-faint); margin:0 0 4px; font-weight:600}
+  .info-grid dd{margin:0; font-size:14px; color:var(--ink); font-weight:500}
+
+  /* ===== Scorecard table ===== */
+  .table-wrap{overflow-x:auto; -webkit-overflow-scrolling:touch}
+  table{width:100%; border-collapse:collapse; font-size:14px}
+  thead th{text-align:left; padding:10px 14px; background:var(--line-soft); font-size:11.5px; letter-spacing:.06em; text-transform:uppercase; color:var(--ink-faint); font-weight:600; border-bottom:2px solid var(--line); white-space:nowrap}
+  tbody td{padding:14px; border-bottom:1px solid var(--line-soft); vertical-align:top; color:var(--ink-soft)}
+  tbody tr:last-child td{border-bottom:none}
+  tbody tr:hover{background:#fafbfc}
+  .mono{font-family:"SF Mono",SFMono-Regular,ui-monospace,"Cascadia Code","Menlo",monospace; font-size:13px}
+  .tabular{font-variant-numeric:tabular-nums}
+
+  /* ===== Rating badges ===== */
+  .rating{display:inline-block; font-size:11px; font-weight:700; letter-spacing:.04em; text-transform:uppercase; padding:3px 10px; border-radius:999px; white-space:nowrap}
+  .rating-good{background:var(--green-bg); color:var(--green); border:1px solid var(--green-border)}
+  .rating-fair{background:var(--amber-bg); color:var(--amber); border:1px solid var(--amber-border)}
+  .rating-poor{background:var(--red-bg); color:var(--red); border:1px solid var(--red-border)}
+  .rating-unverified{background:var(--slate-bg); color:var(--slate); border:1px solid var(--slate-border)}
+
+  /* ===== Summary badges ===== */
+  .summary{display:flex; flex-wrap:wrap; gap:20px; margin-top:16px; padding-top:16px; border-top:1px solid var(--line)}
+  .summary .label{font-size:12px; color:var(--ink-faint); font-weight:600; letter-spacing:.04em; text-transform:uppercase}
+  .summary .value{font-size:14px; color:var(--ink); font-weight:600}
+
+  /* ===== Comparison table ===== */
+  .compare-note{font-size:14px; color:var(--ink-soft); margin-top:14px; line-height:1.65}
+
+  /* ===== Risks ===== */
+  .risk-list{list-style:none; padding:0; margin:0}
+  .risk-list li{padding:10px 0; border-bottom:1px solid var(--line-soft); font-size:14px; color:var(--ink-soft); line-height:1.6}
+  .risk-list li:last-child{border-bottom:none}
+  .risk-list li::before{content:"⚠"; margin-right:10px; font-size:13px}
+
+  /* ===== Bottom line ===== */
+  .bottom-line{font-size:15px; color:var(--ink); line-height:1.7; font-weight:500}
+
+  /* ===== Sources ===== */
+  .source-list{list-style:none; padding:0; margin:0}
+  .source-list li{padding:6px 0; font-size:13px; color:var(--ink-soft); border-bottom:1px solid var(--line-soft)}
+  .source-list li:last-child{border-bottom:none}
+  .source-list a{color:var(--green)}
+
+  /* ===== Disclaimer ===== */
+  footer{margin-top:40px; padding:28px 0; border-top:1px solid var(--line); text-align:center}
+  footer p{font-size:12px; color:var(--ink-faint); line-height:1.7; max-width:720px; margin:0 auto}
+  footer strong{color:var(--ink-soft)}
+
+  /* ===== Print ===== */
+  @media print{
+    body{background:#fff; color:#000}
+    header{background:#1e293b; -webkit-print-color-adjust:exact; print-color-adjust:exact}
+    .verdict{box-shadow:none; border-width:2px}
+    .card{box-shadow:none; border:1px solid #ddd}
+    .rating{border-width:2px; -webkit-print-color-adjust:exact; print-color-adjust:exact}
+    thead th{background:#f1f5f9; -webkit-print-color-adjust:exact; print-color-adjust:exact}
+    section{break-inside:avoid}
+    a{color:#000; text-decoration:underline}
+  }
+
+  /* ===== Mobile ===== */
+  @media(max-width:640px){
+    header{padding:28px 0 24px}
+    header .wrap{flex-direction:column; align-items:flex-start}
+    header .meta{text-align:left}
+    .verdict{padding:20px 22px}
+    .card{padding:18px 16px}
+    .info-grid{grid-template-columns:repeat(2,1fr)}
+    thead th, tbody td{padding:10px 12px; font-size:13px}
+  }
+</style>
+</head>
+<body>
+
+<!-- ===== HEADER ===== -->
+<header>
+  <div class="wrap">
+    <div>
+      <h1>{{FUND_NAME}}</h1>
+      <div class="subtitle">{{TICKER}} · {{ISIN}} · {{INDEX_NAME}} ({{INDEX_PROVIDER}})</div>
+    </div>
+    <div class="meta">
+      <span>Evaluated: {{DATE}}</span>
+      <span>Data as of: {{DATA_AS_OF}}</span>
+      <span>Investor: {{INVESTOR_CONTEXT}}</span>
+    </div>
+  </div>
+</header>
+
+<!-- ===== VERDICT ===== -->
+<div class="verdict-card">
+  <div class="verdict verdict-{{VERDICT_CLASS}}">
+    <span class="badge">{{VERDICT_TEXT}}</span>
+    <p class="rationale">{{VERDICT_RATIONALE}}</p>
+  </div>
+</div>
+
+<div class="wrap">
+
+  <!-- ===== FUND DETAILS ===== -->
+  <section>
+    <div class="sec-head"><span class="n">01</span><h2>Fund Details</h2></div>
+    <dl class="info-grid">
+      <div><dt>Share Class</dt><dd>{{SHARE_CLASS}} ({{DISTRIBUTION_POLICY}})</dd></div>
+      <div><dt>Currency</dt><dd>{{FUND_CURRENCY}}</dd></div>
+      <div><dt>Domicile</dt><dd>{{DOMICILE}}</dd></div>
+      <div><dt>Structure</dt><dd>{{STRUCTURE}}</dd></div>
+      <div><dt>Replication</dt><dd>{{REPLICATION_METHOD}}</dd></div>
+      <div><dt>Provider</dt><dd>{{PROVIDER}}</dd></div>
+      <div><dt>Inception</dt><dd>{{INCEPTION_DATE}}</dd></div>
+      <div><dt>Listing</dt><dd>{{LISTING_EXCHANGE}}</dd></div>
+    </dl>
+  </section>
+
+  <!-- ===== SCORECARD ===== -->
+  <section>
+    <div class="sec-head"><span class="n">02</span><h2>10-Point Scorecard</h2></div>
+    <div class="card">
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th style="width:36px">#</th>
+              <th>Criterion</th>
+              <th style="width:110px">Rating</th>
+              <th>Value (source · as-of)</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <!-- REPEAT:scorecard-row — one <tr> per checklist item -->
+            <tr>
+              <td class="mono tabular">{{ROW_NUM}}</td>
+              <td><strong>{{CRITERION_NAME}}</strong></td>
+              <td><span class="rating rating-{{RATING_CLASS}}">{{RATING_TEXT}}</span></td>
+              <td class="mono tabular">{{VALUE_CELL}}</td>
+              <td>{{NOTES_CELL}}</td>
+            </tr>
+            <!-- /REPEAT:scorecard-row -->
+          </tbody>
+        </table>
+      </div>
+      <!-- Summary -->
+      <div class="summary">
+        <div><span class="label">Core 5:</span> <span class="value">{{CORE_SUMMARY}}</span></div>
+        <div><span class="label">Bonus 5:</span> <span class="value">{{BONUS_SUMMARY}}</span></div>
+        <div><span class="label">Total Good:</span> <span class="value" style="color:var(--green)">{{COUNT_GOOD}}</span></div>
+        <div><span class="label">Total Fair:</span> <span class="value" style="color:var(--amber)">{{COUNT_FAIR}}</span></div>
+        <div><span class="label">Total Poor:</span> <span class="value" style="color:var(--red)">{{COUNT_POOR}}</span></div>
+        <div><span class="label">Unverified:</span> <span class="value" style="color:var(--slate)">{{COUNT_UNVERIFIED}}</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== COMPARISON ===== -->
+  <section>
+    <div class="sec-head"><span class="n">03</span><h2>Comparison vs Similar ETFs</h2></div>
+    <div class="card">
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Fund</th>
+              <th>TER</th>
+              <th>AUM</th>
+              <th>Replication</th>
+              <th>Domicile</th>
+              <th>Tracking</th>
+              <th>Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            <!-- REPEAT:compare-row -->
+            <tr>
+              <td><strong>{{COMP_FUND_NAME}}</strong><br><span class="mono" style="font-size:12px;color:var(--ink-faint)">{{COMP_ISIN}}</span></td>
+              <td class="mono tabular">{{COMP_TER}}</td>
+              <td class="mono tabular">{{COMP_AUM}}</td>
+              <td>{{COMP_REPLICATION}}</td>
+              <td>{{COMP_DOMICILE}}</td>
+              <td class="mono tabular">{{COMP_TRACKING}}</td>
+              <td>{{COMP_NOTE}}</td>
+            </tr>
+            <!-- /REPEAT:compare-row -->
+          </tbody>
+        </table>
+      </div>
+      <p class="compare-note">{{COMPARE_NOTE}}</p>
+    </div>
+  </section>
+
+  <!-- ===== RISKS ===== -->
+  <section>
+    <div class="sec-head"><span class="n">04</span><h2>Key Risks</h2></div>
+    <div class="card">
+      <ul class="risk-list">
+        <!-- REPEAT:risk-item -->
+        <li>{{RISK_TEXT}}</li>
+        <!-- /REPEAT:risk-item -->
+      </ul>
+    </div>
+  </section>
+
+  <!-- ===== BOTTOM LINE ===== -->
+  <section>
+    <div class="sec-head"><span class="n">05</span><h2>Bottom Line</h2></div>
+    <div class="card">
+      <p class="bottom-line">{{BOTTOM_LINE}}</p>
+    </div>
+  </section>
+
+  <!-- ===== SOURCES ===== -->
+  <section>
+    <div class="sec-head"><span class="n">06</span><h2>Sources</h2></div>
+    <div class="card">
+      <ol class="source-list">
+        <!-- REPEAT:source-item -->
+        <li>{{SOURCE_TEXT}}</li>
+        <!-- /REPEAT:source-item -->
+      </ol>
+    </div>
+  </section>
+
+  <!-- ===== DISCLAIMER ===== -->
+  <footer>
+    <p>Data as of <strong>{{DATA_AS_OF}}</strong>. Figures marked "Unverified" could not be confirmed from a public source and should be checked on the official factsheet before investing. This is an educational evaluation, <strong>not personalized financial advice</strong>; past performance does not guarantee future results. Do your own research.</p>
+  </footer>
+
+</div>
+</body>
+</html>
+```
+
+## Section-by-section guide
+
+| Section | Placeholders to fill | Notes |
+|---------|---------------------|-------|
+| Header | `FUND_NAME`, `TICKER`, `ISIN`, `INDEX_NAME`, `INDEX_PROVIDER`, `DATE`, `DATA_AS_OF`, `INVESTOR_CONTEXT` | Header is dark navy; keep fund name prominent |
+| Verdict | `VERDICT_CLASS` (invest/consider/avoid), `VERDICT_TEXT`, `VERDICT_RATIONALE` | Class controls the card color |
+| Fund Details | All `{{...}}` in the `<dl>` grid | 8 key attributes as a compact grid |
+| Scorecard | Repeat `<tr>` 10 times, one per checklist item | Each row: number, criterion name, rating badge, value+source, notes |
+| Comparison | Repeat `<tr>` 1–3 times (this fund + alternatives) | First row is always the evaluated fund |
+| Risks | Repeat `<li>` per risk | Use the bullet icon (⚠) from CSS |
+| Bottom Line | Single paragraph | 1–3 sentences restating verdict + position guidance |
+| Sources | Repeat `<li>` per source | Include URL as `<a>` tag where applicable |
+| Footer | `DATA_AS_OF` | Standard disclaimer, do not modify text |

--- a/skills/etf-evaluator/references/scorecard-template.md
+++ b/skills/etf-evaluator/references/scorecard-template.md
@@ -1,0 +1,73 @@
+# ETF Evaluation — Output Report Template
+
+Read this in **Phase 6**. Fill every bracket. Keep cited figures with their source + as-of date.
+Any figure you could not verify stays as `Unverified` — do not fill it from memory.
+
+---
+
+```markdown
+# ETF Evaluation: [Full Fund Name] ([TICKER])
+
+**ISIN:** [ISIN] · **Share class:** [Acc / Dist] · **Fund currency:** [CCY] · **Listing:** [Exchange]
+**Index tracked:** [Index name + provider]
+**Evaluated for:** [Core holding / Satellite-thematic] · **Investor context:** [broker / base currency / tax domicile]
+**Data as of:** [YYYY-MM-DD] · **Sources:** factsheet/KIID, justETF, Morningstar, etc.
+
+## Verdict: ✅ Invest / 🟡 Consider / ⛔ Avoid
+
+[2–4 sentences: the decision and the single most important reason, tied to the goal. For a thematic
+ETF, state the recommended position cap, e.g. "satellite only — cap at 5–15% of portfolio."]
+
+## Scorecard
+
+| # | Criterion | Rating | Value (with source + as-of) | Notes |
+|---|-----------|--------|-----------------------------|-------|
+| 1 | Tracking Error / Difference | [Good/Fair/Poor/Unverified] | [e.g. −0.18%/yr 3-yr, justETF 2026-06] | [reasoning] |
+| 2 | Expense Ratio (TER/OCF) & Cost | [...] | [e.g. 0.22%, KIID] | [vs goal threshold] |
+| 3 | AUM & Liquidity | [...] | [e.g. €4.2bn, factsheet] | [closure risk / spread] |
+| 4 | Replication & Structure | [...] | [e.g. Physical full, UCITS, IE domicile] | [counterparty note] |
+| 5 | Index Quality & Characteristics | [...] | [e.g. 1,400 holdings, top-10 22%] | [concentration] |
+| 6 | Historical Performance & Risk | [...] | [1/3/5-yr vs benchmark; max DD] | [stress behaviour] |
+| 7 | Dividend Policy & Tax Efficiency | [...] | [Acc, Ireland-domiciled] | [fit for investor] |
+| 8 | Provider Reputation & Stability | [...] | [e.g. iShares/BlackRock] | [closure history] |
+| 9 | Portfolio Fit & Diversification | [...] | [overlap with holdings] | [marginal risk] |
+| 10 | Trading Costs & Accessibility | [...] | [spread, broker, savings plan] | [currency/hedge] |
+
+**Core-5 summary:** [N Good / N Fair / N Poor / N Unverified]
+**Bonus-5 summary:** [N Good / N Fair / N Poor / N Unverified]
+
+## Comparison vs Similar ETFs (same / near-identical index)
+
+| Fund (ISIN) | TER | AUM | Replication | Domicile | Tracking | Note |
+|-------------|-----|-----|-------------|----------|----------|------|
+| **[This fund]** | [..] | [..] | [..] | [..] | [..] | evaluated |
+| [Alternative 1](URL) | [..] | [..] | [..] | [..] | [..] | [cheaper/larger/…] |
+| [Alternative 2](URL) | [..] | [..] | [..] | [..] | [..] | [..] |
+
+[1–2 sentences: does a twin beat it? Would you pick this one or an alternative, and why?]
+
+## Key Risks
+
+- [Currency / sector-concentration / counterparty (if synthetic) / closure / tax / geopolitical]
+- [Stress-test note: how it likely behaves in a 2008- or 2022-style drawdown]
+
+## Bottom Line
+
+[1–3 sentences. Restate verdict, the position-size guidance if thematic, and what (if anything) the
+user should verify or watch (e.g. "re-check AUM in 12 months", "confirm it's on your broker's savings
+plan").]
+
+---
+*Data as of [YYYY-MM-DD]. Figures marked "Unverified" could not be confirmed from a public source and
+should be checked on the official factsheet before investing. This is an educational evaluation, **not
+personalized financial advice**; past performance does not guarantee future results. Do your own
+research.*
+```
+
+## Filling rules
+- Lead with the **Verdict** — readers want the decision first.
+- Keep each scorecard cell's **source + as-of date** so the user can audit any number.
+- If the Core-5 contains any `Poor` or multiple `Unverified`, the verdict should not be a clean
+  "Invest" — explain the reservation.
+- For a **core** fund, weight cost + liquidity + tracking + domicile. For a **thematic** fund, always
+  attach a position-size cap and label it a satellite.


### PR DESCRIPTION
## What

Add a **self-contained HTML report** output to the ETF Evaluator skill — replacing the previous Markdown-in-chat delivery with a professional, print-ready, zero-dependency HTML file.

## Changes

- **New file:** `references/html-output-template.md` — full HTML rendering contract with embedded CSS (navy header, verdict cards, scorecard table, comparison table, risk list, sources, disclaimer). No external deps, no JS, fully responsive + print-ready.
- **Updated:** `SKILL.md` — Phase 6 now instructs the skill to render the full report as an HTML file saved to `~/etf-evaluations/<ISIN>_etf_evaluation.html`. Version bumped 1.1.0 → 1.2.0.
- **Updated:** `docs/README.md` and `evals/evals.json` — reflect the new HTML output capability.

## Design highlights

- Single self-contained HTML file, no CDN/external fonts/JS
- Semantic colour system: green (Invest/Good), amber (Consider/Fair), red (Avoid/Poor), slate (Unverified)
- Responsive layout (mobile + print media queries)
- All dynamic text HTML-escaped; no unfilled placeholders
- File saved to `~/etf-evaluations/<ISIN>_etf_evaluation.html`

## Testing

Manually evaluated **Amundi CAC 40 UCITS ETF Dist** (ISIN FR0007052782) end-to-end. Report generated at:
```
/Users/montimage/etf-evaluations/FR0007052782_etf_evaluation.html
```
