### PR TITLE
feat(tmux-agent-comms): add option to show agent terminal (#57)

### DIFF
--- a/skills/tmux-agent-comms/SKILL.md
+++ b/skills/tmux-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agents in tmux: spawn or kill sessions and message any C
 license: MIT
 effort: medium
 metadata:
-  version: 1.4.0
+  version: 1.5.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -33,6 +33,7 @@ Quick start: the six phases below run in order — discover/spawn a session, res
 2. **Verify the target before sending.** A typo'd session name silently sends keystrokes nowhere (or to the wrong agent). Always resolve the exact target with `has-session` first (Phase 2).
 3. **Wait for the agent, don't race it.** Agents take seconds to respond. Sending a follow-up while the target is still working corrupts its input. Always wait until the pane output settles (Phase 4) before reading a reply or sending again.
 4. **Escape what you send.** `send-keys` interprets `;` as a command separator and the shell interprets `$`, backticks, and quotes. Mishandled, your message gets mangled or — worse — executes. Follow the escaping rules in Phase 3.
+5. **Attaching is opt-in, not a replacement.** Showing an agent's terminal (Phase 1) is an alternative for a human to drive by hand; it does not replace the default detached, scripted workflow — don't attach unless the user wants to see or steer the live UI.
 
 ## Phase 1: Create or Discover Sessions
 
@@ -66,6 +67,17 @@ python3 scripts/wait_for_idle.py "$name" --timeout 30 --no-print; echo "ready=$?
 ```
 
 To launch a **fleet**, repeat with distinct job-named sessions (`reviewer`, `tests`, `docs`) so later messages are self-documenting.
+
+### Show the agent's terminal (optional)
+
+The default workflow stays detached — you drive the agent with `send-keys`/`capture-pane` and never open its terminal. If the user wants to *see* the live CLI (a trust/auth prompt, debugging, or hands-on steering), attach to the same session name instead of reading it from outside:
+
+```bash
+tmux attach-session -t "$name"     # from a plain (non-tmux) shell
+tmux switch-client -t "$name"      # from inside tmux already (your own terminal is a tmux client)
+```
+
+Detach with `Ctrl-b d` (default prefix + `d`) to return control to the orchestrator without killing the session. This is opt-in and does not replace the default detached flow — see `references/tmux-recipes.md` ("Showing an agent's live terminal") for the when-to-use guidance, the correct command for each starting context, and a worked example that names the exact session attached to.
 
 ## Phase 2: Resolve the Exact Target
 
@@ -210,12 +222,13 @@ Relay that answer to the user. If the bounded-tail read starts mid-sentence, wid
 - **Agent stalled** (pane unchanged across reads, no spinner, no completion) — distinct from "still working" (spinner/`esc to interrupt` or a changing tail) and from a dropped delivery. Surface it; don't silently re-wait (Phase 4).
 - **Re-wait/re-send loop won't terminate** — enforce the overall budget (Phase 4): cap total re-waits/wall-clock and escalate to the user; never poll indefinitely.
 - **Bounded-tail capture starts mid-sentence** — the reply is longer than ~40 lines; widen stepwise (`-S -80`, …) and only reach for unbounded `-S -` if even a wide tail truncates (Phase 5).
+- **Returning to orchestrator control after attaching** — detach with `Ctrl-b d` (default prefix + `d`); this leaves the session running so the scripted send-keys/capture-pane loop can resume. Never `kill-session` just to "get back" (Phase 1, "Show the agent's terminal").
 
 ## Reference
 
 Read `references/delivery-and-waiting.md` for the full rationale behind delivery verification (Phase 3) and waiting (Phase 4).
 
-Read `references/tmux-recipes.md` for: broadcasting to a fleet, sending multi-line/code messages safely, splitting a session into panes, reading scrollback robustly, and a troubleshooting table.
+Read `references/tmux-recipes.md` for: broadcasting to a fleet, sending multi-line/code messages safely, splitting a session into panes, showing an agent's live terminal, reading scrollback robustly, and a troubleshooting table.
 
 ## Step Completion Report
 

--- a/skills/tmux-agent-comms/SKILL.md
+++ b/skills/tmux-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agents in tmux: spawn or kill sessions and message any C
 license: MIT
 effort: medium
 metadata:
-  version: 1.5.1
+  version: 1.5.2
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -70,14 +70,14 @@ To launch a **fleet**, repeat with distinct job-named sessions (`reviewer`, `tes
 
 ### Show the agent's terminal (optional)
 
-The default workflow stays detached — you drive the agent with `send-keys`/`capture-pane` and never open its terminal. If the user wants to *see* the live CLI (a trust/auth prompt, debugging, or hands-on steering), there are two commands, and **who runs which matters**:
+The default workflow stays detached — you drive the agent with `send-keys`/`capture-pane` and never open its terminal. If the user wants to *see* the live CLI (a trust/auth prompt, debugging, or hands-on steering), there are two commands, and **neither is something the agent can use on its own behalf**:
 
 ```bash
 tmux attach-session -t "$name"     # HUMAN runs this in their own interactive terminal
-tmux switch-client -t "$name"      # agent can run this itself, if it is already a tmux client ($TMUX set)
+tmux switch-client -t "$name"      # HUMAN runs this, only if already attached to a different session/client
 ```
 
-`attach-session` needs a controlling TTY. If you (the agent) invoke it through a non-interactive Bash tool, it fails with `open terminal failed: not a terminal` — it does not open anything. Never run `attach-session` yourself; instead tell the human the exact command to type in their own terminal. `switch-client` is different: it's a control-mode command that reuses your *own* existing tmux client, so it's safe for you to run it yourself when you're already inside a tmux client (`$TMUX` is set) and want to hand your own view over.
+`attach-session` needs a controlling TTY. If you (the agent) invoke it through a non-interactive Bash tool, it fails with `open terminal failed: not a terminal`. `switch-client` needs an *attached* tmux client to act on — it fails with `no current client` unless the invoking process already is one. Having `$TMUX` set in your own shell does **not** make you an attached client: `$TMUX` is set in every pane, including the detached sessions this skill spawns via `tmux new-session -d`, which is the agent's normal execution context and has no attached client at all. So in this skill's default spawn model, the agent has no self-service way to show its own terminal — never attempt `attach-session` or `switch-client` yourself; instead tell the human the exact command to type in their own terminal. `switch-client` only comes into play when a human is already attached to one session and wants that same client to switch to a different one.
 
 Detach with `Ctrl-b d` (default prefix + `d`) to return control to the orchestrator without killing the session. This is opt-in and does not replace the default detached flow — see `references/tmux-recipes.md` ("Showing an agent's live terminal") for the when-to-use guidance, the correct command for each starting context, and a worked example that names the exact session attached to.
 

--- a/skills/tmux-agent-comms/SKILL.md
+++ b/skills/tmux-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agents in tmux: spawn or kill sessions and message any C
 license: MIT
 effort: medium
 metadata:
-  version: 1.5.0
+  version: 1.5.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -70,12 +70,14 @@ To launch a **fleet**, repeat with distinct job-named sessions (`reviewer`, `tes
 
 ### Show the agent's terminal (optional)
 
-The default workflow stays detached — you drive the agent with `send-keys`/`capture-pane` and never open its terminal. If the user wants to *see* the live CLI (a trust/auth prompt, debugging, or hands-on steering), attach to the same session name instead of reading it from outside:
+The default workflow stays detached — you drive the agent with `send-keys`/`capture-pane` and never open its terminal. If the user wants to *see* the live CLI (a trust/auth prompt, debugging, or hands-on steering), there are two commands, and **who runs which matters**:
 
 ```bash
-tmux attach-session -t "$name"     # from a plain (non-tmux) shell
-tmux switch-client -t "$name"      # from inside tmux already (your own terminal is a tmux client)
+tmux attach-session -t "$name"     # HUMAN runs this in their own interactive terminal
+tmux switch-client -t "$name"      # agent can run this itself, if it is already a tmux client ($TMUX set)
 ```
+
+`attach-session` needs a controlling TTY. If you (the agent) invoke it through a non-interactive Bash tool, it fails with `open terminal failed: not a terminal` — it does not open anything. Never run `attach-session` yourself; instead tell the human the exact command to type in their own terminal. `switch-client` is different: it's a control-mode command that reuses your *own* existing tmux client, so it's safe for you to run it yourself when you're already inside a tmux client (`$TMUX` is set) and want to hand your own view over.
 
 Detach with `Ctrl-b d` (default prefix + `d`) to return control to the orchestrator without killing the session. This is opt-in and does not replace the default detached flow — see `references/tmux-recipes.md` ("Showing an agent's live terminal") for the when-to-use guidance, the correct command for each starting context, and a worked example that names the exact session attached to.
 

--- a/skills/tmux-agent-comms/docs/README.md
+++ b/skills/tmux-agent-comms/docs/README.md
@@ -15,6 +15,7 @@
 - **Message any agent** — send a prompt to a target session with proper escaping, including the separate-`Enter` gotcha for stubborn TUIs.
 - **Read replies reliably** — a bundled `wait_for_idle.py` polls the pane until output settles instead of guessing with a fixed `sleep`, then returns the answer.
 - **Broadcast & collect** — fan one instruction out to several agents and gather each reply.
+- **Show an agent's terminal on demand** — attach to (or switch to) a spawned agent's session to see its live CLI and type into it directly, for trust prompts, debugging, or hands-on steering, without giving up the default detached workflow.
 - **Safe teardown** — kill individual sessions (or the whole server) behind explicit user confirmation, so no agent's work is lost by accident.
 
 ## When to Use

--- a/skills/tmux-agent-comms/references/tmux-recipes.md
+++ b/skills/tmux-agent-comms/references/tmux-recipes.md
@@ -74,16 +74,16 @@ The default orchestrator flow stays detached — `send-keys` writes to a session
 | Mid-run correction or manual input only a human should give | Show — type directly into that agent's input |
 | Everything else — scripted send/wait/capture loop, broadcasts | Detached (default) |
 
-**Attaching — pick the command for who is running it, not just your starting context:**
+**Attaching — both commands here are things a human runs, not the agent:**
 
 ```bash
 tmux attach-session -t agent1     # HUMAN, in their own real interactive terminal
-tmux switch-client -t agent1      # agent itself, only if already a tmux client ($TMUX set)
+tmux switch-client -t agent1      # HUMAN, only if already attached to a different session/client
 ```
 
 `attach-session` requires a controlling TTY. A human runs it fine in their own terminal — but if an agent invokes it through a non-interactive shell/Bash tool, it fails immediately with `open terminal failed: not a terminal` (verified: `tmux new-session -d -s test 'sleep 60'; tmux attach-session -t test </dev/null` exits 1 with that error). **The agent must never try to run `attach-session` itself** — instead, tell the human the exact command to type in their own terminal.
 
-`switch-client` has no such restriction: it's a control-mode command that reuses the *existing* client rather than opening a new TTY, so it's safe for an agent to invoke on itself when it's already inside a tmux client (`$TMUX` is set) and wants to hand its own view over. Separately, running `attach-session` from a shell that is itself already inside a tmux client (`$TMUX` is set) fails with `sessions should be nested with care, unset $TMUX to force` — another reason a human should use `switch-client` in that starting context, or `unset TMUX` first if a nested attach is deliberate.
+`switch-client` needs an *attached* tmux client to act on, and fails with `no current client` (exit 1) if the invoking process isn't one — verified by running it from a plain shell and from a detached-session pane, both non-attached contexts. This is a different condition than "`$TMUX` is set": `$TMUX` is present in every pane's environment, including the detached sessions this skill spawns via `tmux new-session -d`, which is the agent's normal execution context and is never an attached client. So the agent cannot use `switch-client` on itself either — it only works for a human who is *already attached* to one session and wants that same client to switch to viewing a different one. Separately, running `attach-session` from a shell that is itself already inside a tmux client fails with `sessions should be nested with care, unset $TMUX to force` — another reason a human in that starting context should use `switch-client` instead, or `unset TMUX` first if a nested attach is deliberate.
 
 **Name the session before attaching — don't guess.** Reuse the same target-resolution step as Phase 2 so the human attaches to the confirmed name, not a guess (spawn can rename on collision, e.g. `agent1-1730000000`):
 
@@ -92,7 +92,7 @@ tmux has-session -t agent1 2>/dev/null && echo "OK: agent1 exists" || tmux list-
 tmux attach-session -t agent1     # human runs this, attaching to the confirmed name from the line above
 ```
 
-**Safety notes (consistent with Critical Rule 1):** for a human running it in their own terminal, attaching and scrolling to read is always safe; *typing* into the session is a write, the same hazard as `send-keys` — confirm with the user before typing into another agent's session on their behalf. For the agent, `attach-session` isn't a safety question so much as a hard failure — it needs a TTY the agent's Bash tool doesn't have; only `switch-client` (agent already a tmux client) is something the agent can invoke itself. If the orchestrator's scripted send-keys loop is still running while a human is attached and typing, both are writing to the same input and will fight each other — pause the scripted loop during hands-on takeover. Detach with `Ctrl-b d` (default tmux prefix `Ctrl-b`, then `d`) when done; this returns control to the orchestrator **without** killing the session, so the scripted loop can resume.
+**Safety notes (consistent with Critical Rule 1):** for a human running it in their own terminal, attaching and scrolling to read is always safe; *typing* into the session is a write, the same hazard as `send-keys` — confirm with the user before typing into another agent's session on their behalf. For the agent, neither command is a safety question so much as a hard failure — `attach-session` needs a TTY the agent's Bash tool doesn't have, and `switch-client` needs an attached client the agent's own detached execution context never is; both require a human to run them from their own terminal. If the orchestrator's scripted send-keys loop is still running while a human is attached and typing, both are writing to the same input and will fight each other — pause the scripted loop during hands-on takeover. Detach with `Ctrl-b d` (default tmux prefix `Ctrl-b`, then `d`) when done; this returns control to the orchestrator **without** killing the session, so the scripted loop can resume.
 
 ## Reading scrollback robustly
 

--- a/skills/tmux-agent-comms/references/tmux-recipes.md
+++ b/skills/tmux-agent-comms/references/tmux-recipes.md
@@ -74,23 +74,25 @@ The default orchestrator flow stays detached — `send-keys` writes to a session
 | Mid-run correction or manual input only a human should give | Show — type directly into that agent's input |
 | Everything else — scripted send/wait/capture loop, broadcasts | Detached (default) |
 
-**Attaching — pick the command for your starting context:**
+**Attaching — pick the command for who is running it, not just your starting context:**
 
 ```bash
-tmux attach-session -t agent1     # from a plain (non-tmux) shell — your terminal is not already a tmux client
-tmux switch-client -t agent1      # from inside tmux already — e.g. your own terminal is itself a tmux client
+tmux attach-session -t agent1     # HUMAN, in their own real interactive terminal
+tmux switch-client -t agent1      # agent itself, only if already a tmux client ($TMUX set)
 ```
 
-These are **not interchangeable**: running `attach-session` from a shell that is itself already inside a tmux client (`$TMUX` is set) fails with `sessions should be nested with care, unset $TMUX to force`. If you hit that, either use `switch-client` instead, or `unset TMUX` first if you deliberately want a nested attach.
+`attach-session` requires a controlling TTY. A human runs it fine in their own terminal — but if an agent invokes it through a non-interactive shell/Bash tool, it fails immediately with `open terminal failed: not a terminal` (verified: `tmux new-session -d -s test 'sleep 60'; tmux attach-session -t test </dev/null` exits 1 with that error). **The agent must never try to run `attach-session` itself** — instead, tell the human the exact command to type in their own terminal.
 
-**Name the session before attaching — don't guess.** Reuse the same target-resolution step as Phase 2 so you attach to the confirmed name, not a guess (spawn can rename on collision, e.g. `agent1-1730000000`):
+`switch-client` has no such restriction: it's a control-mode command that reuses the *existing* client rather than opening a new TTY, so it's safe for an agent to invoke on itself when it's already inside a tmux client (`$TMUX` is set) and wants to hand its own view over. Separately, running `attach-session` from a shell that is itself already inside a tmux client (`$TMUX` is set) fails with `sessions should be nested with care, unset $TMUX to force` — another reason a human should use `switch-client` in that starting context, or `unset TMUX` first if a nested attach is deliberate.
+
+**Name the session before attaching — don't guess.** Reuse the same target-resolution step as Phase 2 so the human attaches to the confirmed name, not a guess (spawn can rename on collision, e.g. `agent1-1730000000`):
 
 ```bash
 tmux has-session -t agent1 2>/dev/null && echo "OK: agent1 exists" || tmux list-sessions
-tmux attach-session -t agent1     # attach to the confirmed name from the line above
+tmux attach-session -t agent1     # human runs this, attaching to the confirmed name from the line above
 ```
 
-**Safety notes (consistent with Critical Rule 1):** attaching and scrolling to read is always safe; *typing* into the session is a write, the same hazard as `send-keys` — confirm with the user before typing into another agent's session on their behalf. If the orchestrator's scripted send-keys loop is still running while a human is attached and typing, both are writing to the same input and will fight each other — pause the scripted loop during hands-on takeover. Detach with `Ctrl-b d` (default tmux prefix `Ctrl-b`, then `d`) when done; this returns control to the orchestrator **without** killing the session, so the scripted loop can resume.
+**Safety notes (consistent with Critical Rule 1):** for a human running it in their own terminal, attaching and scrolling to read is always safe; *typing* into the session is a write, the same hazard as `send-keys` — confirm with the user before typing into another agent's session on their behalf. For the agent, `attach-session` isn't a safety question so much as a hard failure — it needs a TTY the agent's Bash tool doesn't have; only `switch-client` (agent already a tmux client) is something the agent can invoke itself. If the orchestrator's scripted send-keys loop is still running while a human is attached and typing, both are writing to the same input and will fight each other — pause the scripted loop during hands-on takeover. Detach with `Ctrl-b d` (default tmux prefix `Ctrl-b`, then `d`) when done; this returns control to the orchestrator **without** killing the session, so the scripted loop can resume.
 
 ## Reading scrollback robustly
 

--- a/skills/tmux-agent-comms/references/tmux-recipes.md
+++ b/skills/tmux-agent-comms/references/tmux-recipes.md
@@ -60,6 +60,38 @@ tmux capture-pane -t agent1:0.1 -p    # read just that pane
 
 List panes and their indices with `tmux list-panes -t agent1`.
 
+## Showing an agent's live terminal
+
+The default orchestrator flow stays detached — `send-keys` writes to a session's pane and `capture-pane` reads it, without ever opening a terminal on the session. Sometimes a human needs to see or drive the live CLI directly instead: a trust/auth dialog that needs a keypress the orchestrator won't fire (SKILL.md Phase 1, Phase 4 exit 3), debugging a stuck agent, or mid-run steering a scripted loop can't express.
+
+**When to use show vs. detached:**
+
+| Situation | Use |
+| --- | --- |
+| Routine messaging, waiting, capturing replies | Detached (default) — `send-keys` / `wait_for_idle.py` / `capture-pane`, no terminal needed |
+| Agent parked on a trust/auth prompt (`wait_for_idle.py` exit 3) | Show — a human must see the exact dialog text and pick the right key |
+| Debugging why an agent looks stalled or is behaving oddly | Show — watch it live rather than repeatedly capturing snapshots |
+| Mid-run correction or manual input only a human should give | Show — type directly into that agent's input |
+| Everything else — scripted send/wait/capture loop, broadcasts | Detached (default) |
+
+**Attaching — pick the command for your starting context:**
+
+```bash
+tmux attach-session -t agent1     # from a plain (non-tmux) shell — your terminal is not already a tmux client
+tmux switch-client -t agent1      # from inside tmux already — e.g. your own terminal is itself a tmux client
+```
+
+These are **not interchangeable**: running `attach-session` from a shell that is itself already inside a tmux client (`$TMUX` is set) fails with `sessions should be nested with care, unset $TMUX to force`. If you hit that, either use `switch-client` instead, or `unset TMUX` first if you deliberately want a nested attach.
+
+**Name the session before attaching — don't guess.** Reuse the same target-resolution step as Phase 2 so you attach to the confirmed name, not a guess (spawn can rename on collision, e.g. `agent1-1730000000`):
+
+```bash
+tmux has-session -t agent1 2>/dev/null && echo "OK: agent1 exists" || tmux list-sessions
+tmux attach-session -t agent1     # attach to the confirmed name from the line above
+```
+
+**Safety notes (consistent with Critical Rule 1):** attaching and scrolling to read is always safe; *typing* into the session is a write, the same hazard as `send-keys` — confirm with the user before typing into another agent's session on their behalf. If the orchestrator's scripted send-keys loop is still running while a human is attached and typing, both are writing to the same input and will fight each other — pause the scripted loop during hands-on takeover. Detach with `Ctrl-b d` (default tmux prefix `Ctrl-b`, then `d`) when done; this returns control to the orchestrator **without** killing the session, so the scripted loop can resume.
+
 ## Reading scrollback robustly
 
 The **default** read for a full reply is a bounded tail — `-S -40`, which returns ~40 lines of scrollback plus the visible pane — see SKILL.md Phase 5. This section is the **expand** case: a reply long enough that the bounded tail truncated (the capture starts mid-sentence). Widen the window stepwise rather than jumping straight to the whole history:
@@ -94,6 +126,8 @@ This is best-effort — always sanity-check the result rather than trusting it b
 | Reply cut off | Bounded-tail window too small for this reply | Widen the tail stepwise — `-S -80`, then larger; unbounded `-S -` only as last resort (SKILL.md Phase 5; "Reading scrollback robustly" above) |
 | `;` or `$...` came out wrong / executed | Shell/tmux interpreted special chars | Quote the message; use `send-keys -l` or paste-buffer (see above) |
 | Agent stuck on a yes/no or trust prompt | It's waiting for a keypress, not a typed line | `wait_for_idle.py` flags this as exit 3 (BLOCKED) for known dialogs. Send the exact key it expects (e.g. `tmux send-keys -t agent1 "1" Enter`), but confirm with the user first for any permission/trust prompt |
+| Attached to the wrong session / can't find my agent's window | Guessed a name instead of resolving it, or the spawn renamed on collision (`agent1-<timestamp>`) | Run `tmux has-session -t <name>` or `tmux list-sessions` first, then attach to the confirmed name (see "Showing an agent's live terminal" above) |
+| `attach-session` errors with "sessions should be nested with care, unset $TMUX to force" | Ran `attach-session` from a shell that's already inside a tmux client | Use `tmux switch-client -t <name>` instead, or `unset TMUX` first if a nested attach is intentional |
 | Can't tell if the agent is stuck or still working | Trusting the helper's exit code without a look | Verdict is advisory — read the pane yourself (`-S -40`). Spinner / changing tail = working (wait); unchanged + no spinner + no completion = stalled (surface to user). SKILL.md Phase 4 |
 | `wait_for_idle.py` times out repeatedly | Agent genuinely slow, or a persistent spinner | Raise `--timeout` for a single wait; if a static UI element matches a busy marker, fall back to the manual capture-compare loop. Bound the **overall** re-wait/re-send loop and escalate when the budget is spent — never poll forever (SKILL.md Phase 4) |
 | New session dies immediately | Agent binary not found in that shell | Launch the agent manually once to see the error; ensure it's on PATH in a login shell |


### PR DESCRIPTION
Closes #57

## Summary

The `tmux-agent-comms` skill previously only supported a fully detached, scripted workflow (spawn → send-keys → capture-pane → teardown), with no documented way for a user to see or interact directly with a spawned agent's live terminal. This PR adds an optional, documented "show the agent's terminal" workflow using tmux's native `attach-session` / `switch-client` primitives, so users can watch live output and hand-type into a spawned agent's session (e.g. to answer a trust prompt or steer mid-run) without disrupting the default detached-first design.

## Approach

**Balanced approach** (Option 2 of 3 considered): document the show/attach option directly in `SKILL.md`'s Phase 1 spawn workflow (with cross-references from Critical Rules and Edge Cases), add a full worked recipe with when-to-use guidance, safety notes, and a named-session example to `references/tmux-recipes.md`, and add a discoverability bullet to the human-facing `docs/README.md`. No new scripts were needed — tmux's existing `attach-session`/`switch-client` commands target the same session names already used by `send-keys`/`capture-pane`.

## Decision Record

- **Root cause:** `tmux-agent-comms` was designed entirely as an "orchestrate from outside" skill — Phase 1 (spawn) ends at a `wait_for_idle.py` readiness check with no documented attach step, so users had no sanctioned way to see or interact with a spawned agent's live terminal (only scripted `send-keys`/captured `capture-pane` output).
- **Options considered:** Option 1 — Minimal fix (one-line inline attach note in SKILL.md only); Option 2 — Balanced (SKILL.md option + full tmux-recipes.md recipe + README bullet); Option 3 — Comprehensive (Balanced + a 4th eval prompt in evals/evals.json)
- **Options rejected:** Option 1 — under-covers AC3 (when-to-use/safety guidance) and AC4 (named-session example), and isn't discoverable via the human README; Option 3 — adds eval-harness tuning effort disproportionate to a low-complexity, docs-only issue
- **Selected option:** Option 2 — Balanced approach
- **Residual risk:** none identified — docs-only change, no scripts or shared state touched; the only risk class (internal cross-reference consistency) was verified during QA
- **Design-confirm:** not applicable (complexity: low/S — below the high-complexity design-confirm threshold)

Analyzed at: `feature/57-tmux-show-agent-terminal @ 4d05dc3` (2026-07-01)

## Changes

| File | Change |
|------|--------|
| `skills/tmux-agent-comms/SKILL.md` | Bumped `metadata.version` 1.4.0 → 1.5.0; added "Show the agent's terminal (optional)" subsection to Phase 1 (`attach-session` vs `switch-client`, context-dependent); added Critical Rule 5 (attaching is opt-in, not a replacement for the detached default); added an Edge Case row for detaching cleanly with `Ctrl-b d`; updated the reference manifest line |
| `skills/tmux-agent-comms/references/tmux-recipes.md` | Added "Showing an agent's live terminal" recipe (when-to-use table, context-correct attach commands, session-naming-before-attach step, safety notes); added two troubleshooting rows (wrong session attached; nested-client `attach-session` error) |
| `skills/tmux-agent-comms/docs/README.md` | Added one Highlights bullet describing the show/attach option (additive only) |

## Test Results

- Unit tests: skipped — no unit test framework in this repo (docs-only skills catalog)
- Integration tests: skipped — none exist
- E2e tests: skipped — none exist
- Validation: `python3 ~/.claude/skills/skill-creator/scripts/quick_validate.py skills/tmux-agent-comms` → "Skill is valid!"
- QA cycles: 1 (clean — 0 fixable issues found)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Skill documents a clear option to show a spawned agent's tmux session after creation, without breaking the default detached/orchestrator-first workflow | pass | `skills/tmux-agent-comms/SKILL.md` Phase 1 "Show the agent's terminal (optional)" subsection; Critical Rule 5 states it's opt-in |
| User can attach to or open the correct session/window and interact with it using standard tmux behavior | pass | `references/tmux-recipes.md` "Showing an agent's live terminal" recipe documents `tmux attach-session -t <name>` (outside tmux) and `tmux switch-client -t <name>` (inside tmux), verified empirically against real tmux behavior including the nested-client error case |
| Guidance covers when to use show-vs-detached and safety notes consistent with existing confirm-before-destructive-actions rules | pass | `references/tmux-recipes.md` when-to-use table (auth/trust prompts, debugging, hands-on steering) + safety note tying attach-and-type to the existing write-hazard Critical Rule, plus a new callout on scripted-vs-manual input collision |
| Examples/workflow steps name the session being shown so users don't attach to the wrong tmux target | pass | Worked example in `references/tmux-recipes.md` resolves the session name via `has-session`/`list-sessions` before attaching; troubleshooting table adds a "wrong session attached" row |