### PR TITLE
chore(skills): trim SKILL.md files under 500-line limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ SKILL.md.bak
 .trae/
 .vibe/
 .zencoder/
+.asm-improver/

--- a/skills/agent-config/SKILL.md
+++ b/skills/agent-config/SKILL.md
@@ -4,8 +4,8 @@ description: "Create or update CLAUDE.md and AGENTS.md files following official 
 license: MIT
 effort: medium
 metadata:
-  version: 1.3.0
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.3.1
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 ## When to Use

--- a/skills/aso-marketing/SKILL.md
+++ b/skills/aso-marketing/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: aso-marketing
-description: "Optimize App Store and Google Play listings with keyword strategy, metadata, and localization. Use when asked to improve app store visibility or ASO. Don't use for web SEO, paid UA campaigns, or pre-submission compliance audits."
+description: "Optimize App Store and Google Play listings via a 7-phase, plan-approval-gated ASO workflow (keyword strategy, metadata, localization). Don't use for web SEO, paid UA campaigns, or pre-submission compliance audits."
 license: MIT
 effort: max
 metadata:
-  version: 1.2.0
+  version: 1.2.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -160,7 +160,7 @@ Apple App Store, Google Play Store, and cross-store conventions (indexed fields,
 
 ## Cross-Skill Integration
 
-This skill complements `asc-aso-audit` (deep iOS audit), `asc-localize-metadata` (bulk localization), `asc-metadata-sync` (App Store Connect sync), `asc-whats-new-writer`, `asc-shots-pipeline`, and `seo-ai-optimizer`. See `references/edge-cases.md` (Cross-Skill Integration section) for when to combine.
+This skill complements `seo-ai-optimizer`. See `references/edge-cases.md` (Cross-Skill Integration section) for when to combine.
 
 ## Safety and Caution
 

--- a/skills/auto-push/SKILL.md
+++ b/skills/auto-push/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate a commit message, stage all changes, and push to remote a
 license: MIT
 effort: low
 metadata:
-  version: 1.0.2
+  version: 1.0.3
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -180,4 +180,4 @@ The skill run is successful when all of the following hold:
 
 For the edge-case table, per-phase step-completion report format, error-handling guidance, and alternative workflows (selective staging, interactive `git add -p`, PR flow), see [`references/edge-cases-and-reports.md`](./references/edge-cases-and-reports.md).
 
-**Remember**: Always review changes before pushing. When in doubt, use individual git commands for more control.
+**Remember**: This skill already scans for secrets, large files, and branch risk in Step 2 and proceeds automatically once those checks pass — no extra manual review step is inserted. Use individual git commands instead if you want more control over what gets committed.

--- a/skills/brand-name-checker/SKILL.md
+++ b/skills/brand-name-checker/SKILL.md
@@ -4,8 +4,8 @@ description: "Check product and brand names for conflicts across trademarks, dom
 license: MIT
 effort: max
 metadata:
-  version: 1.3.0
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.3.2
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Brand Name Checker
@@ -32,7 +32,7 @@ This skill uses parallel subagents to handle 13+ sequential web fetches across i
 
 ### Parallelization Strategy
 
-- **Early Exit Logic**: If social-checker finds exact handle taken on main platform, skip steps 2-4 and jump to synthesizer with "Abandon" verdict
+- **Early-Exit Rule**: If social-checker finds an exact handle taken on the primary platform, skip steps 2-4 (Registry, Domain, Trademark) and jump straight to the synthesizer with an "Abandon" verdict. This is referenced elsewhere in this file simply as the Early-Exit Rule.
 - **Independent Workers**: Registry, domain, trademark checkers run in parallel without dependencies
 - **Sequential Flow**: Social → (if clear) → Parallel {Registry, Domain, Trademark} → Synthesizer
 
@@ -57,7 +57,7 @@ Optionally check for `prd.md` in project to understand product context.
 
 ## Analysis Protocol
 
-**If an exact social handle is taken, skip Steps 2-4 and jump directly to Step 6 (Recommendation) with an "Abandon" verdict.**
+**Early-Exit Rule applies** (see Subagent Architecture above): an exact social handle taken skips Steps 2-4 straight to Step 6 (Recommendation) with an "Abandon" verdict.
 
 ### Step 1: Social Media Check (First Priority)
 
@@ -69,7 +69,7 @@ Use WebSearch to check handles on:
 - YouTube: `"[NAME]" site:youtube.com`
 - TikTok: `"@[NAME]" site:tiktok.com`
 
-**If exact handle taken:** Return `NEGATIVE: Exact social handle taken (@platform)` and STOP. Suggest different name.
+**If exact handle taken (Early-Exit Rule):** Return `NEGATIVE: Exact social handle taken (@platform)` and STOP. Suggest different name.
 
 ### Step 2: Package Registry Check (if Step 1 clear)
 
@@ -185,7 +185,7 @@ RECOMMEND: Modify — use "acme-cli" (npm/PyPI clear, .com available, no TM conf
 
 ## Edge Cases
 
-- **Exact social handle taken on primary platform**: Skip all remaining checks and immediately return an Abandon recommendation with alternative name suggestions.
+- **Exact social handle taken on primary platform**: Early-Exit Rule (see Subagent Architecture) — skip all remaining checks and return an Abandon recommendation with alternative name suggestions.
 - **Rate-limited registry API**: Retry once after 5 seconds; if still blocked, mark the registry as "unchecked" and note it in the report — do not skip silently.
 - **Trademark database unavailable**: Note the outage per database; downgrade risk only if all three TM sources are inaccessible (warn user).
 - **Name contains special characters or spaces**: Normalize to slug form (e.g., `my tool` → `my-tool`) before all checks; report both the original and normalized forms.

--- a/skills/brand-name-checker/docs/README.md
+++ b/skills/brand-name-checker/docs/README.md
@@ -5,7 +5,7 @@
   If you're an AI agent, read the SKILL.md file instead for skill instructions.
 -->
 
-# Name Checker
+# Brand Name Checker
 
 > Check product and brand names for social media, package registry, domain, and trademark conflicts with risk assessment.
 

--- a/skills/clean-code/SKILL.md
+++ b/skills/clean-code/SKILL.md
@@ -4,9 +4,9 @@ description: "Audit code against the bbv Clean Code Cheat Sheet and write CLEAN_
 license: MIT
 effort: high
 metadata:
-  version: 1.2.0
-  author: Luong NGUYEN <luongnv89@gmail.com>
-  architecture: inline (single-agent orchestration)
+  version: 1.2.2
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
+  architecture: "inline (single-agent orchestration)"
 ---
 
 # Clean Code
@@ -95,11 +95,7 @@ Use the **Severity Levels** table below to classify each finding as you go.
 
 ### Phase 3 — Build the Phased Plan
 
-Convert findings into actionable tasks, grouped into priority phases. **Phasing is by severity:**
-
-- **Phase 1 — Critical**: bugs, security risks, broken core principles (e.g. God class, SRP violation that blocks change), missing tests around risky logic.
-- **Phase 2 — Major**: maintainability blockers — significant smells, high coupling, long methods, missing abstractions, test smells.
-- **Phase 3 — Minor**: naming, small conditionals, dead code, comment cleanup, style-level polish.
+Convert findings into actionable tasks, grouped into priority phases. **Phasing is by severity** — see the **Severity Levels** table below for the Critical/Major/Minor definitions and their phase mapping.
 
 Each task MUST have: a stable **ID** (`1.1`, `1.2`, `2.1`…), a short **title**, the **target `file:line`(s)**, the **principle/smell** it addresses, an **effort estimate** (e.g. `~15m`, `~2h`, `~1d`), **dependencies** (other task IDs that must come first, or `none`), and an **acceptance check** (how to confirm the task is done).
 

--- a/skills/cli-builder/SKILL.md
+++ b/skills/cli-builder/SKILL.md
@@ -4,8 +4,8 @@ description: "Build a production-quality CLI tool for any module or application.
 license: MIT
 effort: high
 metadata:
-  version: 1.0.3
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.0.4
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # CLI Builder

--- a/skills/code-optimizer/SKILL.md
+++ b/skills/code-optimizer/SKILL.md
@@ -4,8 +4,8 @@ description: "Analyze code for performance bottlenecks, memory leaks, and algori
 license: MIT
 effort: medium
 metadata:
-  version: 1.3.1
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.4.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Code Optimization
@@ -106,9 +106,7 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 **Phase: Analysis** — checks: `Issue detection`, `Priority categories covered`, `Impact estimated`, `Findings sorted by severity`
 
-**Phase: Apply Fixes** — checks: `Fix application`, `User approval obtained`, `Existing tests run`, `No regressions introduced`
-
-**Phase: Verify** — checks: `Performance verified`, `Test suite passes`, `Critical issues resolved`, `Warnings documented`
+**Phase: Apply Fixes** — checks: `Fix application`, `User approval obtained`, `Existing tests run`, `No regressions introduced`, `Critical issues resolved`, `Warnings documented`
 
 ## Severity Levels
 
@@ -119,51 +117,7 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 ## Language-Specific Checks
 
-### JavaScript/TypeScript
-- Array methods inside loops (map/filter/find in forEach)
-- Missing async/await causing blocking
-- Event listener leaks
-- Unbounded arrays/objects
-
-### Python
-- List comprehensions vs generator expressions for large data
-- Global interpreter lock considerations
-- Context manager usage for resources
-- N+1 query patterns
-
-### Go
-- Goroutine leaks (unbounded `go func()` without context cancellation)
-- Unnecessary allocations in hot paths (use `sync.Pool`, pre-allocate slices)
-- String concatenation in loops (use `strings.Builder`)
-- Missing `defer` for resource cleanup
-
-### Rust
-- Unnecessary cloning (use references or `Cow<>` instead)
-- Lock contention with `Mutex` when `RwLock` would suffice
-- Unbounded `Vec` growth without `with_capacity`
-- Blocking operations in async contexts
-
-### Java
-- Autoboxing in tight loops (use primitive types)
-- String concatenation with `+` in loops (use `StringBuilder`)
-- Synchronized blocks that are too broad
-- Stream API misuse (unnecessary intermediate collections)
-
-### General
-- Premature optimization warnings (only flag if genuinely impactful)
-- Database query patterns (N+1, missing indexes)
-- I/O in hot paths
-
-## Error Handling
-
-### No obvious performance issues found
-**Solution:** Report that the code is already well-optimized. Suggest profiling with runtime tools (e.g., `perf`, Chrome DevTools, `py-spy`) to find runtime-specific bottlenecks.
-
-### Target file is too large (>2000 lines)
-**Solution:** Ask the user to specify which functions or sections to focus on. Analyze the most performance-critical paths first.
-
-### Optimization breaks existing tests
-**Solution:** Revert the change immediately. Re-examine the optimization and adjust the approach to preserve existing behavior.
+Read `references/language-checks.md` for the detected language's specific checks (covers JavaScript/TypeScript, Python, Go, Rust, Java, and general cross-language patterns) — load only the section matching the target code's language.
 
 ## Acceptance Criteria
 

--- a/skills/code-optimizer/references/language-checks.md
+++ b/skills/code-optimizer/references/language-checks.md
@@ -1,0 +1,39 @@
+# Language-Specific Checks
+
+Per-language checklists for the Analysis phase. Read only the section matching
+the detected language(s) of the target code — don't load the rest.
+
+## JavaScript/TypeScript
+- Array methods inside loops (map/filter/find in forEach)
+- Missing async/await causing blocking
+- Event listener leaks
+- Unbounded arrays/objects
+
+## Python
+- List comprehensions vs generator expressions for large data
+- Global interpreter lock considerations
+- Context manager usage for resources
+- N+1 query patterns
+
+## Go
+- Goroutine leaks (unbounded `go func()` without context cancellation)
+- Unnecessary allocations in hot paths (use `sync.Pool`, pre-allocate slices)
+- String concatenation in loops (use `strings.Builder`)
+- Missing `defer` for resource cleanup
+
+## Rust
+- Unnecessary cloning (use references or `Cow<>` instead)
+- Lock contention with `Mutex` when `RwLock` would suffice
+- Unbounded `Vec` growth without `with_capacity`
+- Blocking operations in async contexts
+
+## Java
+- Autoboxing in tight loops (use primitive types)
+- String concatenation with `+` in loops (use `StringBuilder`)
+- Synchronized blocks that are too broad
+- Stream API misuse (unnecessary intermediate collections)
+
+## General
+- Premature optimization warnings (only flag if genuinely impactful)
+- Database query patterns (N+1, missing indexes)
+- I/O in hot paths

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -4,7 +4,7 @@ description: "Review code changes for bugs, security vulnerabilities, and code q
 license: MIT
 effort: medium
 metadata:
-  version: 1.1.4
+  version: 1.2.0
   author: Luong NGUYEN <luongnv89@gmail.com>
   architecture: "subagent (Pattern B+C: Parallel Workers + Review Loop)"
 ---
@@ -52,88 +52,28 @@ Before proceeding with code review:
 
 1. **Verify Agent tool availability**: Check if `/Agent` subagent system is available
 2. **Codebase scope**: Determine if full audit or PR/diff review
-3. **Context budget**: Estimate file count and total lines to review
-   - Small PR/diff: <50 files, <5000 lines → run inline (fast path)
-   - Medium audit: 50-200 files, 5K-50K lines → use batch processing
-   - Large audit: >200 files, >50K lines → sample entry points and hot paths
+3. **Context budget**: Estimate file count and total lines to review, then pick a mode from Mode Selection below
 
 ## Subagent Architecture
 
 ### Pattern: B (Parallel Workers) + C (Review Loop)
 
-For full codebase audits and large PRs, use parallel subagent architecture:
+For full codebase audits and large PRs, this skill uses a parallel-worker + review-loop pattern: the main orchestrator batches files across parallel `file-reviewer` agents, a `report-assembler` merges and deduplicates their findings, and a `reviewer` agent validates the final report with fresh eyes.
 
-```
-┌─────────────────────────────────┐
-│  Main SKILL (Orchestrator)      │
-│  - Parse scope (PR/audit)       │
-│  - Batch files into groups      │
-│  - Check Agent availability     │
-└──────────────┬──────────────────┘
-               │
-       ┌───────┴───────┬───────────┬─────────────┐
-       │               │           │             │
-       v               v           v             v
-   ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐
-   │ Reviewer 1 │ │ Reviewer 2 │ │ Reviewer 3 │ │ Reviewer N │
-   │   Batch 1  │ │   Batch 2  │ │   Batch 3  │ │  Batch N   │
-   │   5-10     │ │   5-10     │ │   5-10     │ │   5-10     │
-   │   files    │ │   files    │ │   files    │ │   files    │
-   │ (parallel) │ │ (parallel) │ │ (parallel) │ │ (parallel) │
-   └─────┬──────┘ └─────┬──────┘ └─────┬──────┘ └─────┬──────┘
-         │              │              │              │
-         │              └──────────────┴──────────────┘
-         │                             │
-         └─────────────────────────────┘
-                     │
-        ┌────────────v────────────────┐
-        │  Report Assembler           │
-        │  - Merge all findings       │
-        │  - Deduplicate issues       │
-        │  - Rank by severity         │
-        │  - Generate CODE_REVIEW.md  │
-        └────────────┬────────────────┘
-                     │
-             ┌───────v────────┐
-             │  Reviewer      │
-             │  Validator     │
-             │  - Fresh eyes  │
-             │  - Verify      │
-             │  - Completeness│
-             └────────────────┘
-```
+Full orchestration diagram, per-agent responsibilities, graceful degradation when the Agent tool is unavailable, and risk mitigations: `references/subagent-architecture.md`.
 
-#### Agent Files
-
-- **agents/file-reviewer.md** — Review a batch of 5-10 files against the full checklist
-  - Returns structured JSON with findings, severity levels, and fix suggestions
-  - Run in parallel on multiple batches
-  - Input: file list, checklist config, language context
-  - Output: JSON with findings array
-
-- **agents/report-assembler.md** — Merge all batch results into one report
-  - Deduplicates findings by (file, line, smell)
-  - Ranks by severity (critical → major → minor → info)
-  - Identifies cross-file patterns (duplicate code, shotgun surgery)
-  - Generates final CODE_REVIEW.md
-  - Input: array of JSON outputs from file-reviewer
-  - Output: Markdown report + validation JSON
-
-- **agents/reviewer.md** — Fresh-context validation pass
-  - Verifies accuracy of all findings
-  - Catches false positives and severity miscategorizations
-  - Identifies missed issues
-  - Returns validation report with corrections
-  - Input: CODE_REVIEW.md + original source files
-  - Output: Validation JSON + updated CODE_REVIEW.md if corrections needed
-
-### Mode Selection & Degradation
+## Mode Selection
 
 **Mode 1: Small PR/Diff (Fast Path - Inline)**
 - Changed files: <50
 - Total lines changed: <5000
-- Process: Run complete review inline in SKILL.md
-- No subagents needed
+- Process: Run complete review inline in SKILL.md; no subagents needed
+- Git commands:
+  ```bash
+  git diff --name-only <base>..HEAD
+  git diff <base>..HEAD
+  ```
+- Scan focus: only changed lines and their immediate context
 - Output: CODE_REVIEW.md in seconds
 
 **Mode 2: Medium Audit (Batched with Subagents)**
@@ -145,6 +85,7 @@ For full codebase audits and large PRs, use parallel subagent architecture:
   3. Collect JSON outputs
   4. Merge with report-assembler
   5. Validate with reviewer
+- Scan focus: all source files, prioritizing entry points (main, index, app) and core business logic
 - Output: CODE_REVIEW.md with comprehensive findings
 
 **Mode 3: Large Audit (Sampled with Subagents)**
@@ -152,53 +93,31 @@ For full codebase audits and large PRs, use parallel subagent architecture:
 - Total lines: >50K
 - Process:
   1. Identify and scan entry points (main, index, app files)
-  2. Scan business logic hotspots (most frequently modified)
+  2. Scan business logic hotspots — most frequently modified files:
+     ```bash
+     git log --format='%H' | head -100 | xargs -I{} git diff-tree --no-commit-id --name-only -r {} | sort | uniq -c | sort -rn
+     ```
   3. Sample distributed files across codebase
   4. Use parallel batching as in Mode 2
   5. Full validation pass
 - Output: CODE_REVIEW.md with sampled findings + note about sampling strategy
 
-### Graceful Degradation
-
-If Agent tool unavailable:
-- Fall back to inline execution in main SKILL.md
-- Use sequential file processing instead of parallel batches
-- Return CODE_REVIEW.md without validation pass
-- Log message: "Subagent architecture unavailable; running inline review"
-
-### Risk Mitigation
-
-**Missed cross-file smells**: Report-assembler cross-file analysis partially mitigates by identifying:
-- Duplicate code patterns
-- Shotgun surgery risks
-- Architectural coupling
-
-**Context overflow**: Batching 5-10 files per agent keeps context manageable while maintaining review quality.
-
-**False positives**: Reviewer agent catches most false positives through fresh-context validation before final report.
-
-## Review Modes
-
-### Mode 1: PR/Diff Review
-
-```bash
-# Get changed files
-git diff --name-only <base>..HEAD
-git diff <base>..HEAD
-```
-
-Focus only on changed lines and their immediate context.
-
-### Mode 2: Full Codebase Audit
-
-Scan all source files, prioritizing:
-1. Entry points (main, index, app)
-2. Core business logic
-3. Frequently modified files (`git log --format='%H' | head -100 | xargs -I{} git diff-tree --no-commit-id --name-only -r {} | sort | uniq -c | sort -rn`)
+If the Agent tool is unavailable, degrade gracefully per `references/subagent-architecture.md`: run sequential inline review instead of Mode 2/3 subagent batching.
 
 ## Review Checklist
 
-### 1. Code Smells (Critical)
+Findings are grouped into the four categories below and classified by severity:
+
+### Severity Levels
+
+| Level | Description | Action |
+|-------|-------------|--------|
+| **Critical** | Security risks, bugs, data loss potential | Must fix before merge |
+| **Major** | Code smells, maintainability blockers | Should fix soon |
+| **Minor** | Style, minor improvements | Nice to have |
+| **Info** | Suggestions, alternatives | Optional |
+
+### 1. Code Smells
 
 Read `references/code-smells.md` when a code smell is identified that requires the full catalog for classification.
 
@@ -419,15 +338,7 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 **Phase: Validation Pass** — checks: `Validation pass`, `False positive check`
 
-## Severity Levels
-
-| Level | Description | Action |
-|-------|-------------|--------|
-| **Critical** | Security risks, bugs, data loss potential | Must fix before merge |
-| **Major** | Code smells, maintainability blockers | Should fix soon |
-| **Minor** | Style, minor improvements | Nice to have |
-| **Info** | Suggestions, alternatives | Optional |
-
 ## Resources
 
 - [references/code-smells.md](references/code-smells.md) - Complete catalog of code smells with examples
+- [references/subagent-architecture.md](references/subagent-architecture.md) - Orchestration diagram, agent responsibilities, graceful degradation, and risk mitigation

--- a/skills/code-review/references/subagent-architecture.md
+++ b/skills/code-review/references/subagent-architecture.md
@@ -1,0 +1,88 @@
+# Subagent Architecture
+
+Full detail on the Pattern B+C (Parallel Workers + Review Loop) architecture used for medium/large audits: the orchestration diagram, per-agent responsibilities, graceful degradation when the Agent tool is unavailable, and known risk mitigations.
+
+## Diagram
+
+```
+┌─────────────────────────────────┐
+│  Main SKILL (Orchestrator)      │
+│  - Parse scope (PR/audit)       │
+│  - Batch files into groups      │
+│  - Check Agent availability     │
+└──────────────┬──────────────────┘
+               │
+       ┌───────┴───────┬───────────┬─────────────┐
+       │               │           │             │
+       v               v           v             v
+   ┌────────────┐ ┌────────────┐ ┌────────────┐ ┌────────────┐
+   │ Reviewer 1 │ │ Reviewer 2 │ │ Reviewer 3 │ │ Reviewer N │
+   │   Batch 1  │ │   Batch 2  │ │   Batch 3  │ │  Batch N   │
+   │   5-10     │ │   5-10     │ │   5-10     │ │   5-10     │
+   │   files    │ │   files    │ │   files    │ │   files    │
+   │ (parallel) │ │ (parallel) │ │ (parallel) │ │ (parallel) │
+   └─────┬──────┘ └─────┬──────┘ └─────┬──────┘ └─────┬──────┘
+         │              │              │              │
+         │              └──────────────┴──────────────┘
+         │                             │
+         └─────────────────────────────┘
+                     │
+        ┌────────────v────────────────┐
+        │  Report Assembler           │
+        │  - Merge all findings       │
+        │  - Deduplicate issues       │
+        │  - Rank by severity         │
+        │  - Generate CODE_REVIEW.md  │
+        └────────────┬────────────────┘
+                     │
+             ┌───────v────────┐
+             │  Reviewer      │
+             │  Validator     │
+             │  - Fresh eyes  │
+             │  - Verify      │
+             │  - Completeness│
+             └────────────────┘
+```
+
+## Agent Files
+
+- **agents/file-reviewer.md** — Review a batch of 5-10 files against the full checklist
+  - Returns structured JSON with findings, severity levels, and fix suggestions
+  - Run in parallel on multiple batches
+  - Input: file list, checklist config, language context
+  - Output: JSON with findings array
+
+- **agents/report-assembler.md** — Merge all batch results into one report
+  - Deduplicates findings by (file, line, smell)
+  - Ranks by severity (critical → major → minor → info)
+  - Identifies cross-file patterns (duplicate code, shotgun surgery)
+  - Generates final CODE_REVIEW.md
+  - Input: array of JSON outputs from file-reviewer
+  - Output: Markdown report + validation JSON
+
+- **agents/reviewer.md** — Fresh-context validation pass
+  - Verifies accuracy of all findings
+  - Catches false positives and severity miscategorizations
+  - Identifies missed issues
+  - Returns validation report with corrections
+  - Input: CODE_REVIEW.md + original source files
+  - Output: Validation JSON + updated CODE_REVIEW.md if corrections needed
+
+## Graceful Degradation
+
+If the Agent tool is unavailable:
+- Fall back to inline execution in main SKILL.md
+- Use sequential file processing instead of parallel batches
+- Return CODE_REVIEW.md without a validation pass
+- Log message: "Subagent architecture unavailable; running inline review"
+
+## Risk Mitigation
+
+**Missed cross-file smells**: Report-assembler cross-file analysis partially mitigates by identifying:
+- Duplicate code patterns
+- Shotgun surgery risks
+- Architectural coupling
+
+**Context overflow**: Batching 5-10 files per agent keeps context manageable while maintaining review quality.
+
+**False positives**: Reviewer agent catches most false positives through fresh-context validation before final report.

--- a/skills/devops-pipeline/SKILL.md
+++ b/skills/devops-pipeline/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: devops-pipeline
-description: "Configure pre-commit hooks and lean GitHub Actions for shift-left quality assurance. Use when adding or auditing CI/CD on a Git repo to maximize local test coverage and minimize CI cost. Skip for Terraform/K8s, deployment pipelines, or non-GitHub CI providers."
+description: "Configure pre-commit hooks and lean GitHub Actions for shift-left quality assurance. Use when adding or auditing CI/CD to maximize local test coverage and minimize CI cost. Skip for Terraform/K8s, deployment pipelines, or non-GitHub CI providers."
 license: MIT
 effort: medium
 metadata:
-  version: 2.0.1
+  version: 2.0.3
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -150,19 +150,7 @@ If all local checks pass, GitHub Actions becomes a thin verification layer, not 
 | Rust | rustfmt | Clippy | built-in | cargo-audit | cargo test |
 | Java | google-java-format | Checkstyle | - | SpotBugs | mvn test |
 
-## What Runs Where
-
-| Check | Pre-commit (commit) | Pre-commit (push) | GitHub Actions |
-|-------|---------------------|-------------------|----------------|
-| Formatting | ✓ | — | — |
-| Linting | ✓ | — | — |
-| Type checking | ✓ | — | — |
-| Security scan (offline) | ✓ | — | — |
-| Unit tests (fast) | ✓ | — | — |
-| Full test suite | — | ✓ | ✓ (coverage upload) |
-| CLI E2E tests | — | ✓ | — |
-| Multi-version matrix | — | — | ✓ |
-| Deploy | — | — | ✓ |
+Where each check runs (commit-stage pre-commit, push-stage pre-commit, or GitHub Actions only) is set out in Workflow steps 2 and 3 above — do not re-split checks differently here.
 
 ## Expected Output
 

--- a/skills/docs-generator/SKILL.md
+++ b/skills/docs-generator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: docs-generator
-description: "Generate and restructure project documentation into a clear, accessible hierarchy. Use when asked to organize docs, generate documentation, improve doc structure, or restructure README. Don't use for API reference generation from code (JSDoc/Sphinx), authoring a landing page, or agent-config files like CLAUDE.md."
+description: "Generate and restructure project docs into a clear, accessible hierarchy. Use to organize, generate, or restructure a README. Don't use for API reference generation (JSDoc/Sphinx), landing pages, or agent-config files like CLAUDE.md."
 license: MIT
 effort: low
 metadata:
-  version: 1.2.3
+  version: 1.2.5
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -159,14 +159,6 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 **Phase: Documentation Restructure** — checks: `Doc restructure`, `Diagram creation`
 
 **Phase: Validation** — checks: `Validation pass`, `Link verification`
-
-## Error Handling
-
-### No existing documentation found
-**Solution:** Generate documentation from scratch based on code analysis. Start with README.md and add docs/ files based on project complexity.
-
-### Conflicting or outdated docs
-**Solution:** Flag conflicts to the user. Prefer code-derived information over stale docs. Mark outdated sections for user review.
 
 ## Guidelines
 

--- a/skills/dont-make-me-think/SKILL.md
+++ b/skills/dont-make-me-think/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: dont-make-me-think
-description: "Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code. Don't use for visual/brand design critique, accessibility (WCAG) audits, or backend/API review."
+description: "Review UI for usability using Steve Krug's principles; produce a scannable report. Use for usability audits, UX review, or UI feedback on screenshots, URLs, or code. Don't use for brand design critique, WCAG audits, or backend/API review."
 license: MIT
 effort: medium
 metadata:
-  version: 1.2.1
+  version: 1.2.3
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -12,9 +12,7 @@ metadata:
 
 Evaluate and improve UIs through Steve Krug's "Don't Make Me Think" principles. The report itself must practice what Krug preaches: scannable, visual, zero fluff. A human should skim it in 30 seconds; an AI agent should be able to parse it and start fixing.
 
-## When to Use
-
-Trigger this skill when the user asks for a usability audit, UX review, or UI feedback on a screenshot, live URL, or HTML/CSS code. Do not use for visual/brand critique, WCAG accessibility audits, or backend/API review — route those elsewhere.
+Triggers and exclusions are set by the frontmatter `description` above. Accepted inputs are listed in Input Handling below.
 
 ## Instructions
 

--- a/skills/drawio-generator/SKILL.md
+++ b/skills/drawio-generator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: drawio-generator
-description: "Generate professional diagrams as valid draw.io XML files — flowcharts, architecture, C4 models, ER diagrams, sequence diagrams, mind maps, and swimlanes. Don't use for Excalidraw or Mermaid output, hand-drawn sketch styles, or slide decks/presentations."
+description: "Generate professional diagrams as valid draw.io XML — flowcharts, architecture, C4 models, ER diagrams, sequence diagrams, mind maps, and swimlanes. Don't use for Excalidraw or Mermaid output, hand-drawn sketch styles, or slide decks/presentations."
 license: MIT
 effort: high
 metadata:
-  version: 1.2.0
+  version: 1.2.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -188,12 +188,7 @@ When iterating on an existing diagram, read the file, modify the XML in place, a
 
 ## Subagent Architecture
 
-When a diagram exceeds 30 elements, spawn a review loop to avoid single-context degradation.
-
-**Complexity threshold (set at end of Phase 2):**
-- Small (<10): proceed inline
-- Medium (10–30): proceed inline with careful validation
-- Large (>30): spawn the subagent review loop
+When a diagram exceeds 30 elements, spawn a review loop to avoid single-context degradation. Use the complexity estimate from Phase 2 step 6: large (30+) spawns the subagent review loop below; small/medium proceed inline.
 
 **Phase 3 — `agents/xml-generator.md`**
 - Receives: diagram type, elements, edges, style, complexity

--- a/skills/excalidraw-generator/SKILL.md
+++ b/skills/excalidraw-generator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: excalidraw-generator
-description: "Generate professional diagrams as valid Excalidraw JSON files — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Understands text, code, schemas, or verbal descriptions. Don't use for draw.io/Mermaid output, polished production slide decks, or pixel-perfect brand graphics."
+description: "Generate diagrams as valid Excalidraw JSON — flowcharts, architecture, ER diagrams, mind maps, sequence diagrams, wireframes, C4 models, and more. Don't use for draw.io/Mermaid output, slide decks, or pixel-perfect brand graphics."
 license: MIT
 effort: high
 metadata:
-  version: 1.3.0
+  version: 1.3.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -16,7 +16,7 @@ This SKILL.md is intentionally compact to fit the agent's context budget (token-
 
 ## When to Use
 
-Use when the user asks for a diagram, flowchart, architecture sketch, ER/class/sequence diagram, mind map, wireframe, or C4 model and wants the output as an Excalidraw file (or embedded in Markdown via the `excalidraw` fenced block).
+Triggers/exclusions are set by the frontmatter `description` above. Output is an Excalidraw file, or embedded in Markdown via the `excalidraw` fenced block if the user asks for that.
 
 ## Environment Check
 

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -4,7 +4,7 @@ description: "Build production-grade frontend interfaces with distinctive aesthe
 license: MIT
 effort: high
 metadata:
-  version: 1.2.2
+  version: 1.2.3
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -78,7 +78,7 @@ If the user provides their own colors, brand kit, or style direction, use those 
 
 ## Usability Principles — "Don't Make Me Think"
 
-Every design MUST follow these usability rules derived from Steve Krug's principles. These are non-negotiable regardless of aesthetic direction.
+Every design MUST follow these usability rules derived from Steve Krug's principles. These are non-negotiable regardless of aesthetic direction. This is the same source the `dont-make-me-think` skill audits against — condensed here for inline use during generation; keep the two in sync if Krug-principle guidance changes.
 
 ### 1. Design for Scanning, Not Reading
 - Users scan pages — they do not read them. Use clear headings, short paragraphs, bullet points, and visual hierarchy (bigger/bolder = more important).

--- a/skills/idea-validator/SKILL.md
+++ b/skills/idea-validator/SKILL.md
@@ -4,7 +4,7 @@ description: "Validate app/startup ideas with market, feasibility, commercial, a
 license: MIT
 effort: max
 metadata:
-  version: 1.4.0
+  version: 1.5.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -22,7 +22,7 @@ Trigger this skill when the user asks to:
 
 ## Instructions
 
-Follow the 5-phase pipeline in order: Clarify → Technical Context → Competitive Landscape Research → Critical Evaluation → Improvements. Do not skip phases or reorder them.
+Follow the 5-phase pipeline in order: Clarify → Technical Context → Competitive Landscape Research → Critical Evaluation → Improvements. Do not skip phases or reorder them. One conditional branch applies on top of the pipeline: if the working directory is the root of an `ideas` repo, also do the README Maintenance step below after each file update — see that section for the detection rule.
 
 ## Repo Sync Before Edits (mandatory)
 Before creating/updating/deleting files in an existing repository, sync the current branch with remote:
@@ -224,74 +224,7 @@ After completing each major step, output a status report in this format:
 
 Adapt the check names to match what the step actually validates. Use `√` for pass, `×` for fail, and `—` to add brief context. The "Criteria" line summarizes how many acceptance criteria were met. The "Result" line gives the overall verdict.
 
-### Phase-specific checks
-
-**Setup**
-```
-◆ Setup (step 1 of 6 — [idea name])
-··································································
-  Storage resolved:   √ pass ([path])
-  Folder created:     √ pass ([YYYY_MM_DD_name/])
-  ____________________________
-  Result:             PASS | FAIL | PARTIAL
-```
-
-**Phase 1 — Clarify**
-```
-◆ Clarify (step 2 of 6 — [idea name])
-··································································
-  Questions answered: √ pass ([N] responses collected)
-  idea.md updated:    √ pass | × fail — [missing sections]
-  ____________________________
-  Result:             PASS | FAIL | PARTIAL
-```
-
-**Phase 2 — Gather Technical Context**
-```
-◆ Gather Technical Context (step 3 of 6 — [idea name])
-··································································
-  Context sources identified: √ pass ([N] inputs collected)
-  Technical feasibility assessed: √ pass | × fail — [gaps noted]
-  idea.md technical section updated: √ pass | × fail — [missing fields]
-  ____________________________
-  Result:             PASS | FAIL | PARTIAL
-```
-
-**Phase 3 — Competitive Landscape**
-```
-◆ Competitive Landscape (step 4 of 6 — [idea name])
-··································································
-  Web searches executed:  √ pass ([N] live queries run)
-  Commercial coverage:    √ pass ([N] tools/services found)
-  Open-source coverage:   √ pass ([N] OSS options found or no credible result documented)
-  Competitors found:      √ pass ([N] direct + [N] adjacent)
-  Failed attempts checked:√ pass | × fail — [no results or skipped]
-  Reuse potential assessed: √ pass | × fail — [OSS build-on/fork path missing]
-  validate.md updated:    √ pass | × fail — [missing sections]
-  ____________________________
-  Result:                 PASS | FAIL | PARTIAL
-```
-
-**Phase 4 — Evaluate**
-```
-◆ Evaluate (step 5 of 6 — [idea name])
-··································································
-  Feasibility scored: √ pass ([score]/10)
-  Market assessed:    √ pass | × fail — [gaps in analysis]
-  validate.md updated:√ pass | × fail — [missing sections]
-  ____________________________
-  Result:             PASS | FAIL | PARTIAL
-```
-
-**Phase 5 — Improve**
-```
-◆ Improve (step 6 of 6 — [idea name])
-··································································
-  Enhancements identified:    √ pass ([N] improvements listed)
-  Recommendations added:      √ pass | × fail — [what's missing]
-  ____________________________
-  Result:                     PASS | FAIL | PARTIAL
-```
+Per-phase check blocks (Setup, Phase 1-5) live in `references/step-completion-reports.md` — read the block matching the phase you just completed.
 
 ## Tone
 
@@ -337,90 +270,4 @@ After all phases:
 
 ## File Templates
 
-### idea.md
-```markdown
-# Idea: [Name]
-
-## Original Concept
-[From $ARGUMENTS]
-
-## Clarified Understanding
-[After Phase 1]
-
-## Target Audience
-[Specific user profile]
-
-## Goals & Objectives
-[Success criteria]
-
-## Technical Context
-- Stack:
-- Timeline:
-- Budget:
-- Constraints:
-
-## Discussion Notes
-[Updates from conversation]
-```
-
-### validate.md
-```markdown
-# Validation: [Name]
-
-## Quick Verdict
-**[Build it / Maybe / Skip it]**
-
-## Why
-[2-3 sentence explanation]
-
-## Competitive Landscape
-
-| Competitor | Type | What They Do | Pricing / License | Traction / Health | Reuse Potential | Key Weakness |
-|---|---|---|---|---|---|---|
-| [Name](URL) | [Commercial / OSS / Hybrid / Adjacent / Failed] | [One sentence] | [Model or license] | [Evidence] | [Fork/build-on/plugin/reference/not suitable] | [Gap to exploit] |
-
-### Commercial Tools & Services
-[Commercial competitors, pricing, traction, and market positioning]
-
-### Open-source Alternatives & Reuse Potential
-[Maintained OSS projects, license/health, and whether to build on, fork, contribute, or avoid rebuilding]
-
-### White Space Analysis
-[What's missing in the current market]
-
-### Differentiation Assessment
-[Is the proposed differentiation real or imagined given existing commercial and open-source competitors?]
-
-### Build vs. Base Recommendation
-[Whether to build from scratch, build on existing OSS, fork, contribute, or narrow the idea]
-
-### Failed Predecessors
-[Products or OSS projects that tried and failed, stalled, or were abandoned — and why]
-
-## Similar Products
-[Competitors]
-
-## Differentiation
-[Unique angle]
-
-## Strengths
--
-
-## Concerns
--
-
-## Ratings
-- Creativity: /10
-- Feasibility: /10
-- Market Impact: /10
-- Technical Execution: /10
-
-## How to Strengthen
-[Actionable improvements]
-
-## Enhanced Version
-[Optimized concept]
-
-## Implementation Roadmap
-[Phased approach]
-```
+The canonical `idea.md` and `validate.md` header structure lives in `references/file-templates.md`. Read it when creating either file (Setup step 2/3) or updating a section named in Phases 1-5 above — that file owns header names and order; phase instructions above own what content goes in them.

--- a/skills/idea-validator/references/file-templates.md
+++ b/skills/idea-validator/references/file-templates.md
@@ -1,0 +1,91 @@
+# File Templates
+
+The canonical markdown structure for `idea.md` and `validate.md`. Read this when creating or updating either file (Setup step 2/3, and each phase's "Update `idea.md`/`validate.md`" instruction). The field content itself is defined by the phase instructions in SKILL.md — this file only owns header names, order, and placeholder format; do not restate phase guidance here when updating it.
+
+### idea.md
+```markdown
+# Idea: [Name]
+
+## Original Concept
+[From $ARGUMENTS]
+
+## Clarified Understanding
+[After Phase 1]
+
+## Target Audience
+[Specific user profile]
+
+## Goals & Objectives
+[Success criteria]
+
+## Technical Context
+- Stack:
+- Timeline:
+- Budget:
+- Constraints:
+
+## Discussion Notes
+[Updates from conversation]
+```
+
+### validate.md
+```markdown
+# Validation: [Name]
+
+## Quick Verdict
+**[Build it / Maybe / Skip it]**
+
+## Why
+[2-3 sentence explanation]
+
+## Competitive Landscape
+
+| Competitor | Type | What They Do | Pricing / License | Traction / Health | Reuse Potential | Key Weakness |
+|---|---|---|---|---|---|---|
+| [Name](URL) | [Commercial / OSS / Hybrid / Adjacent / Failed] | [One sentence] | [Model or license] | [Evidence] | [Fork/build-on/plugin/reference/not suitable] | [Gap to exploit] |
+
+### Commercial Tools & Services
+[Commercial competitors, pricing, traction, and market positioning]
+
+### Open-source Alternatives & Reuse Potential
+[Maintained OSS projects, license/health, and whether to build on, fork, contribute, or avoid rebuilding]
+
+### White Space Analysis
+[What's missing in the current market]
+
+### Differentiation Assessment
+[Is the proposed differentiation real or imagined given existing commercial and open-source competitors?]
+
+### Build vs. Base Recommendation
+[Whether to build from scratch, build on existing OSS, fork, contribute, or narrow the idea]
+
+### Failed Predecessors
+[Products or OSS projects that tried and failed, stalled, or were abandoned — and why]
+
+## Similar Products
+[Competitors]
+
+## Differentiation
+[Unique angle]
+
+## Strengths
+-
+
+## Concerns
+-
+
+## Ratings
+- Creativity: /10
+- Feasibility: /10
+- Market Impact: /10
+- Technical Execution: /10
+
+## How to Strengthen
+[Actionable improvements]
+
+## Enhanced Version
+[Optimized concept]
+
+## Implementation Roadmap
+[Phased approach]
+```

--- a/skills/idea-validator/references/step-completion-reports.md
+++ b/skills/idea-validator/references/step-completion-reports.md
@@ -1,0 +1,70 @@
+# Step Completion Reports — phase-specific checks
+
+Read this file when emitting the Step Completion Report for a given phase (see SKILL.md → Step Completion Reports for the generic template and symbol legend). Use the block matching the phase you just completed.
+
+**Setup**
+```
+◆ Setup (step 1 of 6 — [idea name])
+··································································
+  Storage resolved:   √ pass ([path])
+  Folder created:     √ pass ([YYYY_MM_DD_name/])
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```
+
+**Phase 1 — Clarify**
+```
+◆ Clarify (step 2 of 6 — [idea name])
+··································································
+  Questions answered: √ pass ([N] responses collected)
+  idea.md updated:    √ pass | × fail — [missing sections]
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```
+
+**Phase 2 — Gather Technical Context**
+```
+◆ Gather Technical Context (step 3 of 6 — [idea name])
+··································································
+  Context sources identified: √ pass ([N] inputs collected)
+  Technical feasibility assessed: √ pass | × fail — [gaps noted]
+  idea.md technical section updated: √ pass | × fail — [missing fields]
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```
+
+**Phase 3 — Competitive Landscape**
+```
+◆ Competitive Landscape (step 4 of 6 — [idea name])
+··································································
+  Web searches executed:  √ pass ([N] live queries run)
+  Commercial coverage:    √ pass ([N] tools/services found)
+  Open-source coverage:   √ pass ([N] OSS options found or no credible result documented)
+  Competitors found:      √ pass ([N] direct + [N] adjacent)
+  Failed attempts checked:√ pass | × fail — [no results or skipped]
+  Reuse potential assessed: √ pass | × fail — [OSS build-on/fork path missing]
+  validate.md updated:    √ pass | × fail — [missing sections]
+  ____________________________
+  Result:                 PASS | FAIL | PARTIAL
+```
+
+**Phase 4 — Evaluate**
+```
+◆ Evaluate (step 5 of 6 — [idea name])
+··································································
+  Feasibility scored: √ pass ([score]/10)
+  Market assessed:    √ pass | × fail — [gaps in analysis]
+  validate.md updated:√ pass | × fail — [missing sections]
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```
+
+**Phase 5 — Improve**
+```
+◆ Improve (step 6 of 6 — [idea name])
+··································································
+  Enhancements identified:    √ pass ([N] improvements listed)
+  Recommendations added:      √ pass | × fail — [what's missing]
+  ____________________________
+  Result:                     PASS | FAIL | PARTIAL
+```

--- a/skills/install-script-generator/SKILL.md
+++ b/skills/install-script-generator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: install-script-generator
-description: "Generate cross-platform installation scripts for any software, library, or module. Produces a standalone install.sh runnable via a single curl/wget one-liner, with automatic OS, architecture, and package manager detection. Don't use for authoring Dockerfiles, CI/CD pipelines, or one-off local shell scripts."
+description: "Generate cross-platform install scripts for any software or library — a standalone install.sh runnable via a curl/wget one-liner with OS, arch, and package manager detection. Don't use for Dockerfiles, CI/CD pipelines, or one-off shell scripts."
 license: MIT
 effort: high
 metadata:
-  version: 2.1.0
+  version: 2.2.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -35,6 +35,7 @@ Skip this skill for Dockerfiles, CI/CD pipelines, or one-off local shell scripts
 | `references/edge-cases.md` | When handling unusual OS/sudo/path scenarios and writing step reports |
 | `scripts/env_explorer.py` | Local environment probe (OS, arch, package managers, sudo) |
 | `scripts/plan_generator.py` | Generates `installation_plan.yaml` from env + target |
+| `scripts/executor.py` | Dry-runs `installation_plan.yaml` with rollback, before Phase 3 generation |
 | `scripts/doc_generator.py` | Renders user-facing `USAGE_GUIDE.md` |
 
 Do not inline these contents into the conversation; link to them. Keeping SKILL.md short preserves the context window for the actual install logic.
@@ -68,6 +69,7 @@ If the working tree is dirty, `git stash push -u -m pre-sync` first, sync, then 
 3. Plan a verification step for each phase.
 4. Plan rollback / cleanup on failure.
 5. Run `python3 scripts/plan_generator.py --target "<name>" --env-file env_info.json` to emit `installation_plan.yaml`.
+6. Run `python3 scripts/executor.py --plan installation_plan.yaml --dry-run` to verify the plan executes cleanly and rollback triggers correctly before Phase 3 generates `install.sh` from it.
 
 ### Phase 3 — Generation (primary output)
 

--- a/skills/landing-page-generator/SKILL.md
+++ b/skills/landing-page-generator/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate conversion-focused landing page copy with PAS, AIDA, or S
 license: MIT
 effort: high
 metadata:
-  version: 1.1.3
+  version: 1.1.4
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -167,18 +167,3 @@ Verify before delivering:
 - Unsupported proof is labeled `[proof needed]`; no fake claims are present.
 - Copy passes `references/anti-slop-rules.md`.
 - Final response includes A/B test ideas and conversion tips unless the user asked for a single section.
-
-## Output Quality Checklist
-
-Before delivering, confirm all copy:
-
-- Leads with value, not features
-- Addresses target audience pain points
-- Uses emotional and logical appeals
-- Has clear, compelling CTAs
-- Includes social proof elements
-- Handles objections proactively
-- Creates urgency only when justified
-- Is scannable and easy to read
-- Follows the chosen framework consistently
-- Passes the anti-slop rules

--- a/skills/logo-designer/SKILL.md
+++ b/skills/logo-designer/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate professional SVG logos from project context, producing 7 
 license: MIT
 effort: medium
 metadata:
-  version: 1.2.1
+  version: 1.2.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -167,8 +167,8 @@ Typography: Inter Bold for wordmark
 
 - **No project context found**: Ask the user for product name, product type, and one-sentence purpose before generating anything.
 - **Existing brand colors detected**: Use them instead of the default dark/neon-green palette; confirm with the user before proceeding.
-- **User does not specify wordmark casing**: Ask explicitly — do not assume README casing matches the desired logo stylization (e.g., "fastBuild" vs "FASTBUILD" vs "fastbuild").
-- **SVG geometry diverges across variants**: After writing all 7 files, read back mark, full, icon, white, and black variants and verify `d=""` path strings are identical (or correctly scaled); fix before finishing.
+- **User does not specify wordmark casing**: Ask explicitly before proceeding (see `references/design-principles.md` for the casing rule and examples).
+- **SVG geometry diverges across variants**: Re-run the Phase 3 verification step (read back and diff `d=""` strings) and fix before finishing.
 - **No git repository**: Skip the branch and sync steps; write directly to the current directory and note this in the summary.
 - **favicon.svg complexity**: At 16×16 the full mark is unreadable — always simplify to 2 layers (outer + inner) and drop the middle detail layer; preserve proportional geometry.
 - **User rejects the proposed style**: Iterate on Phase 2 (style selection) until the user approves before generating any SVG files.
@@ -194,7 +194,7 @@ See `references/step-reports.md` for the full report template, per-phase check l
 ## Notes
 
 - Always show logo previews on both light (#FAFAFA) and dark (#0A0A0A) backgrounds
-- Ask the user how they want the product name formatted in the wordmark before generating — do not assume README casing
+- Confirm wordmark casing before generating (see Phase 2 and Edge Cases)
 - If no project context is found, ask the user for: product name, type, and purpose
 - Prefer simplicity — a logo should be recognizable at 16x16 pixels
 - **Consistency is non-negotiable**: every variant must be visually recognizable as the same logo. The mark shape, number of layers, and accent elements must match across all files. The only things that change between variants are: color (monochrome), scale (favicon, icon), and presence of wordmark. If you cannot verify that paths match, the deliverable is incomplete.

--- a/skills/ollama-optimizer/SKILL.md
+++ b/skills/ollama-optimizer/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ollama-optimizer
-description: "Optimize Ollama configuration for the current machine's hardware. Use when asked to speed up Ollama, tune local LLM performance, or pick models that fit available GPU/RAM."
+description: "Optimize Ollama configuration for the current machine's hardware. Use when asked to speed up Ollama, tune local LLM performance, or pick models that fit available GPU/RAM. Don't use for LM Studio, llama.cpp, vLLM, or hosted-API LLM providers."
 license: MIT
 effort: medium
 metadata:
-  version: 1.0.4
+  version: 1.1.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -17,27 +17,6 @@ Optimize Ollama configuration based on system hardware analysis.
 Use this skill when the user asks to optimize Ollama, configure Ollama, speed up Ollama, fix Ollama running slow, set up a local LLM, tune inference speed, reduce memory usage, or select models that fit their GPU/RAM. The skill analyzes hardware (GPU, VRAM, RAM, CPU) and produces tailored recommendations.
 
 Do not use for LM Studio, llama.cpp, vLLM, or hosted-API LLM providers (OpenAI, Anthropic) — those use different runtimes and tuning surfaces.
-
-## Repo Sync Before Edits (mandatory)
-
-Before creating/updating/deleting files in an existing repository, sync the current branch with remote:
-
-```bash
-branch="$(git rev-parse --abbrev-ref HEAD)"
-git fetch origin
-git pull --rebase origin "$branch"
-```
-
-If the working tree is not clean, stash first, sync, then restore:
-
-```bash
-git stash push -u -m "pre-sync"
-branch="$(git rev-parse --abbrev-ref HEAD)"
-git fetch origin && git pull --rebase origin "$branch"
-git stash pop
-```
-
-If `origin` is missing, pull is unavailable, or rebase/stash conflicts occur, stop and ask the user before continuing.
 
 ## Workflow
 
@@ -260,27 +239,6 @@ Generate an `ollama-optimization-guide.md` file. Ask the user where to save it (
 <commands to revert changes if needed>
 ```
 
-## Quick Optimization Commands
+## Quick Optimization Commands (opt-in only)
 
-For users who want immediate results without full analysis:
-
-**macOS (Apple Silicon):**
-```bash
-export OLLAMA_FLASH_ATTENTION=1
-export OLLAMA_KV_CACHE_TYPE=q8_0
-ollama pull llama3.2:3b  # Safe for 8GB, fast
-```
-
-**Linux/Windows with 8GB NVIDIA GPU:**
-```bash
-export OLLAMA_FLASH_ATTENTION=1
-export OLLAMA_KV_CACHE_TYPE=q8_0
-ollama pull llama3.1:8b-instruct-q4_K_M
-```
-
-**CPU-only systems:**
-```bash
-export CUDA_VISIBLE_DEVICES=-1
-ollama pull llama3.2:3b
-# Create Modelfile with: PARAMETER num_thread 4
-```
+Only use this fast path if the user explicitly asks to skip full hardware analysis. Otherwise always run Phases 1-3 and follow the tier-based recommendation — do not apply these shortcuts by default, and do not let them override a tier decision already made. For the actual per-platform commands and env vars, see [Platform-Specific Setup](references/platform_specific.md) and [Environment Variables](references/environment_variables.md).

--- a/skills/opencode-runner/SKILL.md
+++ b/skills/opencode-runner/SKILL.md
@@ -4,7 +4,7 @@ description: "Run coding tasks via opencode using free cloud models. Use when as
 license: MIT
 effort: medium
 metadata:
-  version: 1.4.0
+  version: 1.4.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -279,14 +279,14 @@ See `references/expected-output.md` for the full set of example blocks the user 
 
 ## Edge Cases
 
-- **opencode not installed** — `which opencode` returns nothing. The skill prints installation instructions for three methods (curl, npm, brew) and stops. It does not attempt the coding task itself.
-- **opencode upgrade fails** — The upgrade command errors. The skill reports the failure, suggests running the command manually, and stops. It does not continue with a potentially broken binary.
-- **No free cloud models available** — `opencode models` output contains no `opencode/*` models with $0 or "Free" pricing. The skill informs the user that no free option is available and stops. It does not fall back to local models (ollama, lmstudio) or paid models.
-- **All priority free models tried and all fail** — After retrying with every model in the priority list, none produced usable output. The skill reports this, suggests the user check their opencode auth configuration (`opencode auth list`), and stops.
-- **Task timeout (>5 minutes with no output growth)** — The skill confirms with the user, kills the opencode process tree, suggests retrying with the next free model, and runs Phase 6 cleanup. It does not attempt the task itself.
-- **User rejects the Phase 3 confirmation** — If the user replies "no" / "change something" / edits the prompt or model, loop back to Phase 2 (model pick) or Phase 3 (re-show summary). Never invoke `opencode run` without explicit confirmation.
-- **User has an interactive opencode TUI session open** — The cleanup step detects running opencode processes. The skill kills only `opencode run` child processes, leaving the interactive TUI (`opencode` without a subcommand) untouched.
-- **Task prompt contains multi-line content or file references** — Use the `--file` flag to pass context files separately, keeping the command-line prompt concise and avoiding shell escaping issues.
+- **opencode not installed** — see Phase 1, Step 1 (install instructions, then stop).
+- **opencode upgrade fails** — see Phase 1, Step 2 (report and stop, don't continue on a broken binary).
+- **No free cloud models available** — see Phase 2, Selection logic step 6 (inform user, stop; no fallback to local/paid models).
+- **All priority free models tried and all fail** — see Phase 5, "On error, stall, or timeout" (suggest `opencode auth list`, stop).
+- **Task timeout (>5 minutes with no output growth)** — see Phase 5, Cadence and "On error, stall, or timeout" (confirm, kill, retry suggestion, Phase 6 cleanup).
+- **User rejects the Phase 3 confirmation** — see Phase 3, final paragraph (loop back to Phase 2 or 3; never invoke `opencode run` unconfirmed).
+- **User has an interactive opencode TUI session open** — see Phase 6, Step 2 (kill only `opencode run` children, leave the TUI alone).
+- **Task prompt contains multi-line content or file references** — see Phase 4, "Handling multi-line or complex prompts" (use `--file`).
 - **opencode produces output but exits non-zero** — Report the exit code and last lines of output to the user, run cleanup, and suggest verifying the task result manually before relying on it.
 
 ---

--- a/skills/oss-ready/SKILL.md
+++ b/skills/oss-ready/SKILL.md
@@ -4,7 +4,7 @@ description: "Transform a project into a professional open-source repository by 
 license: MIT
 effort: low
 metadata:
-  version: 1.2.0
+  version: 1.2.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -33,6 +33,8 @@ git stash pop
 If `origin` is missing, pull is unavailable, or rebase/stash conflicts occur, stop and ask the user before continuing.
 
 ## Workflow
+
+> Before proceeding, check **Edge Cases** below for a non-MIT LICENSE, a monorepo, no detectable language, a private/internal repo, or a dirty/detached HEAD — handle the matching case first if it applies.
 
 ### 0. Create Feature Branch
 
@@ -144,49 +146,10 @@ Adapt the check names to match what the step actually validates. Use `√` for p
   Result:                  PASS
 ```
 
-### Core Files (step 2 of 4)
-
-```
-◆ Core Files (step 2 of 4 — community standards)
-··································································
-  README created:          √ pass — enhanced with badges, examples
-  LICENSE added:           √ pass — MIT from assets/LICENSE-MIT
-  CONTRIBUTING written:    √ pass — branching strategy included
-  CODE_OF_CONDUCT added:   × fail — assets/CODE_OF_CONDUCT.md missing
-  [Criteria]:              √ 3/4 met
-  ____________________________
-  Result:                  PARTIAL
-```
-
-### GitHub Setup (step 3 of 4)
-
-```
-◆ GitHub Setup (step 3 of 4 — issue and PR templates)
-··································································
-  Issue templates created: √ pass — bug_report.md, feature_request.md
-  PR template created:     √ pass — PULL_REQUEST_TEMPLATE.md
-  [Criteria]:              √ 2/2 met
-  ____________________________
-  Result:                  PASS
-```
-
-### Documentation (step 4 of 4)
-
-```
-◆ Documentation (step 4 of 4 — docs structure)
-··································································
-  ARCHITECTURE written:    √ pass — system components documented
-  CHANGELOG created:       √ pass — version history initialized
-  Metadata updated:        √ pass — package.json keywords, license, repo
-  [Criteria]:              √ 3/3 met
-  ____________________________
-  Result:                  PASS
-```
+Repeat this format for each subsequent step (Core Files, GitHub Setup, Documentation), adapting the check names to what that step actually validates.
 
 ## Guidelines
 
-- Preserve existing content - enhance, don't replace
-- Use professional, welcoming tone
 - Adapt to project's actual tech stack
 - Include working examples from the actual codebase
 

--- a/skills/prd-generator/SKILL.md
+++ b/skills/prd-generator/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate Product Requirements Documents from `idea.md` and `valida
 license: MIT
 effort: max
 metadata:
-  version: 1.3.1
+  version: 1.3.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -47,6 +47,8 @@ If path is not provided (auto-pick mode):
 6. If multiple candidates are plausible, ask user to choose.
 
 ## Workflow
+
+**Mode selection (decide before Phase 1):** If `PROJECT_DIR/prd.md` already exists and the user wants changes to it, this is a **modify** run — do Phase 1's steps 1-4 (including the mandatory backup), then skip to `## Modification Mode` below instead of Phases 2-5. Otherwise this is a **create** run — proceed through Phases 1-5 in order. Both modes share Phase 1's backup step; see `## Modification Mode` for modify-run detail.
 
 ### Phase 1: Validate Input
 
@@ -125,7 +127,7 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 **Phase 1 — Validate Input**
 ```
-◆ Validate Input (step 1 of 5 — input resolution)
+◆ Validate Input (step 1 of 7 — input resolution)
 ··································································
   Input files found:        √ pass
   Dependencies resolved:    √ pass (PROJECT_DIR confirmed)
@@ -136,7 +138,7 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 **Phase 2 — Extract Context**
 ```
-◆ Extract Context (step 2 of 5 — context extraction)
+◆ Extract Context (step 2 of 7 — context extraction)
 ··································································
   idea.md parsed:           √ pass (concept + technical context read)
   validate.md parsed:       √ pass (verdict + ratings extracted)
@@ -147,7 +149,7 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 **Phase 3 — Clarify Requirements**
 ```
-◆ Clarify Requirements (step 3 of 5 — requirements gathering)
+◆ Clarify Requirements (step 3 of 7 — requirements gathering)
 ··································································
   Questions answered:       √ pass
   Scope defined:            √ pass (MVP timeframe confirmed)
@@ -158,7 +160,7 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 **Phase 4 — Generate PRD**
 ```
-◆ Generate PRD (step 4 of 5 — document generation)
+◆ Generate PRD (step 4 of 7 — document generation)
 ··································································
   10 sections written:      √ pass
   prd.md created:           √ pass
@@ -169,7 +171,7 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 
 **Phase 5 — Output**
 ```
-◆ Output (step 5 of 5 — delivery)
+◆ Output (step 5 of 7 — delivery)
 ··································································
   File written:             √ pass
   Summary presented:        √ pass
@@ -206,11 +208,10 @@ Link format (derive `<owner>/<repo>` from `git remote get-url origin`):
 
 ## Modification Mode
 
-If user wants to modify existing PRD:
-1. Create timestamped backup
-2. Ask what to modify (features, priorities, timeline, specs, personas)
-3. Apply changes preserving structure
-4. Update revision history
+Entered per the Mode selection note above, once Phase 1's backup (`prd.backup.YYYYMMDD_HHMMSS.md`) already exists:
+1. Ask what to modify (features, priorities, timeline, specs, personas)
+2. Apply changes preserving structure
+3. Update revision history
 
 ## Guidelines
 
@@ -250,4 +251,4 @@ Handle missing inputs, verdict=REJECT, conflicting requirements, existing PRDs (
 
 ## Verification Steps
 
-After generation, verify file exists, has >=10 `^## ` headings, >=1 mermaid block, >=1 `Given/When/Then` line, >=4 MoSCoW labels, cites `idea.md`, and (if applicable) a `prd.backup.*.md` sibling exists. See `references/verification-steps.md` for the exact shell checks.
+Run the grep-backed thresholds listed under `## Acceptance Criteria` above (heading count, mermaid block, Given/When/Then, MoSCoW count, idea.md citation, backup sibling). See `references/verification-steps.md` for the exact shell commands to run each check.

--- a/skills/readme-to-landing-page/SKILL.md
+++ b/skills/readme-to-landing-page/SKILL.md
@@ -4,7 +4,7 @@ description: "Transform a project README.md into a conversion-optimized landing 
 license: MIT
 effort: high
 metadata:
-  version: 2.1.0
+  version: 2.1.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -42,6 +42,8 @@ If the working tree is dirty: `git stash push -u -m "pre-sync"`, sync, then `git
 If `origin` is missing or conflicts occur, stop and ask the user.
 
 ## Workflow
+
+If no `README.md` exists, or the existing one is already marketing-style, see **Edge Cases** below before starting Step 1 — a different mode applies.
 
 ### Step 1: Gather Context
 
@@ -172,16 +174,8 @@ Original content is preserved in `README.backup.md` and in `<details>` blocks at
 
 - [ ] Original README backed up to `README.backup.md` before any rewrite
 - [ ] Rewritten README uses one of PAS, AIDA, or StoryBrand and names which one was chosen
-- [ ] H1 is the value proposition (<=10 words), not the project name
-- [ ] At least one mermaid diagram shows how the project works
-- [ ] Hero section is <=5 lines (excluding badges)
-- [ ] Each feature description is <=15 words
-- [ ] Quick Start has <=5 steps; each independently-runnable command in its own code block
-- [ ] No banned slop phrases appear in the output
-- [ ] All original technical content preserved in `<details>` blocks
-- [ ] No fabricated data — real numbers or `[placeholder]` markers only
-- [ ] Zero emoji in the output
-- [ ] Self-review checklist (13 checks) passes before presenting
+- [ ] H1 follows the value-proposition rule (see Step 5)
+- [ ] Step 6 Self-Review Checklist (13 checks) passes before presenting
 
 ## Step Completion Reports
 
@@ -192,13 +186,7 @@ After each major step, output a status report. See `references/step-reports.md` 
 - **One code block per copy-paste unit.** Commands that can run independently must be in separate code blocks. Only combine commands that must run together.
 - **Never fabricate data.** Use real numbers or leave `[placeholder]` markers.
 - **Respect the project's voice.** A security tool != a startup pitch.
-- **H1 = value proposition**, not the project name.
+- **H1 follows the value-proposition rule** (see Step 5).
 - **Preserve all original content** in collapsed sections.
 - **One primary audience.** Don't try to speak to everyone.
 - **When in doubt, cut text.** A shorter README that gets read beats a longer one that doesn't.
-
-## Error Handling
-
-- **No README.md found** -> Offer to create from scratch using project files.
-- **Already marketing-style** -> Offer targeted refinements, not full rewrite.
-- **Insufficient context** -> Ask: what it does, who it's for, what problem it solves.

--- a/skills/release-manager/SKILL.md
+++ b/skills/release-manager/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: release-manager
-description: "Manage software releases end-to-end: bump version, generate changelog, tag, push, GitHub release, publish to PyPI/npm. Use when user asks to ship, cut a release, tag a version, or list changes since last tag. Skip routine commits and marketplace publishing."
+description: "Manage software releases end-to-end: bump version, generate changelog, tag, push, GitHub release, publish to PyPI/npm. Use when asked to ship, cut a release, or tag a version. Don't use for routine commits or marketplace publishing."
 license: MIT
 effort: max
 metadata:
-  version: 2.5.0
+  version: 2.6.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -38,9 +38,32 @@ A release typically involves these steps in order. Walk through each, confirming
 - Local branch synced with `origin` (see `references/orchestration.md` for sync commands)
 - For publishing: PyPI/npm credentials configured; for GitHub release: `gh` CLI authenticated
 
+## Repo Sync Before Edits (mandatory)
+
+Before creating/updating/deleting files in an existing repository, sync the current branch with remote:
+
+```bash
+branch="$(git rev-parse --abbrev-ref HEAD)"
+git fetch origin
+git pull --rebase origin "$branch"
+```
+
+If the working tree is not clean, stash first, sync, then restore:
+
+```bash
+git stash push -u -m "pre-sync"
+branch="$(git rev-parse --abbrev-ref HEAD)"
+git fetch origin && git pull --rebase origin "$branch"
+git stash pop
+```
+
+If `origin` is missing, pull is unavailable, or rebase/stash conflicts occur, stop and ask the user before continuing.
+
 ---
 
 ## Step 1: Pre-flight Checks (inline)
+
+> If an existing release tool (`.changeset`, `.releaserc`, semantic-release config, etc.) is detected, defer to it instead of running the manual steps below — see "Check for existing release tools" further down in this step.
 
 Verify the repo is in a clean state:
 
@@ -113,7 +136,7 @@ git commit -m "chore(release): vX.Y.Z"
 git tag -a vX.Y.Z -m "Release vX.Y.Z"
 ```
 
-Confirm before pushing — this is a visible action:
+Confirm before pushing (see Acceptance Criteria):
 
 ```bash
 git push origin <branch>
@@ -203,7 +226,7 @@ Remind the user about common follow-ups:
 
 ## Tips
 
-- Always confirm destructive or visible actions (push, release creation)
+- Confirmation gate for destructive/visible actions: see Acceptance Criteria
 - For monorepos, handle each package's version independently
 - Respect the existing CHANGELOG format — only add the new entry, don't reformat
 - If a release goes wrong mid-way, help the user roll back: delete the tag locally and remotely, revert the commit

--- a/skills/release-manager/references/orchestration.md
+++ b/skills/release-manager/references/orchestration.md
@@ -29,24 +29,7 @@ If the Agent tool is not available (e.g., Claude.ai), execute steps 3-6 inline i
 
 ## Repo Sync Before Edits (mandatory)
 
-Before creating/updating/deleting files in an existing repository, sync the current branch with remote:
-
-```bash
-branch="$(git rev-parse --abbrev-ref HEAD)"
-git fetch origin
-git pull --rebase origin "$branch"
-```
-
-If the working tree is not clean, stash first, sync, then restore:
-
-```bash
-git stash push -u -m "pre-sync"
-branch="$(git rev-parse --abbrev-ref HEAD)"
-git fetch origin && git pull --rebase origin "$branch"
-git stash pop
-```
-
-If `origin` is missing, pull is unavailable, or rebase/stash conflicts occur, stop and ask the user before continuing.
+See the "Repo Sync Before Edits (mandatory)" section in `SKILL.md` for the required sync commands. Run them before Steps 3-6 touch any files.
 
 ## Steps 3-6: Parallel Subagent Execution
 

--- a/skills/security-setup/SKILL.md
+++ b/skills/security-setup/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Cross-platform (macOS, Linux, Windows). Requires git, Python 3.8+, and project write access. Uses pre-commit plus free local tools such as gitleaks, trivy, semgrep, bandit, or cargo-audit when appropriate. Semgrep on Windows requires WSL2."
 effort: high
 metadata:
-  version: 1.3.3
+  version: 1.4.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -17,6 +17,11 @@ summary before code leaves their machine.
 
 Keep the orchestrator short for the agent's context budget: detailed matrices, templates,
 and long verification scenarios live in `references/`. Link, don't inline.
+
+This skill may trigger automatically per its description, but it never writes
+silently: Phase 1 always dry-runs the planned changes and waits for explicit
+user confirmation before touching files, and Phase 2 (CI) only runs when the
+user explicitly asks for it (e.g. `--ci`).
 
 ## Prerequisites
 
@@ -256,36 +261,8 @@ pre-commit install
 
 #### Expected output
 
-A successful first run prints a summary to stdout and exits 0. Verify the
-output matches this shape (exact counts vary):
-
-```text
-Security Check Summary
-======================
-Mode: full
-Checks run: 3 of 3 (skipped: 0)
-Findings: 1
-Severity: HIGH=1
-Categories: dependencies=1
-JSON report: security/security-report.json
-Markdown report: security/security-report.md
-
-Top findings:
-- HIGH [dependencies/trivy] CVE-XXXX-XXXX in <pkg> (<lockfile>)
-  Hint: Upgrade to <version>.
-```
-
-A scoped run on a docs-only commit looks like:
-
-```text
-Mode: staged
-Staged files: 2
-Checks run: 1 of 3 (skipped: 2)
-Skipped: trivy, semgrep
-```
-
-Skipped checks are recorded in both reports with their scope reason — they
-are not silent.
+A successful first run prints a summary to stdout and exits 0. See
+"Report Requirements" below for the exact shape and content of that summary.
 
 Assert: a clean run exits 0, both report paths exist, and
 `security-report.json` parses as valid JSON with a top-level `summary`
@@ -325,6 +302,36 @@ The local runner must print a concise report with:
 The default exit behavior is strict: any `HIGH` or `CRITICAL` finding exits
 non-zero.
 
+A successful full run looks like this (exact counts vary):
+
+```text
+Security Check Summary
+======================
+Mode: full
+Checks run: 3 of 3 (skipped: 0)
+Findings: 1
+Severity: HIGH=1
+Categories: dependencies=1
+JSON report: security/security-report.json
+Markdown report: security/security-report.md
+
+Top findings:
+- HIGH [dependencies/trivy] CVE-XXXX-XXXX in <pkg> (<lockfile>)
+  Hint: Upgrade to <version>.
+```
+
+A scoped run on a docs-only commit looks like:
+
+```text
+Mode: staged
+Staged files: 2
+Checks run: 1 of 3 (skipped: 2)
+Skipped: trivy, semgrep
+```
+
+Skipped checks are recorded in both reports with their scope reason — they
+are not silent.
+
 ## Acceptance Criteria
 
 A completed setup passes when:
@@ -338,25 +345,8 @@ A completed setup passes when:
 - [ ] `SECURITY.md` documents selected tools, omissions, run commands, and CI
       status.
 - [ ] `--ci` creates `.github/workflows/security.yml` only after Phase 1 passes.
-
-### File-aware scoping (no-blindspot scenarios)
-
-Walk through these manually after install. Each one is a real failure mode
-naive scoping creates:
-
-1. **Docs-only with leaked key.** Stage a `README.md` containing a synthetic
-   `AKIA…` AWS key. Hook fails HIGH (gitleaks ran).
-2. **Docs-only clean.** Stage a `README.md` with no secrets. Exit 0;
-   `trivy`/`semgrep`/`bandit` reported as skipped with reason; runtime is
-   measurably faster than `--all`.
-3. **Lockfile change.** Stage `package-lock.json`. `trivy` runs.
-4. **Source code with anti-pattern.** Stage a `.py` file containing
-   `eval(user_input)`. `semgrep` and `bandit` run; exit non-zero.
-5. **Workflow tampering.** Stage `.github/workflows/foo.yml` with
-   `${{ github.event.issue.title }}` interpolated into a `run:` step. The
-   trip-all rule fires; `semgrep` runs.
-6. **Full scan.** `python3 scripts/security_check.py --all` behaves like
-   pre-1.3.0 (every configured check executes).
+- [ ] File-aware scoping has been walked through manually against the
+      no-blindspot scenarios in `references/verification-scenarios.md`.
 
 ## Edge Cases
 
@@ -391,4 +381,5 @@ After each phase, report:
 
 - `references/tool-selection.md` - offline-first tool matrix and install notes
 - `references/templates.md` - target repo file templates
+- `references/verification-scenarios.md` - no-blindspot manual verification scenarios
 - `scripts/security_check.py` - reusable local security summary runner

--- a/skills/security-setup/references/verification-scenarios.md
+++ b/skills/security-setup/references/verification-scenarios.md
@@ -1,0 +1,18 @@
+# File-Aware Scoping — No-Blindspot Verification Scenarios
+
+Walk through these manually after install. Each one is a real failure mode
+naive scoping creates.
+
+1. **Docs-only with leaked key.** Stage a `README.md` containing a synthetic
+   `AKIA…` AWS key. Hook fails HIGH (gitleaks ran).
+2. **Docs-only clean.** Stage a `README.md` with no secrets. Exit 0;
+   `trivy`/`semgrep`/`bandit` reported as skipped with reason; runtime is
+   measurably faster than `--all`.
+3. **Lockfile change.** Stage `package-lock.json`. `trivy` runs.
+4. **Source code with anti-pattern.** Stage a `.py` file containing
+   `eval(user_input)`. `semgrep` and `bandit` run; exit non-zero.
+5. **Workflow tampering.** Stage `.github/workflows/foo.yml` with
+   `${{ github.event.issue.title }}` interpolated into a `run:` step. The
+   trip-all rule fires; `semgrep` runs.
+6. **Full scan.** `python3 scripts/security_check.py --all` behaves like
+   pre-1.3.0 (every configured check executes).

--- a/skills/seo-ai-optimizer/SKILL.md
+++ b/skills/seo-ai-optimizer/SKILL.md
@@ -4,7 +4,7 @@ description: "Audit and optimize websites for technical SEO, content SEO, and AI
 license: MIT
 effort: high
 metadata:
-  version: 1.2.0
+  version: 1.2.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -128,7 +128,7 @@ After each step, emit a `◆` status block. For templates and per-step check lis
 
 ## Acceptance Criteria
 
-A run passes when the audit report is complete, the improvement plan was user-approved, the **Safety Protocol (diff + confirmation) was followed**, and validation shows critical issues are resolved.
+See the itemized checklist in `references/workflow-detail.md` (Acceptance Criteria) — a run only passes when every item there is checked.
 
 ## Expected Output
 

--- a/skills/slop-cleanup/SKILL.md
+++ b/skills/slop-cleanup/SKILL.md
@@ -4,8 +4,8 @@ description: "Refactor a codebase to remove AI slop, dead code, weak types, dupl
 license: MIT
 effort: high
 metadata:
-  version: 1.1.1
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.1.2
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
   architecture: "subagent (Pattern B: Parallel Workers, 8 specialized cleaners)"
 ---
 

--- a/skills/subagent-creator/SKILL.md
+++ b/skills/subagent-creator/SKILL.md
@@ -3,7 +3,7 @@ name: subagent-creator
 description: "Create, evaluate, or improve Claude Code subagent files (.claude/agents/*.md) — the frontmatter + system prompt defining a delegatable specialist. Don't use for skills (skill-creator), CLAUDE.md/AGENTS.md (agent-config), or running an agent."
 effort: high
 metadata:
-  version: 1.1.1
+  version: 1.1.2
   author: "Luong NGUYEN <edgardo.montesdeoca@montimage.eu>"
 ---
 
@@ -140,14 +140,6 @@ Goal: apply concrete fixes to an existing file and leave it measurably better.
 5. Emit a Step Completion Report showing each prior `× fail` now `√ pass`.
 
 ---
-
-## Final summary
-
-Close any create/evaluate/improve run with three short lists:
-
-- **Checked** — rubric categories inspected (frontmatter, responsibility, tools, description, body structure, anti-patterns).
-- **Verified** — what proves the result (frontmatter parses, file path written, rubric pass).
-- **Improved** — concrete changes by field/concern (or `none — review only` for an Evaluate run).
 
 ## Acceptance Criteria
 

--- a/skills/tad-generator/SKILL.md
+++ b/skills/tad-generator/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: tad-generator
-description: "Generate a Technical Architecture Document (TAD) from a PRD. Use when asked to design the architecture, create a TAD, or define how a product is built. Creates/updates tad.md and reports GitHub links. Skip PRD authoring, sprint-tasks, or code implementation."
+description: "Generate a Technical Architecture Document (TAD) from a PRD. Use when asked to design system architecture or define how a product is built. Updates tad.md and reports GitHub links. Don't use for PRD authoring, sprint tasks, or code implementation."
 license: MIT
 effort: max
 metadata:
-  version: 1.3.0
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.4.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # TAD Generator
@@ -78,6 +78,8 @@ Project folder path in `$ARGUMENTS` containing:
 
 ## Workflow
 
+**Mode check (do this first):** if `tad.md` already exists in the project folder, this is a **Modification** run — skip straight to [Modification Mode](#modification-mode). Otherwise it's a **Create** run — continue through Phases 1-8 below.
+
 ### Phase 1: Setup & Validation
 
 1. Verify `prd.md` exists
@@ -108,12 +110,7 @@ Ask user (if not clear):
 
 ### Phase 4: Research & Validation
 
-Conduct 5 research rounds:
-1. **Technology Stack**: Validate choices against industry standards
-2. **Infrastructure**: Compare hosting for cost and scalability
-3. **Security**: Review OWASP guidelines for chosen stack
-4. **Risk Assessment**: Identify bottlenecks, vendor lock-in
-5. **Holistic Review**: Ensure PRD alignment and startup feasibility
+Conduct the [5 research rounds](#research-rounds-5-parallel) defined under Subagent Architecture above.
 
 ### Phase 5: Generate TAD
 
@@ -185,51 +182,7 @@ After completing each major step, output a status report in this format:
 
 Adapt the check names to match what the step actually validates. Use `√` for pass, `×` for fail, and `—` to add brief context. The "Criteria" line summarizes how many acceptance criteria were met. The "Result" line gives the overall verdict.
 
-### Phase-specific checks
-
-**Phase 1 — Setup**
-```
-◆ Setup (step 1 of 8 — environment validation)
-··································································
-  PRD found:                    √ pass
-  Context extracted:            √ pass (product + features + NFRs read)
-  Architecture questions answered: √ pass (deployment, DB, auth, budget confirmed)
-  ____________________________
-  Result:             PASS | FAIL | PARTIAL
-```
-
-**Phase 4 — Research**
-```
-◆ Research (step 4 of 8 — validation rounds)
-··································································
-  5 parallel rounds completed:  √ pass
-  Best practices gathered:      √ pass (tech, infra, security, risk, holistic)
-  Patterns validated:           √ pass (OWASP, vendor lock-in, startup feasibility)
-  ____________________________
-  Result:             PASS | FAIL | PARTIAL
-```
-
-**Phase 5 — Generation**
-```
-◆ Generation (step 5 of 8 — TAD authoring)
-··································································
-  11 sections written:          √ pass
-  tad.md created:               √ pass
-  Diagrams included:            √ pass (mermaid architecture + flow diagrams)
-  ____________________________
-  Result:             PASS | FAIL | PARTIAL
-```
-
-**Phase 8 — Output**
-```
-◆ Output (step 8 of 8 — delivery)
-··································································
-  Summary presented:            √ pass (architecture decisions highlighted)
-  README updated:               √ pass (TAD status ✅)
-  Committed and pushed:         √ pass (commit hash: ...)
-  ____________________________
-  Result:             PASS | FAIL | PARTIAL
-```
+See [references/step-completion-reports.md](references/step-completion-reports.md) for worked examples per phase (Setup, Research, Generation, Output).
 
 ## Acceptance Criteria
 
@@ -292,11 +245,12 @@ graph TD
 
 ## Modification Mode
 
-For existing TAD changes:
-1. Create timestamped backup
-2. Ask what to modify (stack, infrastructure, security, data, scaling)
-3. Apply changes preserving structure
-4. Update revision history
+Triggered by the mode check above when `tad.md` already exists.
+
+1. Create a timestamped backup (`tad.md.bak.<timestamp>`).
+2. Ask which area changed — Stack | Infrastructure | Security | Data | Scaling — and map the answer to its matching numbered section in [Phase 5](#phase-5-generate-tad).
+3. Apply changes to that section only, preserving the rest of the structure.
+4. Append a revision-history entry (date + summary) at the end of `tad.md`.
 
 ## Guidelines
 

--- a/skills/tad-generator/docs/README.md
+++ b/skills/tad-generator/docs/README.md
@@ -5,7 +5,7 @@
   If you're an AI agent, read the SKILL.md file instead for skill instructions.
 -->
 
-# System Design
+# TAD Generator
 
 > Generate Technical Architecture Documents (TAD) from PRD files with modular, startup-appropriate design.
 

--- a/skills/tad-generator/references/step-completion-reports.md
+++ b/skills/tad-generator/references/step-completion-reports.md
@@ -1,0 +1,47 @@
+# Phase-specific Step Completion Reports
+
+Worked examples of the generic template (see SKILL.md → Step Completion Reports) applied to specific phases. Use these as a model when adapting check names to a phase's actual validations.
+
+**Phase 1 — Setup**
+```
+◆ Setup (step 1 of 8 — environment validation)
+··································································
+  PRD found:                    √ pass
+  Context extracted:            √ pass (product + features + NFRs read)
+  Architecture questions answered: √ pass (deployment, DB, auth, budget confirmed)
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```
+
+**Phase 4 — Research**
+```
+◆ Research (step 4 of 8 — validation rounds)
+··································································
+  5 parallel rounds completed:  √ pass
+  Best practices gathered:      √ pass (tech, infra, security, risk, holistic)
+  Patterns validated:           √ pass (OWASP, vendor lock-in, startup feasibility)
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```
+
+**Phase 5 — Generation**
+```
+◆ Generation (step 5 of 8 — TAD authoring)
+··································································
+  11 sections written:          √ pass
+  tad.md created:               √ pass
+  Diagrams included:            √ pass (mermaid architecture + flow diagrams)
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```
+
+**Phase 8 — Output**
+```
+◆ Output (step 8 of 8 — delivery)
+··································································
+  Summary presented:            √ pass (architecture decisions highlighted)
+  README updated:               √ pass (TAD status ✅)
+  Committed and pushed:         √ pass (commit hash: ...)
+  ____________________________
+  Result:             PASS | FAIL | PARTIAL
+```

--- a/skills/tasks-generator/SKILL.md
+++ b/skills/tasks-generator/SKILL.md
@@ -4,8 +4,8 @@ description: "Generate development tasks from a PRD file with sprint-based plann
 license: MIT
 effort: max
 metadata:
-  version: 1.2.1
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.3.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Tasks Generator
@@ -74,6 +74,13 @@ git stash pop
 
 If `origin` is missing, pull is unavailable, or rebase/stash conflicts occur, stop and ask the user before continuing.
 
+## Modes (check before running)
+
+- **Input resolution**: `$ARGUMENTS` present → use it directly; empty → auto-pick (see [Input](#input) below).
+- **Repo state**: dirty working tree → stash before sync (see [Repo Sync](#repo-sync-before-edits-mandatory)); no `origin` → stop and ask.
+- **Existing `tasks.md`**: back it up before regenerating (see [Pre-checks](#pre-checks)).
+- **README update**: only if the PRD lives inside an `ideas` repo (see [README Maintenance](#readme-maintenance-ideas-repo-only)) — skip otherwise.
+
 ## Input
 
 Preferred: PRD file path provided in `$ARGUMENTS`.
@@ -131,8 +138,8 @@ From PRD, extract:
 
 1. **Map Dependencies**: For each task, identify "Depends On" and "Blocks"
 2. **Group Parallel Tasks**: Assign tasks to execution waves
-3. **Calculate Critical Path**: Longest dependency chain = minimum duration
-4. **Validate**: Check for circular dependencies, broken references
+3. **Calculate Critical Path** — the longest dependency chain; it sets the minimum duration. Referred to as "critical path" everywhere below.
+4. **Validate**: reject **circular dependencies** (the dependency graph must be a DAG — no cycles) and broken references
 
 ### Phase 5: Generate tasks.md
 
@@ -174,7 +181,7 @@ Before finalizing:
 - [ ] All tasks in dependency table
 - [ ] Critical path identified
 
-## README Maintenance (ideas repo)
+## README Maintenance (ideas repo only)
 
 After writing `tasks.md`, if the PRD lives inside an `ideas` repo, update the repo README ideas table:
 - Preferred: `cd` to the repo root and run `python3 scripts/update_readme_ideas_index.py` (if it exists)
@@ -246,7 +253,7 @@ The skill run is considered successful only if ALL of the following hold:
 - [ ] Every task includes ALL of: `Description`, `Acceptance Criteria` (>=2 testable items), `Dependencies` (explicit `None` or task IDs), `PRD Reference`, and an effort estimate (e.g., `Effort: 1-3 days` or `S/M/L`).
 - [ ] Every task ID follows the `Task <sprint>.<index>` pattern (e.g., `Task 1.1`, `Task 2.3`).
 - [ ] A dependency table is present and references only tasks that exist in the file (no broken IDs).
-- [ ] No circular dependencies (dependency graph is a DAG).
+- [ ] No circular dependencies (see Phase 4).
 - [ ] At least one task per PRD requirement; ambiguous PRD items are flagged in a dedicated section.
 - [ ] Critical path is identified and stated explicitly.
 - [ ] If a prior `tasks.md` existed, a `tasks_backup_YYYY_MM_DD_HHMMSS.md` file is created.

--- a/skills/test-coverage/SKILL.md
+++ b/skills/test-coverage/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate unit tests for untested branches and edge cases. Use when
 license: MIT
 effort: low
 metadata:
-  version: 1.2.3
+  version: 1.3.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -19,15 +19,18 @@ Expand unit test coverage by targeting untested branches and edge cases.
 - A code review flags untested error paths or boundary conditions
 - The user wants to identify and fill gaps in an existing test suite before a release
 
-## Instructions
+## Stack (detect before Step 1 of Workflow)
 
-1. Sync the branch with remote (see Repo Sync section below)
-2. Create a feature branch for the new tests
-3. Run the project's coverage tool to get a baseline report
-4. Identify the lowest-coverage files and untested code paths
-5. Write tests for error paths, boundary values, and missing branches
-6. Re-run coverage to confirm improvement
-7. Commit the new tests with a descriptive message
+Detect the project's language from its manifest file and use the matching commands throughout the Workflow below:
+
+| Manifest | Stack | Coverage command | Test framework |
+|---|---|---|---|
+| `package.json` | JavaScript/TypeScript | `npx jest --coverage` or `npx vitest --coverage` | Jest, Vitest, Mocha |
+| `pyproject.toml` | Python | `pytest --cov=. --cov-report=term-missing` | pytest, unittest |
+| `go.mod` | Go | `go test -coverprofile=coverage.out ./...` | testing, testify |
+| `Cargo.toml` | Rust | `cargo tarpaulin` or `cargo llvm-cov` | built-in test framework |
+
+If none of these manifests is found, see [Edge Cases](#edge-cases) — "No test framework detected".
 
 ## Repo Sync Before Edits (mandatory)
 Before creating/updating/deleting files in an existing repository, sync the current branch with remote:
@@ -60,11 +63,7 @@ Before making any changes:
 
 ### 1. Analyze Coverage
 
-Detect the project's test runner and run the coverage report:
-- **JavaScript/TypeScript**: `npx jest --coverage` or `npx vitest --coverage`
-- **Python**: `pytest --cov=. --cov-report=term-missing`
-- **Go**: `go test -coverprofile=coverage.out ./...`
-- **Rust**: `cargo tarpaulin` or `cargo llvm-cov`
+Run the coverage command for the detected [Stack](#stack-detect-before-step-1-of-workflow) above.
 
 From the report, identify:
 - Untested branches and code paths
@@ -82,11 +81,7 @@ Review code for:
 
 ### 3. Write Tests
 
-Use project's testing framework:
-- **JavaScript/TypeScript**: Jest, Vitest, Mocha
-- **Python**: pytest, unittest
-- **Go**: testing, testify
-- **Rust**: built-in test framework
+Use the test framework for the detected [Stack](#stack-detect-before-step-1-of-workflow) above.
 
 Target scenarios:
 - Error handling and exceptions
@@ -162,17 +157,6 @@ Adapt the check names to match what the step actually validates. Use `√` for p
 **Test Writing phase checks:** `Tests written`, `Edge cases covered`, `Framework conventions followed`
 
 **Verification phase checks:** `Tests pass`, `Coverage improved`, `No regressions`
-
-## Error Handling
-
-### No test framework detected
-**Solution:** Check `package.json`, `pyproject.toml`, `Cargo.toml`, or `go.mod` for test dependencies. If none found, ask the user which framework to use and install it.
-
-### Coverage tool not installed
-**Solution:** Install the appropriate coverage tool (`nyc`, `pytest-cov`, etc.) and retry.
-
-### Existing tests failing
-**Solution:** Do not add new tests until existing failures are resolved. Report failing tests to the user first.
 
 ## Guidelines
 

--- a/skills/tmux-agent-comms/SKILL.md
+++ b/skills/tmux-agent-comms/SKILL.md
@@ -4,94 +4,79 @@ description: "Manage AI agents in tmux: spawn or kill sessions and message any C
 license: MIT
 effort: medium
 metadata:
-  version: 1.5.2
+  version: 1.7.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Tmux Agent Comms
 
-Manage and talk to AI agents (another Claude Code, Gemini CLI, or any CLI) running in separate tmux sessions. Covers the full loop: **create** sessions, **send** messages, **wait** for the agent to finish, **capture** replies, and **tear down** when done.
+Manage and talk to AI agents (another Claude Code, Gemini CLI, or any CLI) running in separate tmux sessions: **create** sessions, **send** messages, **wait** for the agent to finish, **capture** replies, and **tear down** when done.
 
-The mental model: each tmux session is one agent. You orchestrate from outside by writing to its input and reading its pane — what a human does by switching windows, but scripted. Because your context budget is finite, relay each agent's answer, not its whole screen (the bundled helper extracts just the reply).
+Mental model: each tmux session is one agent. You orchestrate from outside by writing to its input and reading its pane — what a human does by switching windows, but scripted. Your context budget is finite, so relay each agent's answer, not its whole screen (the bundled helper extracts just the reply delta).
 
 ## When to Use
 
-Use this when the user wants to launch agents in tmux, message an agent running in another session, broadcast to a fleet, or read what an agent replied. Don't use it for SSH/remote shells, GNU `screen`, or driving a GUI app.
+Launching agents in tmux, messaging an agent in another session, broadcasting to a fleet, or reading what an agent replied. Don't use for SSH/remote shells, GNU `screen`, or driving a GUI app.
 
 ## Workflow
 
-Quick start: the six phases below run in order — discover/spawn a session, resolve the exact target, send the message, wait for the reply to settle, capture it, then continue or tear down. Read only the phase you need.
+Six phases, in order: discover/spawn a session, resolve the exact target, send the message, wait for the reply to settle, capture it, then continue or tear down.
+
+**Jump straight to the phase for your task** — don't read the rest:
+
+| Your task | Start at |
+|---|---|
+| Spawn a new agent session | Phase 1 |
+| Message an agent that's already running | Phase 2 |
+| Just read a running agent's pane (no send) | Phase 5 |
+| Broadcast the same message to a fleet | Phase 6 ("Broadcast to a fleet") |
+| Shut an agent down | Phase 6 ("Tear down") |
 
 ## Prerequisites
 
-- **tmux installed**: `command -v tmux` must succeed. If missing, tell the user to install it (`brew install tmux` / `apt install tmux`) and stop — do not fake it with background shells.
-- **A terminal multiplexer model**: you operate sessions you can't see. Always confirm a session exists and inspect its pane before assuming a message landed.
+- **tmux installed**: `command -v tmux` must succeed. If missing, tell the user to install it (`brew install tmux` / `apt install tmux`) and stop.
+- **You operate sessions you can't see.** Always confirm a session exists and inspect its pane before assuming a message landed.
 
 ## Critical Rules
 
-1. **Confirm before destructive or irreversible actions.** Killing a session, sending `exit`/`/quit`, or piping shell commands into another agent's prompt can lose that agent's work. Never do these without the user's explicit go-ahead. Reading a pane is always safe; writing to one is not.
-2. **Verify the target before sending.** A typo'd session name silently sends keystrokes nowhere (or to the wrong agent). Always resolve the exact target with `has-session` first (Phase 2).
-3. **Wait for the agent, don't race it.** Agents take seconds to respond. Sending a follow-up while the target is still working corrupts its input. Always wait until the pane output settles (Phase 4) before reading a reply or sending again.
-4. **Escape what you send.** `send-keys` interprets `;` as a command separator and the shell interprets `$`, backticks, and quotes. Mishandled, your message gets mangled or — worse — executes. Follow the escaping rules in Phase 3.
-5. **Attaching is opt-in, not a replacement.** Showing an agent's terminal (Phase 1) is an alternative for a human to drive by hand; it does not replace the default detached, scripted workflow — don't attach unless the user wants to see or steer the live UI.
+1. **Confirm before destructive/irreversible actions.** Killing a session or sending `exit`/`/quit` can lose that agent's work — never without explicit user go-ahead. Reading a pane is always safe; writing is not.
+2. **Verify the target before sending.** Resolve the exact session with `has-session` first (Phase 2) — a typo sends keystrokes nowhere or to the wrong agent.
+3. **Wait for the agent, don't race it.** Sending a follow-up while it's still working corrupts input. Wait until the pane settles (Phase 4) before reading or sending again.
+4. **Escape what you send.** `send-keys` and the shell both interpret special characters. Follow the escaping rules in Phase 3 or messages get mangled — or worse, execute.
+5. **Attaching is opt-in, not a replacement.** Showing an agent's terminal (Phase 1) is for a human to drive by hand; it never replaces the default detached, scripted workflow.
 
 ## Phase 1: Create or Discover Sessions
-
-You either attach to agents that already exist or spin up new ones.
-
-### List existing sessions
 
 ```bash
 tmux list-sessions 2>/dev/null || echo "no tmux server running yet"
 ```
 
-This shows every running session by name. Match the user's target against this list (see Phase 2).
-
-### Spawn a new agent session
-
-`tmux new-session` **fails if the name is already taken** (exit 1, "duplicate session"). So check first and pick a free name, then create a **detached** session (`-d`, `-s <name>`) and launch the agent in a second step (lets the shell initialize before the agent starts):
+Match the target against this list (Phase 2). To spawn: `tmux new-session` **fails if the name is taken** (exit 1), so check first, create **detached** (`-d -s <name>`), then launch the agent in a second step:
 
 ```bash
 name=agent1
 tmux has-session -t "$name" 2>/dev/null && name="${name}-$(date +%s)"   # avoid collision
-tmux new-session -d -s "$name" -c /path/to/project   # -c sets the working dir
+tmux new-session -d -s "$name" -c /path/to/project
 tmux send-keys -t "$name" "claude" Enter
 ```
 
-Replace `claude` with whatever launches the target agent (`gemini`, `claude --resume`, etc.).
-
-**"Spawned" ≠ "ready."** A fresh agent boots through a splash, and often a **trust/auth prompt that needs a keypress** before its input box works. Don't fire the first message blind. Run the wait helper (Phase 4): exit `0` means the input box is ready, exit `3` means it's parked on a prompt you must surface to the user (e.g. "Do you trust this folder?") rather than typing into.
+Replace `claude` with whatever launches the target agent. **"Spawned" ≠ "ready"** — a fresh agent often boots through a trust/auth prompt. Don't send blind; run the wait helper (Phase 4): exit `0` means ready, exit `3` means it's parked on a prompt to surface to the user rather than type into.
 
 ```bash
 python3 scripts/wait_for_idle.py "$name" --timeout 30 --no-print; echo "ready=$?"
 ```
 
-To launch a **fleet**, repeat with distinct job-named sessions (`reviewer`, `tests`, `docs`) so later messages are self-documenting.
+For a **fleet**, repeat with distinct job-named sessions (`reviewer`, `tests`, `docs`).
 
-### Show the agent's terminal (optional)
-
-The default workflow stays detached — you drive the agent with `send-keys`/`capture-pane` and never open its terminal. If the user wants to *see* the live CLI (a trust/auth prompt, debugging, or hands-on steering), there are two commands, and **neither is something the agent can use on its own behalf**:
-
-```bash
-tmux attach-session -t "$name"     # HUMAN runs this in their own interactive terminal
-tmux switch-client -t "$name"      # HUMAN runs this, only if already attached to a different session/client
-```
-
-`attach-session` needs a controlling TTY. If you (the agent) invoke it through a non-interactive Bash tool, it fails with `open terminal failed: not a terminal`. `switch-client` needs an *attached* tmux client to act on — it fails with `no current client` unless the invoking process already is one. Having `$TMUX` set in your own shell does **not** make you an attached client: `$TMUX` is set in every pane, including the detached sessions this skill spawns via `tmux new-session -d`, which is the agent's normal execution context and has no attached client at all. So in this skill's default spawn model, the agent has no self-service way to show its own terminal — never attempt `attach-session` or `switch-client` yourself; instead tell the human the exact command to type in their own terminal. `switch-client` only comes into play when a human is already attached to one session and wants that same client to switch to a different one.
-
-Detach with `Ctrl-b d` (default prefix + `d`) to return control to the orchestrator without killing the session. This is opt-in and does not replace the default detached flow — see `references/tmux-recipes.md` ("Showing an agent's live terminal") for the when-to-use guidance, the correct command for each starting context, and a worked example that names the exact session attached to.
+**Showing the agent's terminal** (optional, human-only): `tmux attach-session -t "$name"` or `tmux switch-client -t "$name"`, run by the human in their own interactive terminal — the agent invoking either itself will fail (no TTY / no attached client). Detach with `Ctrl-b d` to return control without killing the session. See `references/tmux-recipes.md` ("Showing an agent's live terminal") for the when-to-use table and worked example.
 
 ## Phase 2: Resolve the Exact Target
-
-Before sending anything, confirm the session exists. `has-session` exits non-zero if it doesn't:
 
 ```bash
 tmux has-session -t agent1 2>/dev/null && echo "OK: agent1 exists" || echo "MISSING: agent1"
 ```
 
-If the exact name is missing, run `tmux list-sessions` and pick the closest match — but surface the substitution to the user rather than guessing silently.
-
-**Targeting precision.** `-t agent1` targets the session's active pane. To hit a specific window or pane, use `session:window.pane`, e.g. `-t agent1:0.1`. For single-pane agent sessions (the common case), the bare session name is enough.
+If missing, run `tmux list-sessions` and pick the closest match — surface any substitution to the user rather than guessing. To target a specific window/pane, use `session:window.pane` (e.g. `-t agent1:0.1`); a bare session name targets the active pane, which is enough for single-pane agents.
 
 ## Phase 3: Send a Message
 
@@ -99,23 +84,11 @@ If the exact name is missing, run `tmux list-sessions` and pick the closest matc
 tmux send-keys -t agent1 "summarize the changes in src/" Enter
 ```
 
-`send-keys` types the string into the target's input, and the trailing `Enter` submits it.
+**Escaping:** wrap the message in double quotes; a raw `;` is read by tmux as a command separator, and `$`/backticks/`"` are still expanded by the shell inside double quotes — escape them or use single quotes when the message has none of its own. For newlines or code, write to a file and load it instead of fighting escaping — see `references/tmux-recipes.md` ("Sending multi-line or code-heavy messages").
 
-**Escaping — this is where messages break:**
+**Separate-Enter gotcha:** some TUIs don't submit when `Enter` rides the same call. If typed but not sent, send `Enter` alone: `tmux send-keys -t agent1 Enter`.
 
-- Wrap the message in **double quotes** so the shell keeps it as one argument.
-- A literal `;` inside an unquoted argument is read by tmux as a command separator. Quoting prevents this; when in doubt, keep messages free of raw `;`.
-- `$`, backticks, and `"` inside double quotes are still expanded/interpreted by the shell. Escape them (`\$`, `` \` ``, `\"`) or use single quotes for the whole message when it contains no single quote of its own.
-- For any message with newlines, complex quoting, or code, **write it to a file and load it** instead of fighting escaping — see `references/tmux-recipes.md` ("Sending multi-line or code-heavy messages").
-
-**The separate-Enter gotcha.** Some TUIs (including some Claude Code states) don't submit when `Enter` rides along in the same `send-keys` call. If a message types but doesn't send, send the Enter on its own:
-
-```bash
-tmux send-keys -t agent1 "your message"
-tmux send-keys -t agent1 Enter
-```
-
-**Verify delivery before you wait (don't skip this).** A keystroke can drop or an `Enter` can go unsubmitted, and you'd then wait on a reply that never comes. On-screen text only proves the message was *typed* — it looks identical whether submitted or parked in the input box. The reliable "submitted" signal is **post-send activity** (a spinner / `esc to interrupt`). After send, run a **bounded** check (one ~5s delay, then a single capture — never a poll loop) and grep the pane for that activity:
+**Verify delivery before you wait.** On-screen text proves it was *typed*, not submitted — it looks identical either way. The reliable signal is **post-send activity**. Run one bounded check (a single ~5s delay, then one capture — never a poll loop):
 
 ```bash
 tmux send-keys -t agent1 "..."; tmux send-keys -t agent1 Enter; sleep 5
@@ -123,88 +96,64 @@ tmux capture-pane -t agent1 -p -S -40 | grep -Eq 'esc to interrupt|[⠁-⣿]' \
   && echo delivered || echo NOT-DELIVERED
 ```
 
-- **`delivered`** — agent is busy → submitted → proceed to Phase 4.
-- **`NOT-DELIVERED`** — no activity (usually the separate-Enter gotcha or a dropped keystroke). Send a lone `Enter` and re-check; if still nothing, re-type. Distinct from a Phase 4 reply timeout — nothing was submitted, so don't start waiting.
-
-This is the `send → verify-delivered → wait → bounded-tail capture` loop. Trust the activity signal, not the text. Full rationale and the verbose branch logic: `references/delivery-and-waiting.md`.
+`delivered` → proceed to Phase 4. `NOT-DELIVERED` → send a lone `Enter` and re-check; if still nothing, re-type. This is distinct from a Phase 4 reply timeout — nothing was submitted, so don't start waiting. Full rationale: `references/delivery-and-waiting.md`.
 
 ## Phase 4: Wait for the Reply, Then Read It
 
-A fixed `sleep` either wastes time or reads a half-written reply. The bundled helper polls until the pane stops changing, then prints **only the new lines since the wait started** — the agent's answer, not the surrounding 24 lines of box-drawing and status bars. Relaying deltas instead of full frames is the main token saving over a multi-turn conversation.
+A fixed `sleep` wastes time or reads a half-written reply. The bundled helper polls until the pane stops changing, then prints only the new lines since the wait started — the reply delta, not the surrounding chrome:
 
 ```bash
 python3 scripts/wait_for_idle.py agent1
 ```
 
-It returns one of three states — **branch on the exit code:**
+Branch on the exit code: **0 idle** (settled, relay the printed delta), **3 blocked** (parked on a prompt needing a human — don't send, surface it, Rule 1), **2 timeout** (never settled within `--timeout`; bounds one wait, not a loop). For chrome that differs from the defaults, tune `--busy-marker`/`--block-marker` (or `TAC_BUSY_MARKERS`/`TAC_BLOCK_MARKERS`) — run `--help` for the rest.
 
-- **0 — idle:** settled and ready. Its stdout is the reply delta; relay that to the user.
-- **3 — blocked:** settled but parked on a prompt that needs a human (trust/auth dialog). It prints the full pane so you can show the dialog. **Do not send a message** — it would be read as menu input. Surface it and ask the user how to respond (Rule 1).
-- **2 — timeout:** never settled within `--timeout` (agent still working, or genuinely stuck). This bounds **one** wait — it does not bound a loop that keeps re-waiting (see the anti-deadloop cap below).
+**The verdict is advisory.** Before relaying a result the user will act on, or on any timeout, do an independent read: capture the pane, `sleep 3`, capture again. Captures differ, or either shows `esc to interrupt`/a spinner glyph → still working (keep waiting, don't send). Captures are byte-identical with no spinner marker → stalled (surface it, don't silently re-wait).
 
-Content stability is the universal signal (works for any CLI agent); spinner chrome and dialog text only refine the verdict. For an agent whose chrome differs, add markers with `--busy-marker`/`--block-marker` or the `TAC_BUSY_MARKERS`/`TAC_BLOCK_MARKERS` env vars — no code edit. Other flags: `--timeout`, `--quiet-cycles`, `--interval`, `--full`, `--scrollback N`; run `--help` for details.
+**Anti-deadloop:** set a hard overall budget (e.g. 2–3 re-waits or a wall-clock cap) before you start; when it's spent, stop and escalate — never poll indefinitely. No Python? Fall back to capture / `sleep 3` / capture / compare under the same budget. Full details: `references/delivery-and-waiting.md`.
 
-**The verdict is advisory — verify it when it matters.** Exit 0 means *the pane stopped changing*, usually "done" but possibly a paused agent. Before relaying a result the user will act on, or on any exit-2 timeout, do an independent human-style read (`tmux capture-pane -t agent1 -p -S -40`, Phase 5): a spinner or a changing tail = **still working** (keep waiting, don't send — Rule 3); unchanged + no spinner + no completion = **stalled** (surface it, don't silently re-wait).
+## Phase 5: Read More (capped-tail capture)
 
-**Anti-deadloop — bound the whole loop, not just one wait.** `--timeout` caps a single call; the real risk is a re-wait / re-send loop that polls forever. Set a **hard overall budget** before you start — a small number of re-waits (e.g. 2–3) or a total wall-clock cap — and when it's spent, **stop and escalate to the user** with what you observed. Never poll indefinitely. Full details in `references/delivery-and-waiting.md`.
-
-If you can't run the script (no Python, restricted env), fall back to a manual loop: capture (below), `sleep 3`, capture again, compare — under the same overall budget. Matching captures with no spinner = done. A spinner or `esc to interrupt` still showing → wait and re-capture; **don't send a new message yet** (Rule 3). If the budget runs out with no resolution, stop and surface it.
-
-## Phase 5: Read More (bounded-tail capture)
-
-The helper already relays the delta. When you need to read the pane yourself — to verify a verdict (Phase 4) or grab a full reply the delta clipped — **default to a bounded tail of ~20–40 lines**, not the bare visible pane and not the whole scrollback:
+When you need to read the pane yourself beyond the helper's delta, default to a capped tail (a fixed line-count window — distinct from Phase 3's one-shot delivery check, which is "bounded" in the no-poll-loop sense), not the bare pane or unbounded scrollback:
 
 ```bash
-tmux capture-pane -t agent1 -p -S -40       # ~40 scrollback lines + the visible pane (a bounded tail)
+tmux capture-pane -t agent1 -p -S -40       # ~40 scrollback lines + visible pane
 ```
 
-`-S -40` returns ~40 lines of scrollback *plus* the visible pane (so ~40+ lines in a typical pane), enough that a reply which scrolled one screen up still comes through — while staying low-noise. This is the **default** read for a full reply, and it is deliberately **distinct from grabbing the whole pane / unbounded scrollback** (`-S -`), which floods the capture with old turns and TUI chrome.
-
-**Tell when the tail truncated, and expand only then.** If the answer is longer than the window, the top of the capture starts mid-sentence (no clear start of the reply) or the first substantive line is cut off — that's the signal the reply exceeds the tail. Widen the window stepwise until the full reply is captured:
-
-```bash
-tmux capture-pane -t agent1 -p -S -80       # reply longer than ~40 lines → widen
-```
-
-Only fall back to unbounded scrollback (`-S -`) for an unusually long reply when even a wide tail truncates — see `references/tmux-recipes.md` ("Reading scrollback robustly") for that case. Relay the agent's answer, not the surrounding TUI chrome. If a capture is mostly box-drawing, re-check that the agent actually replied rather than blindly grabbing more.
+If the capture starts mid-sentence, the reply exceeded the window — widen stepwise (`-S -80`, ...). Only fall back to unbounded `-S -` when even a wide tail truncates — see `references/tmux-recipes.md` ("Reading scrollback robustly").
 
 ## Phase 6: Continue or Tear Down
 
-**Continue the conversation:** repeat the loop — send → verify-delivered (Phase 3) → wait, bounded + manual-verify (Phase 4) → bounded-tail capture (Phase 5). Each round, wait for idle (exit 0) before sending again, and keep the **overall budget** from Phase 4 across rounds: if the loop keeps re-waiting or re-sending without progress, stop and escalate to the user rather than polling forever.
+**Continue:** repeat send → verify-delivered (Phase 3) → wait + manual-verify (Phase 4) → capped-tail capture (Phase 5). Wait for idle before sending again, and keep the overall budget across rounds — if the loop keeps re-waiting without progress, escalate rather than poll forever.
 
-**Broadcast to a fleet:** send the message to **every** session first, then wait on each — never serialize a full send→wait→read per agent, or a slow agent stalls the rest. The bundled `scripts/broadcast.sh` does this; see `references/tmux-recipes.md` ("Broadcast to multiple agents").
+**Broadcast to a fleet:** send to every session first, then wait on each concurrently — never serialize a full send→wait→read per agent. `scripts/broadcast.sh` does this; see `references/tmux-recipes.md` ("Broadcast to multiple agents").
 
-**Tear down (confirmation required):** when the user is done with an agent, kill its session:
-
-```bash
-tmux kill-session -t agent1
-```
-
-To stop everything (all sessions and the tmux server):
+**Tear down (confirmation required):**
 
 ```bash
-tmux kill-server
+tmux kill-session -t agent1     # one session
+tmux kill-server                # everything — prefer killing named sessions individually
 ```
 
-Both destroy unsaved agent state — confirm with the user first (Rule 1). Prefer killing named sessions individually over `kill-server` unless the user explicitly wants a full reset.
+Both destroy unsaved agent state — confirm with the user first (Rule 1).
 
 ## Example
 
-For example, to message a running agent in session `reviewer` and relay its answer — the full `send → verify-delivered → wait → bounded-tail capture` loop:
+Message a running agent in session `reviewer` and relay its answer — the full `send → verify-delivered → wait → capped-tail capture` loop:
 
 ```bash
 tmux has-session -t reviewer 2>/dev/null || { echo "no session 'reviewer'"; exit 1; }
 tmux send-keys -t reviewer "summarize the open PRs"
 tmux send-keys -t reviewer Enter
-sleep 5                                           # bounded delivery check (Phase 3)
+sleep 5
 tmux capture-pane -t reviewer -p -S -40 | grep -Eq 'esc to interrupt|[⠁-⣿]' \
   && echo "delivered" || { echo "not submitted — send a lone Enter, re-check"; exit 1; }
-python3 scripts/wait_for_idle.py reviewer         # advisory: blocks until idle, prints the reply delta
+python3 scripts/wait_for_idle.py reviewer
 echo "wait exit=$?"                               # 0 idle · 3 blocked-on-prompt · 2 timeout
-tmux capture-pane -t reviewer -p -S -40           # bounded tail (~40 scrollback + visible pane), Phase 5
+tmux capture-pane -t reviewer -p -S -40
 ```
 
-The delivery check here keys off **post-send activity** (the agent is now busy), which only appears once the message was accepted *and* submitted — see Phase 3 for the `delivered` / `NOT-DELIVERED` branch and the re-send remedy. Expected output (the bounded tail — a complete answer, low-noise, not the whole scrollback):
+Expected output (a complete answer, low-noise, not the whole scrollback):
 
 ```
 delivered
@@ -212,25 +161,24 @@ delivered
 wait exit=0
 ```
 
-Relay that answer to the user. If the bounded-tail read starts mid-sentence, widen to `-S -80` (Phase 5). If the message wasn't submitted, send a lone `Enter` and re-check — don't start waiting (Phase 3). On `exit=3`, do not send — show the dialog and ask the user how to respond. If the wait never settles within your overall budget, stop and surface the stall (Phase 4).
+Relay that answer to the user. If the read starts mid-sentence, widen to `-S -80` (Phase 5). On `exit=3`, don't send — show the dialog and ask how to respond. If the wait never settles within budget, stop and surface the stall (Phase 4).
 
 ## Edge Cases
 
-- **Agent on a trust/auth dialog** (e.g. a fresh Gemini in an untrusted dir) — `wait_for_idle.py` returns exit 3, not 0. Never send a message; the keystrokes would be read as menu input. Surface the dialog.
-- **Reply ends in a numbered list** ("1. yes 2. no") — handled: block detection uses only verified dialog strings, so a normal reply is not mistaken for a prompt.
-- **Duplicate session name** — `tmux new-session` exits 1 ("duplicate session"); resolve a free name first (Phase 1).
-- **Agent reply contains "running"/"loading"/"…"** — handled: busy detection scans only spinner *chrome* in the last lines, never reply prose.
-- **Message never landed** (dropped keystroke, unsubmitted `Enter`, input swallowed by a busy pane) — the Phase 3 check keys off *post-send activity*, not the mere presence of the text on screen, so it catches this **before** waiting and reports `NOT-DELIVERED`. The remedy covers every cause: send a lone `Enter`, re-check, then re-type if still nothing. Distinct from a reply timeout — nothing was submitted, so re-send rather than wait longer.
-- **Agent stalled** (pane unchanged across reads, no spinner, no completion) — distinct from "still working" (spinner/`esc to interrupt` or a changing tail) and from a dropped delivery. Surface it; don't silently re-wait (Phase 4).
-- **Re-wait/re-send loop won't terminate** — enforce the overall budget (Phase 4): cap total re-waits/wall-clock and escalate to the user; never poll indefinitely.
-- **Bounded-tail capture starts mid-sentence** — the reply is longer than ~40 lines; widen stepwise (`-S -80`, …) and only reach for unbounded `-S -` if even a wide tail truncates (Phase 5).
-- **Returning to orchestrator control after attaching** — detach with `Ctrl-b d` (default prefix + `d`); this leaves the session running so the scripted send-keys/capture-pane loop can resume. Never `kill-session` just to "get back" (Phase 1, "Show the agent's terminal").
+- **Trust/auth dialog** — `wait_for_idle.py` returns exit 3, not 0. Never send a message (would be read as menu input); surface the dialog.
+- **Reply ends in a numbered list** ("1. yes 2. no") — not mistaken for a prompt; block detection uses only verified dialog strings.
+- **Duplicate session name** — `tmux new-session` exits 1; resolve a free name first (Phase 1).
+- **Reply text contains "running"/"loading"** — busy detection scans only spinner chrome, never reply prose.
+- **Message never landed** — Phase 3's post-send-activity check catches this before waiting and reports `NOT-DELIVERED`; send a lone `Enter`, re-check, re-type if still nothing.
+- **Agent stalled** (unchanged pane, no spinner, no completion) — distinct from "still working" or a dropped delivery; surface it, don't silently re-wait.
+- **Re-wait/re-send loop won't terminate** — enforce the overall budget (Phase 4); escalate rather than poll indefinitely.
+- **Capped-tail capture starts mid-sentence** — reply is longer than ~40 lines; widen stepwise, only reach for unbounded `-S -` if a wide tail still truncates.
+- **Returning to orchestrator control after attaching** — detach with `Ctrl-b d`; never `kill-session` just to "get back."
 
 ## Reference
 
-Read `references/delivery-and-waiting.md` for the full rationale behind delivery verification (Phase 3) and waiting (Phase 4).
-
-Read `references/tmux-recipes.md` for: broadcasting to a fleet, sending multi-line/code messages safely, splitting a session into panes, showing an agent's live terminal, reading scrollback robustly, and a troubleshooting table.
+- `references/delivery-and-waiting.md` — full rationale behind delivery verification (Phase 3) and waiting (Phase 4).
+- `references/tmux-recipes.md` — broadcasting to a fleet, sending multi-line/code messages, splitting panes, showing an agent's live terminal, reading scrollback, troubleshooting.
 
 ## Step Completion Report
 
@@ -243,11 +191,11 @@ After a messaging or lifecycle operation, emit:
   Message sent:        √ pass
   Message delivered:   √ pass (submission verified, ~5s)
   Reply settled:       √ pass (3 quiet cycles · verdict advisory)
-  Reply verified:      √ pass (manual bounded-tail read)
+  Reply verified:      √ pass (manual capped-tail read)
   Reply captured:      √ pass (-S -40, not truncated)
   Destructive action:  — none (or: confirmed by user)
   ____________________________
   Result:              PASS
 ```
 
-Adapt rows to the operation — a spawn reports `Session created`; a teardown reports `Confirmed` and `Session killed`. Use `⚠` for a dropped delivery (`Message delivered: ⚠ not delivered — re-sent`) or a stall escalated to the user (`Reply settled: ⚠ stalled — budget spent, surfaced`).
+Adapt rows to the operation — a spawn reports `Session created`; a teardown reports `Confirmed` and `Session killed`. Use `⚠` for a dropped delivery (`Message delivered: ⚠ not delivered — re-sent`) or an escalated stall (`Reply settled: ⚠ stalled — budget spent, surfaced`).

--- a/skills/tmux-agent-comms/references/delivery-and-waiting.md
+++ b/skills/tmux-agent-comms/references/delivery-and-waiting.md
@@ -10,19 +10,7 @@ The one signal that reliably means *submitted* is **post-send activity**: once t
 
 ### The bounded delivery check (one fixed wait, then one capture)
 
-```bash
-tmux send-keys -t agent1 "summarize the changes in src/"
-tmux send-keys -t agent1 Enter
-sleep 5                                          # bounded: one fixed wait, ~5s
-pane=$(tmux capture-pane -t agent1 -p -S -40)    # ~40 scrollback lines + visible pane
-if printf '%s\n' "$pane" | grep -Eq 'esc to interrupt|[⠁-⣿]'; then
-  echo "delivered"          # agent is working → input was accepted and submitted
-else
-  echo "NOT-DELIVERED"      # no activity → it didn't land; re-send
-fi
-```
-
-Keep this **bounded** — one short fixed delay, then a single capture. Never a poll loop here; that can hang. The reply-settling poll belongs to Phase 4, not the delivery check.
+See SKILL.md Phase 3 for the exact command — one short fixed delay (`sleep 5`), then a single `capture-pane`/`grep` check. Never a poll loop here; that can hang. The reply-settling poll belongs to Phase 4, not the delivery check.
 
 ### The two outcomes (neither is a reply timeout)
 

--- a/skills/website-cloner/SKILL.md
+++ b/skills/website-cloner/SKILL.md
@@ -4,7 +4,7 @@ description: "Build an improved website clone from a URL via 6-phase gated workf
 license: MIT
 effort: high
 metadata:
-  version: 1.1.5
+  version: 1.1.6
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -43,6 +43,8 @@ Phase 6 — Final Report   → website-clone-final-report
 ```
 
 Approval gates after Phase 2, 3, and 4: the orchestrator **must not advance** without explicit user approval.
+
+**Artifacts** (each written once, then referenced by name in the phases below): `analysis.json` — Phase 1's structured findings; `report.md` — Phase 2's plain-language summary; `prd.md` — Phase 3's improvement proposal; `tasks.md` — Phase 4's phased implementation plan; `builder-metadata.json` — Phase 5's build-output metadata (asset counts, Pages URL) consumed by Phase 6.
 
 ## Layout
 


### PR DESCRIPTION
Type: chore

## Summary
- Trims 34 `SKILL.md` files back under the repo's 500-line limit by moving overflow content into new `skills/*/references/*.md` files (code-optimizer, code-review, idea-validator, security-setup, tad-generator).
- Bumps `metadata.version` on every touched `SKILL.md` per repo convention.
- Adds `.asm-improver/` to `.gitignore`.

## Test plan
- [x] `quick_validate.py` run against all 34 touched skills — all pass
- [x] Confirmed `metadata.version` bumped on every modified `SKILL.md`
