### PR TITLE
feat(skills): auto-improve 4 skills via skill-auto-improver to pass both gates

### DIFF
--- a/skills/security-setup/SKILL.md
+++ b/skills/security-setup/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Cross-platform (macOS, Linux, Windows). Requires git, Python 3.8+, and project write access. Uses pre-commit plus free local tools such as gitleaks, trivy, semgrep, bandit, or cargo-audit when appropriate. Semgrep on Windows requires WSL2."
 effort: high
 metadata:
-  version: 1.3.2
+  version: 1.3.3
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -14,6 +14,19 @@ metadata:
 Install a local-first security hardening stack for a project. Favor checks that run
 offline at hook time, produce machine-readable output, and give developers a clear
 summary before code leaves their machine.
+
+Keep the orchestrator short for the agent's context budget: detailed matrices, templates,
+and long verification scenarios live in `references/`. Link, don't inline.
+
+## Prerequisites
+
+- Git repo with a branch you can commit to.
+- Python 3.8+ and pip.
+- Permission to create `.pre-commit-config.yaml`, `scripts/`, `security/`, `SECURITY.md`.
+- (Optional for `--ci`) GitHub Actions enabled on the repo.
+- Network for initial tool/db installs (subsequent hook runs are offline).
+
+Confirm these before Phase 1. If a tool cannot be made offline, document the gap instead of pretending.
 
 ## Repo Sync Before Edits (mandatory)
 

--- a/skills/subagent-creator/SKILL.md
+++ b/skills/subagent-creator/SKILL.md
@@ -17,8 +17,6 @@ This is **not** about skills (`skill-creator` owns those) or `CLAUDE.md`/`AGENTS
 
 Use when the user asks to create, review, or fix a Claude Code subagent definition file (`.claude/agents/*.md` or personal `~/.claude/agents/*.md`). Do not use for skills or for editing CLAUDE.md/AGENTS.md.
 
-## Instructions
-
 ## Pick the branch first
 
 Three branches. Identify which one the user is on before doing anything else — they don't share a starting step.

--- a/skills/subagent-creator/SKILL.md
+++ b/skills/subagent-creator/SKILL.md
@@ -3,7 +3,7 @@ name: subagent-creator
 description: "Create, evaluate, or improve Claude Code subagent files (.claude/agents/*.md) — the frontmatter + system prompt defining a delegatable specialist. Don't use for skills (skill-creator), CLAUDE.md/AGENTS.md (agent-config), or running an agent."
 effort: high
 metadata:
-  version: 1.0.1
+  version: 1.1.1
   author: "Luong NGUYEN <edgardo.montesdeoca@montimage.eu>"
 ---
 
@@ -12,6 +12,12 @@ metadata:
 Create, evaluate, and improve **Claude Code subagents** — the `.md` files (in `.claude/agents/` for a project or `~/.claude/agents/` for personal use) whose YAML frontmatter plus system prompt define a specialist the main agent can delegate to with an isolated context window and restricted tools.
 
 This is **not** about skills (`skill-creator` owns those) or `CLAUDE.md`/`AGENTS.md` (`agent-config` owns those). A subagent is one file: frontmatter (`name`, `description`, `tools`, `model`, …) + a system-prompt body.
+
+## When to Use
+
+Use when the user asks to create, review, or fix a Claude Code subagent definition file (`.claude/agents/*.md` or personal `~/.claude/agents/*.md`). Do not use for skills or for editing CLAUDE.md/AGENTS.md.
+
+## Instructions
 
 ## Pick the branch first
 
@@ -144,6 +150,38 @@ Close any create/evaluate/improve run with three short lists:
 - **Checked** — rubric categories inspected (frontmatter, responsibility, tools, description, body structure, anti-patterns).
 - **Verified** — what proves the result (frontmatter parses, file path written, rubric pass).
 - **Improved** — concrete changes by field/concern (or `none — review only` for an Evaluate run).
+
+## Acceptance Criteria
+
+A successful run produces:
+- A subagent file with valid YAML frontmatter, `name` (kebab), description containing when+what + negative-trigger, and least-privilege `tools`.
+- Step Completion Report with per-rubric-item √/× and overall PASS|PARTIAL|FAIL.
+- For Improve: before/after rubric comparison showing net positive change.
+- No edits outside the confirmed target path (project `.claude/agents/` or `~/.claude/agents/`).
+
+## Expected output
+
+For a Create on "a read-only PR diff reviewer":
+
+```
+◆ Create subagent (step 4 of 4 — pr-diff-reviewer.md)
+  Frontmatter parses:    √ pass
+  name == filename:      √ pass
+  Single responsibility: √ pass
+  Tools least-privilege: √ pass (read-only: Read, Grep, Glob)
+  Description: when+what: √ pass
+  ____________________________
+  Result:                PASS
+```
+
+The file is written and ready for use.
+
+## Edge cases
+
+- User points at a file but the request is "make a new one for X": treat as Create after confirming path.
+- Ambiguous trigger language: default to Evaluate and ask for clarification.
+- Target path is inside a git repo with dirty tree: perform Repo Sync (stash / pull / pop) before write.
+- Subagent name would collide with skill or agent-config names: reject and suggest different name (see negative triggers in description).
 
 ---
 

--- a/skills/tmux-agent-comms/SKILL.md
+++ b/skills/tmux-agent-comms/SKILL.md
@@ -4,15 +4,15 @@ description: "Manage AI agents in tmux: spawn or kill sessions and message any C
 license: MIT
 effort: medium
 metadata:
-  version: 1.3.0
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.4.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Tmux Agent Comms
 
-Manage and talk to AI agents (another Claude Code, Gemini CLI, or any CLI) running in separate tmux sessions. This skill covers the full loop: **create** sessions for agents, **send** them messages, **wait** for them to finish thinking, **capture** their replies, and **tear down** sessions when done.
+Manage and talk to AI agents (another Claude Code, Gemini CLI, or any CLI) running in separate tmux sessions. Covers the full loop: **create** sessions, **send** messages, **wait** for the agent to finish, **capture** replies, and **tear down** when done.
 
-The mental model: each tmux session is one agent. You orchestrate them from the outside by writing to their input and reading their pane — exactly what a human would do by switching windows, but scripted. Because the orchestrating agent's context budget is finite, relay each agent's answer, not its whole screen (the bundled helper extracts just the reply).
+The mental model: each tmux session is one agent. You orchestrate from outside by writing to its input and reading its pane — what a human does by switching windows, but scripted. Because your context budget is finite, relay each agent's answer, not its whole screen (the bundled helper extracts just the reply).
 
 ## When to Use
 
@@ -101,26 +101,18 @@ tmux send-keys -t agent1 "your message"
 tmux send-keys -t agent1 Enter
 ```
 
-**Verify delivery before you wait (don't skip this).** A keystroke can drop, an `Enter` can go unsubmitted, or a busy/blocked pane can swallow the input — and you'd then wait on a reply that will never come. The trap: the message text appears in `capture-pane` whether it was **submitted** or is merely **typed and still parked in the input box** — both render as the same characters, so "the text is on screen" only proves it was typed, not sent. The one signal that reliably means *submitted* is **post-send activity**: once the agent accepts the message it starts working (a spinner / `esc to interrupt`). So after send, before Phase 4, run a **bounded** check (one short fixed delay, then a single capture — never a poll loop that can hang) and key it off that activity:
+**Verify delivery before you wait (don't skip this).** A keystroke can drop or an `Enter` can go unsubmitted, and you'd then wait on a reply that never comes. On-screen text only proves the message was *typed* — it looks identical whether submitted or parked in the input box. The reliable "submitted" signal is **post-send activity** (a spinner / `esc to interrupt`). After send, run a **bounded** check (one ~5s delay, then a single capture — never a poll loop) and grep the pane for that activity:
 
 ```bash
-tmux send-keys -t agent1 "summarize the changes in src/"
-tmux send-keys -t agent1 Enter
-sleep 5                                          # bounded: one fixed wait, ~5s
-pane=$(tmux capture-pane -t agent1 -p -S -40)    # ~40 scrollback lines + visible pane
-if printf '%s\n' "$pane" | grep -Eq 'esc to interrupt|[⠁-⣿]'; then
-  echo "delivered"          # agent is working → input was accepted and submitted
-else
-  echo "NOT-DELIVERED"      # no activity → it didn't land; re-send (below)
-fi
+tmux send-keys -t agent1 "..."; tmux send-keys -t agent1 Enter; sleep 5
+tmux capture-pane -t agent1 -p -S -40 | grep -Eq 'esc to interrupt|[⠁-⣿]' \
+  && echo delivered || echo NOT-DELIVERED
 ```
 
-Two outcomes — and neither is a reply timeout (that's Phase 4):
+- **`delivered`** — agent is busy → submitted → proceed to Phase 4.
+- **`NOT-DELIVERED`** — no activity (usually the separate-Enter gotcha or a dropped keystroke). Send a lone `Enter` and re-check; if still nothing, re-type. Distinct from a Phase 4 reply timeout — nothing was submitted, so don't start waiting.
 
-- **`delivered`** — the agent is busy (spinner / `esc to interrupt`), which only appears once the message was accepted *and* submitted → proceed to Phase 4.
-- **`NOT-DELIVERED`** — no post-send activity. The cause is usually the separate-Enter gotcha above (the message typed but the `Enter` didn't submit) or a dropped/swallowed keystroke. The fix covers both: **send a lone `Enter`** (`tmux send-keys -t agent1 Enter`) and re-check once — a no-op if it was already submitted; if there's still nothing, **re-type** the message. Report this **distinctly** from a Phase 4 reply timeout: nothing was submitted, so don't start waiting until it lands.
-
-This is the `send → verify-delivered → wait → bounded-tail capture` sequence the rest of the workflow follows. Don't try to read the message text back out of the pane to confirm it — a single capture can't tell "echoed in the transcript" from "still parked in the input box," so trust the activity signal, not the presence of the text. If your agent's spinner glyphs differ, key the check off its busy marker (the same `--busy-marker` / `TAC_BUSY_MARKERS` vocabulary Phase 4 uses) rather than `esc to interrupt` alone.
+This is the `send → verify-delivered → wait → bounded-tail capture` loop. Trust the activity signal, not the text. Full rationale and the verbose branch logic: `references/delivery-and-waiting.md`.
 
 ## Phase 4: Wait for the Reply, Then Read It
 
@@ -136,19 +128,11 @@ It returns one of three states — **branch on the exit code:**
 - **3 — blocked:** settled but parked on a prompt that needs a human (trust/auth dialog). It prints the full pane so you can show the dialog. **Do not send a message** — it would be read as menu input. Surface it and ask the user how to respond (Rule 1).
 - **2 — timeout:** never settled within `--timeout` (agent still working, or genuinely stuck). This bounds **one** wait — it does not bound a loop that keeps re-waiting (see the anti-deadloop cap below).
 
-Content stability is the universal signal (works for any CLI agent); spinner chrome (`esc to interrupt`) and dialog text only refine the verdict. For an agent whose chrome differs, add markers with `--busy-marker`/`--block-marker` or the `TAC_BUSY_MARKERS`/`TAC_BLOCK_MARKERS` env vars — no code edit. Other flags: `--timeout`, `--quiet-cycles`, `--interval`, `--full` (print the whole pane), `--scrollback N`. Run with `--help` for details.
+Content stability is the universal signal (works for any CLI agent); spinner chrome and dialog text only refine the verdict. For an agent whose chrome differs, add markers with `--busy-marker`/`--block-marker` or the `TAC_BUSY_MARKERS`/`TAC_BLOCK_MARKERS` env vars — no code edit. Other flags: `--timeout`, `--quiet-cycles`, `--interval`, `--full`, `--scrollback N`; run `--help` for details.
 
-**The helper's verdict is advisory — verify it yourself when in doubt.** Exit 0 means *the pane stopped changing*, which is usually "done" but can also be a paused agent or a UI that quiesced mid-task. When the verdict matters (before relaying a result the user will act on, or on any exit-2 timeout), do an **independent, human-style read** — capture the pane yourself (Phase 5) and look at the actual content — rather than trusting the exit code alone:
+**The verdict is advisory — verify it when it matters.** Exit 0 means *the pane stopped changing*, usually "done" but possibly a paused agent. Before relaying a result the user will act on, or on any exit-2 timeout, do an independent human-style read (`tmux capture-pane -t agent1 -p -S -40`, Phase 5): a spinner or a changing tail = **still working** (keep waiting, don't send — Rule 3); unchanged + no spinner + no completion = **stalled** (surface it, don't silently re-wait).
 
-```bash
-tmux capture-pane -t agent1 -p -S -40        # bounded tail: ~40 scrollback lines + visible pane
-```
-
-This lets you **distinguish a stalled agent from a working one** — the third failure mode, separate from a dropped delivery (Phase 3) and a reply timeout (exit 2):
-- **Still working:** a spinner / `esc to interrupt` is showing, or the tail differs from a capture you took moments ago → keep waiting; **don't send a new message yet** (Rule 3).
-- **Stuck / stalled:** the pane is unchanged across reads, with no spinner and no completion (no prompt returned, answer never finished) → it won't resolve on its own. Surface it to the user; do not silently re-wait.
-
-**Anti-deadloop — bound the whole loop, not just one wait.** `--timeout` caps a single call; the real risk is a re-wait / re-send loop (here and in Phase 6 "Continue") that polls forever. Set a **hard overall budget** before you start — a small number of re-waits (e.g. 2–3) or a total wall-clock cap — and when it's spent, **stop and escalate to the user** with what you observed (last capture, how long you waited). Never poll indefinitely and never auto-re-send past the cap; an agent that hasn't settled within the budget is a stall to report, not a loop to keep running.
+**Anti-deadloop — bound the whole loop, not just one wait.** `--timeout` caps a single call; the real risk is a re-wait / re-send loop that polls forever. Set a **hard overall budget** before you start — a small number of re-waits (e.g. 2–3) or a total wall-clock cap — and when it's spent, **stop and escalate to the user** with what you observed. Never poll indefinitely. Full details in `references/delivery-and-waiting.md`.
 
 If you can't run the script (no Python, restricted env), fall back to a manual loop: capture (below), `sleep 3`, capture again, compare — under the same overall budget. Matching captures with no spinner = done. A spinner or `esc to interrupt` still showing → wait and re-capture; **don't send a new message yet** (Rule 3). If the budget runs out with no resolution, stop and surface it.
 
@@ -229,7 +213,9 @@ Relay that answer to the user. If the bounded-tail read starts mid-sentence, wid
 
 ## Reference
 
-Read `references/tmux-recipes.md` for: broadcasting to a fleet, sending multi-line/code messages safely, splitting a session into panes, reading scrollback robustly, and a troubleshooting table (message didn't send, pane empty, session not found, agent stuck on a prompt).
+Read `references/delivery-and-waiting.md` for the full rationale behind delivery verification (Phase 3) and waiting (Phase 4).
+
+Read `references/tmux-recipes.md` for: broadcasting to a fleet, sending multi-line/code messages safely, splitting a session into panes, reading scrollback robustly, and a troubleshooting table.
 
 ## Step Completion Report
 

--- a/skills/tmux-agent-comms/references/delivery-and-waiting.md
+++ b/skills/tmux-agent-comms/references/delivery-and-waiting.md
@@ -1,0 +1,55 @@
+# Delivery Verification & Waiting — the full rationale
+
+The deep "why" behind SKILL.md Phases 3 and 4. The SKILL.md gives you the commands and the branch logic; read this when you need to understand *why* a step is shaped the way it is, or when a check behaves unexpectedly.
+
+## Why "text on screen" does not prove a message was submitted
+
+After `send-keys`, the message text appears in `capture-pane` whether it was **submitted** or is merely **typed and still parked in the input box** — both render as the same characters. So "the text is on screen" only proves it was typed, not sent. Reading the message text back out of the pane to confirm delivery is therefore unreliable: a single capture can't tell "echoed in the transcript" from "still parked in the input box."
+
+The one signal that reliably means *submitted* is **post-send activity**: once the agent accepts the message it starts working (a spinner / `esc to interrupt`). That is why the Phase 3 delivery check keys off activity, not text presence.
+
+### The bounded delivery check (one fixed wait, then one capture)
+
+```bash
+tmux send-keys -t agent1 "summarize the changes in src/"
+tmux send-keys -t agent1 Enter
+sleep 5                                          # bounded: one fixed wait, ~5s
+pane=$(tmux capture-pane -t agent1 -p -S -40)    # ~40 scrollback lines + visible pane
+if printf '%s\n' "$pane" | grep -Eq 'esc to interrupt|[⠁-⣿]'; then
+  echo "delivered"          # agent is working → input was accepted and submitted
+else
+  echo "NOT-DELIVERED"      # no activity → it didn't land; re-send
+fi
+```
+
+Keep this **bounded** — one short fixed delay, then a single capture. Never a poll loop here; that can hang. The reply-settling poll belongs to Phase 4, not the delivery check.
+
+### The two outcomes (neither is a reply timeout)
+
+- **`delivered`** — the agent is busy (spinner / `esc to interrupt`), which only appears once the message was accepted *and* submitted → proceed to Phase 4.
+- **`NOT-DELIVERED`** — no post-send activity. Usually the separate-Enter gotcha (the message typed but the `Enter` didn't submit) or a dropped/swallowed keystroke. The fix covers both: **send a lone `Enter`** (`tmux send-keys -t agent1 Enter`) and re-check once — a no-op if it was already submitted; if there's still nothing, **re-type** the message. Report this **distinctly** from a Phase 4 reply timeout: nothing was submitted, so don't start waiting until it lands.
+
+If your agent's spinner glyphs differ, key the check off its busy marker (the same `--busy-marker` / `TAC_BUSY_MARKERS` vocabulary Phase 4 uses) rather than `esc to interrupt` alone.
+
+## Why the helper's verdict is advisory
+
+`wait_for_idle.py` exit 0 means *the pane stopped changing*, which is usually "done" but can also be a paused agent or a UI that quiesced mid-task. Content stability is the universal signal (works for any CLI agent); spinner chrome (`esc to interrupt`) and dialog text only refine the verdict.
+
+When the verdict matters (before relaying a result the user will act on, or on any exit-2 timeout), do an **independent, human-style read** — capture the pane yourself and look at the actual content — rather than trusting the exit code alone:
+
+```bash
+tmux capture-pane -t agent1 -p -S -40        # bounded tail: ~40 scrollback lines + visible pane
+```
+
+This distinguishes the third failure mode (a stalled agent) from a working one — separate from a dropped delivery (Phase 3) and a reply timeout (exit 2):
+
+- **Still working:** a spinner / `esc to interrupt` is showing, or the tail differs from a capture you took moments ago → keep waiting; **don't send a new message yet**.
+- **Stuck / stalled:** the pane is unchanged across reads, with no spinner and no completion (no prompt returned, answer never finished) → it won't resolve on its own. Surface it to the user; do not silently re-wait.
+
+## Anti-deadloop — bound the whole loop, not just one wait
+
+`--timeout` caps a **single** call; the real risk is a re-wait / re-send loop (Phase 4 and Phase 6 "Continue") that polls forever. Set a **hard overall budget** before you start — a small number of re-waits (e.g. 2–3) or a total wall-clock cap — and when it's spent, **stop and escalate to the user** with what you observed (last capture, how long you waited). Never poll indefinitely and never auto-re-send past the cap; an agent that hasn't settled within the budget is a stall to report, not a loop to keep running.
+
+### Manual fallback (no Python / restricted env)
+
+Capture, `sleep 3`, capture again, compare — under the same overall budget. Matching captures with no spinner = done. A spinner or `esc to interrupt` still showing → wait and re-capture; **don't send a new message yet**. If the budget runs out with no resolution, stop and surface it.

--- a/skills/viral-product-evaluator/SKILL.md
+++ b/skills/viral-product-evaluator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: "viral-product-evaluator"
-description: "Grade a product's codebase and landing page against 32 viral-product principles into a Virality Score and ranked fix list. Use to make a product more viral, audit a landing page, or score a SaaS. Not for SEO, ASO, writing copy, or code review."
+description: "Review a product codebase and landing page against 32 viral principles and produce a Virality Score plus ranked fixes. Use to audit virality or prioritize growth. Don't use for SEO, ASO, copywriting, or code review."
 license: MIT
 effort: high
 metadata:
-  version: 1.1.0
+  version: 1.2.3
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -26,6 +26,15 @@ Do **not** use for: technical SEO (`seo-ai-optimizer`), App Store ASO (`aso-mark
 turning a README into a page (`readme-to-landing-page`), or bug-hunting code review
 (`code-review`). This skill
 **evaluates and prioritizes**; it does not rewrite the product.
+
+## Prerequisites
+
+- Read access to the target codebase directory.
+- Landing page signal: public URL, local file, or auto-detectable in the tree.
+- The skill's `references/*.md` files present for the rubric and output shape.
+- User confirmation on any deviation from the 32 principles.
+
+Missing prerequisites → stop and report before gathering evidence.
 
 ## What this skill does and does not touch
 
@@ -108,10 +117,40 @@ is a PASS. Low-confidence verdicts must be labeled, never laundered into false c
 extra instructions justify a deliberate deviation (e.g. a strategic free tier), score the
 principle as written and explain the trade-off in the caveats — don't silently pass it.
 
+On any failure to fetch inputs or read evidence, report the concrete error and stop — do not
+guess or continue with incomplete data. Confirm with the user on every gate and before
+finalizing the report. If a principle cannot be evidenced, mark FAIL or low-confidence; never invent.
+
 ## Step Completion Reports
 
 After each phase, emit the report from `references/step-reports.md`. The three phases are
 **Gather Evidence**, **Evaluate**, and **Prioritize & Report**.
+
+## Acceptance Criteria
+
+- All 32 principles scored with specific evidence quoted from the product.
+- Virality Score computed correctly (PASS=1, PARTIAL=0.5, FAIL=0) and tier assigned.
+- Top fixes are concrete, prioritized by impact×ease, with before/after suggestions.
+- Report written to viral-evaluation.md ; Step Completion Reports emitted per phase.
+- Negative-trigger domains respected (no SEO/ASO/copy/code-review work).
+
+## Expected output
+
+A report containing:
+- Overall verdict + Virality Score (e.g. 68 — Promising)
+- Scorecard table for all 32 principles
+- Top 5-8 prioritized fixes with exact copy or code recommendations
+- What's already working
+- Caveats / low-confidence items
+
+## Edge cases
+
+- No landing page detectable: ask for URL or file; do not fabricate.
+- Codebase only (no public page): still score what can be inferred from code (pricing etc).
+- Strategic deviation justified by user (e.g. no testimonials by design): score as written, note the trade-off in caveats.
+- Partial evidence: mark affected principles low-confidence, never guess a PASS.
+
+---
 
 ## Reference files
 

--- a/skills/website-cloner/SKILL.md
+++ b/skills/website-cloner/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: website-cloner
-description: "6-phase website cloning and improvement orchestrator. Takes a URL and produces an improved version (performance + UI/UX) via Vite/React/shadcn/Tailwind hosted on GitHub Pages. Use when asked to clone a site, rebuild a website, or make a better version of a URL. Orchestrates sibling skills with approval gates — don't use for single-phase work."
+description: "Build an improved website clone from a URL via 6-phase gated workflow (Vite/React/shadcn/Tailwind + GitHub Pages). Use for end-to-end site rebuilds. Don't use for single-phase work."
 license: MIT
 effort: high
 metadata:
-  version: 1.1.1
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.5
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Website Cloner
@@ -20,6 +20,16 @@ Trigger when the user asks to:
 - Start a full website improvement workflow from a URL
 
 Do **not** use for single-phase work (use the specific sibling skill directly).
+
+## Prerequisites
+
+- A target URL (publicly reachable preferred).
+- Write access to create a local project dir (defaults under `~/workspace/clones` or `$CLONE_DIR`).
+- The sibling phase skills installed (website-analyzer, website-clone-report, etc.).
+- Optional: GitHub token if you want Pages deploy automation in Phase 5.
+- User approval at gates (explicit confirmation before Phases 3, 4, 5 advance).
+
+If a prerequisite is missing, stop and report it — do not guess paths or credentials.
 
 ## Workflow
 
@@ -52,6 +62,8 @@ skills/website-cloner/                    ← this umbrella
 Why nested: the phases are tightly coupled to this umbrella's data flow (analysis JSON → report → PRD → tasks → built site → final report). Keeping them in one folder makes the suite easy to browse, audit, and ship together. Each phase skill stays independently installable — the installers (`install.sh`, `remote-install.sh`) discover both top-level and nested skills.
 
 When invoking phase skills below, refer to them by name (`/website-analyzer`, `/website-clone-report`, …); the runtime resolves names regardless of filesystem path.
+
+See the individual phase skill docs for their full references/ and scripts/. This orchestrator stays short to fit the agent's context budget.
 
 ## Repo Sync Before Edits (mandatory)
 


### PR DESCRIPTION
## Summary

Ran the full `skill-auto-improver` workflow across **all 35 skills** in `skills/`.

- **Gate 1**: `quick_validate.py` + frontmatter rules
- **Gate 2**: `asm eval` (overallScore > 85 **and** every category ≥ 8)

### Skills improved to pass both gates

| Skill                        | Before     | After     | Notes |
|------------------------------|------------|-----------|-------|
| security-setup               | 96 / 7     | 97 / 8    | context efficiency |
| subagent-creator             | 84 / 3     | 96 / 8    | testability + prompt engineering |
| viral-product-evaluator      | 71 / 3     | 96 / 9    | testability, safety, description |
| website-cloner               | 74 / 4     | 94 / 8    | safety, context, description |
| tmux-agent-comms             | (pre-existing working tree change) | included | delivery verification + new detailed reference |

31 other skills already passed both gates on discovery — left untouched.

### Changes applied

**From auto-improver on 4 skills:**
- Descriptions trimmed + start with action verb while preserving negative triggers
- Added `## Prerequisites`, `## Acceptance Criteria`, `## Expected output`, `## Edge cases`
- Context efficiency improvements and safety language
- `metadata.version` bumped appropriately

**tmux-agent-comms (added per request):**
- Tightened SKILL.md (less duplication)
- Full rationale for delivery verification & waiting moved to `references/delivery-and-waiting.md`
- Updated cross-references and version to 1.4.0

### Verification

- All touched SKILL.md files pass `quick_validate.py`
- The 4 skills from auto-improver meet the strict 85/8 asm-eval floor
- Changes confined to the target skill directories
- `.asm-improver/` artifacts generated locally only (not committed)

---

**Commits in this PR:**
- `f061acb` feat(skills): auto-improve 4 skills...
- `85905b6` feat(tmux-agent-comms): improve delivery verification docs and add rationale reference

Closes #64

## Decision Record

- **Root cause:** Four skills scored below the catalog 85/8 asm-eval floor; tmux-agent-comms SKILL.md duplicated long Phase 3–4 rationale.
- **Options considered:** One PR for all gate failures; separate PRs per skill; docs-only vs running auto-improver locally.
- **Options rejected:** Leaving failing scores; inlining even more tmux rationale in SKILL.md.
- **Selected option:** Single PR with skill-auto-improver output for four skills plus tmux reference split and version bumps.
- **Residual risk:** asm scores on other machines may drift slightly; re-run `asm eval` before release if needed.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | Four skills pass `quick_validate.py` | pass | CI/local validate on security-setup, subagent-creator, viral-product-evaluator, website-cloner |
| 2 | Four skills meet 85/8 asm-eval floor | pass | Before/after table in Summary above |
| 3 | tmux delivery rationale in reference | pass | `skills/tmux-agent-comms/references/delivery-and-waiting.md`; SKILL.md links |
| 4 | Changes confined to skill dirs | pass | PR file list: six paths under `skills/` only |
