### PR TITLE
Update tmux-agent-comms observability and startup flow

### DIFF
--- a/skills/tmux-agent-comms/SKILL.md
+++ b/skills/tmux-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agents in tmux: spawn, status/inspect, message, read rep
 license: MIT
 effort: medium
 metadata:
-  version: 1.8.0
+  version: 1.8.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -144,7 +144,7 @@ tmux list-panes -a -F '#{session_name}|#{pane_current_path}|#{pane_current_comma
 tmux capture-pane -t "$session" -p -S -40
 ```
 
-Classify `in-progress` when the tail changes or shows a spinner / `esc to interrupt`; `blocked` when `wait_for_idle.py --no-print` exits 3 or a prompt is visible; `done` when the pane is quiet and a completed reply/prompt is visible; otherwise `unknown`. Keep progress summaries short — the current task or last meaningful line, not full scrollback.
+Keep status checks fast and read-only: prefer two short bounded captures (`sleep 1-3`) to detect changing output, or call `wait_for_idle.py --timeout 3 --quiet-cycles 1 --no-print` rather than the full reply-wait cycle. Classify `in-progress` when the tail changes or shows a spinner / `esc to interrupt`; `blocked` when the short waiter exits 3 or a prompt is visible; `done` when the pane is quiet and a completed reply/prompt is visible; otherwise `unknown`. Keep progress summaries short — the current task or last meaningful line, not full scrollback.
 
 Use **inspect `<agent-id>`** for one agent. Resolve the ID to the exact session, show the same fields as status plus a bounded tail and pane details, and print the human-only attach command:
 

--- a/skills/tmux-agent-comms/SKILL.md
+++ b/skills/tmux-agent-comms/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: tmux-agent-comms
-description: "Manage AI agents in tmux: spawn or kill sessions and message any CLI agent (Claude Code, Gemini, etc.) via send-keys/capture-pane, then read its reply. Use to launch a fleet or talk to a running agent. Don't use for SSH, GNU screen, or GUI apps."
+description: "Manage AI agents in tmux: spawn, status/inspect, message, read replies, or kill sessions via send-keys/capture-pane. Use to launch fleets or talk to running agents. Don't use for SSH, GNU screen, or GUI apps."
 license: MIT
 effort: medium
 metadata:
-  version: 1.7.0
+  version: 1.8.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Tmux Agent Comms
 
-Manage and talk to AI agents (another Claude Code, Gemini CLI, or any CLI) running in separate tmux sessions: **create** sessions, **send** messages, **wait** for the agent to finish, **capture** replies, and **tear down** when done.
+Manage and talk to AI agents (another Claude Code, Gemini CLI, Codex, pi-agent, or any CLI) running in separate tmux sessions: **create** sessions, **send** messages, **wait** for the agent to finish, **capture** replies, **check status**, **inspect** sessions, and **tear down** when done.
 
 Mental model: each tmux session is one agent. You orchestrate from outside by writing to its input and reading its pane — what a human does by switching windows, but scripted. Your context budget is finite, so relay each agent's answer, not its whole screen (the bundled helper extracts just the reply delta).
 
 ## When to Use
 
-Launching agents in tmux, messaging an agent in another session, broadcasting to a fleet, or reading what an agent replied. Don't use for SSH/remote shells, GNU `screen`, or driving a GUI app.
+Launching agents in tmux, messaging an agent in another session, broadcasting to a fleet, checking fleet status, inspecting a managed session, or reading what an agent replied. Don't use for SSH/remote shells, GNU `screen`, or driving a GUI app.
 
 ## Workflow
 
@@ -29,6 +29,8 @@ Six phases, in order: discover/spawn a session, resolve the exact target, send t
 | Spawn a new agent session | Phase 1 |
 | Message an agent that's already running | Phase 2 |
 | Just read a running agent's pane (no send) | Phase 5 |
+| Show fleet status | Phase 5 ("Status and Inspect") |
+| Inspect one agent and get an attach command | Phase 5 ("Status and Inspect") |
 | Broadcast the same message to a fleet | Phase 6 ("Broadcast to a fleet") |
 | Shut an agent down | Phase 6 ("Tear down") |
 
@@ -44,6 +46,7 @@ Six phases, in order: discover/spawn a session, resolve the exact target, send t
 3. **Wait for the agent, don't race it.** Sending a follow-up while it's still working corrupts input. Wait until the pane settles (Phase 4) before reading or sending again.
 4. **Escape what you send.** `send-keys` and the shell both interpret special characters. Follow the escaping rules in Phase 3 or messages get mangled — or worse, execute.
 5. **Attaching is opt-in, not a replacement.** Showing an agent's terminal (Phase 1) is for a human to drive by hand; it never replaces the default detached, scripted workflow.
+6. **Default startup is autonomous and non-blocking.** Spawn detached sessions and continue with readiness checks; don't wait at startup for a human unless the user explicitly asks for interactive mode.
 
 ## Phase 1: Create or Discover Sessions
 
@@ -51,22 +54,29 @@ Six phases, in order: discover/spawn a session, resolve the exact target, send t
 tmux list-sessions 2>/dev/null || echo "no tmux server running yet"
 ```
 
-Match the target against this list (Phase 2). To spawn: `tmux new-session` **fails if the name is taken** (exit 1), so check first, create **detached** (`-d -s <name>`), then launch the agent in a second step:
+Match the target against this list (Phase 2). New sessions use the predictable pattern **`<folder>-<short-task-name>`**: folder is the current project/workspace folder, and short task is a concise slug like `reviewer`, `tests`, or `docs`. This keeps `status`, `inspect`, and attach commands grep-friendly.
+
+To spawn: `tmux new-session` **fails if the name is taken** (exit 1), so check first, create **detached** (`-d -s <name>`), then launch the agent in a second step:
 
 ```bash
-name=agent1
+slug() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-|-$//g'; }
+folder="$(slug "$(basename "$PWD")")"
+task="$(slug "${short_task_name:-reviewer}")"
+name="${folder}-${task}"
 tmux has-session -t "$name" 2>/dev/null && name="${name}-$(date +%s)"   # avoid collision
-tmux new-session -d -s "$name" -c /path/to/project
-tmux send-keys -t "$name" "claude" Enter
+tmux new-session -d -s "$name" -c "$PWD"
+tmux send-keys -t "$name" "${TAC_AGENT_CMD:-claude}" Enter
 ```
 
-Replace `claude` with whatever launches the target agent. **"Spawned" ≠ "ready"** — a fresh agent often boots through a trust/auth prompt. Don't send blind; run the wait helper (Phase 4): exit `0` means ready, exit `3` means it's parked on a prompt to surface to the user rather than type into.
+**Startup mode:** autonomous/non-blocking is the default for pi-agent, Claude, Codex, Gemini, and other CLIs. Use `TAC_STARTUP_MODE=autonomous|interactive` as the global default when present; a per-launch user request like `--interactive` or "show me the setup first" overrides it. In autonomous mode, use a detached launch command (`TAC_AGENT_CMD`, or the user's requested command) and immediately continue to readiness checks; never park the orchestrator on an interactive startup question. In interactive mode, print the attach command and stop before scripted sends.
+
+**"Spawned" ≠ "ready"** — a fresh agent often boots through a trust/auth prompt. Don't send blind; run the wait helper (Phase 4): exit `0` means ready, exit `3` means it's parked on a prompt to surface to the user rather than type into.
 
 ```bash
 python3 scripts/wait_for_idle.py "$name" --timeout 30 --no-print; echo "ready=$?"
 ```
 
-For a **fleet**, repeat with distinct job-named sessions (`reviewer`, `tests`, `docs`).
+For a **fleet**, repeat with distinct task slugs under the same folder prefix (`myrepo-reviewer`, `myrepo-tests`, `myrepo-docs`).
 
 **Showing the agent's terminal** (optional, human-only): `tmux attach-session -t "$name"` or `tmux switch-client -t "$name"`, run by the human in their own interactive terminal — the agent invoking either itself will fail (no TTY / no attached client). Detach with `Ctrl-b d` to return control without killing the session. See `references/tmux-recipes.md` ("Showing an agent's live terminal") for the when-to-use table and worked example.
 
@@ -122,11 +132,35 @@ tmux capture-pane -t agent1 -p -S -40       # ~40 scrollback lines + visible pan
 
 If the capture starts mid-sentence, the reply exceeded the window — widen stepwise (`-S -80`, ...). Only fall back to unbounded `-S -` when even a wide tail truncates — see `references/tmux-recipes.md` ("Reading scrollback robustly").
 
+### Status and Inspect (read-only)
+
+Use **status** when the user asks what every managed tmux agent is doing. Read only — do not send keys. Prefer sessions following the `<folder>-<short-task-name>` convention, plus any sessions launched earlier in this run. Output a table with at least: agent ID, session name, state (`in-progress` / `done` / `blocked` / `unknown`), task/progress summary, started time, and working directory.
+
+Useful raw data:
+
+```bash
+tmux list-sessions -F '#{session_name}|#{t:session_created}'
+tmux list-panes -a -F '#{session_name}|#{pane_current_path}|#{pane_current_command}'
+tmux capture-pane -t "$session" -p -S -40
+```
+
+Classify `in-progress` when the tail changes or shows a spinner / `esc to interrupt`; `blocked` when `wait_for_idle.py --no-print` exits 3 or a prompt is visible; `done` when the pane is quiet and a completed reply/prompt is visible; otherwise `unknown`. Keep progress summaries short — the current task or last meaningful line, not full scrollback.
+
+Use **inspect `<agent-id>`** for one agent. Resolve the ID to the exact session, show the same fields as status plus a bounded tail and pane details, and print the human-only attach command:
+
+```bash
+tmux attach-session -t "$session"
+```
+
+The orchestrator must not run that attach command itself (no TTY); it only gives the user a copy-paste command for their own terminal.
+
 ## Phase 6: Continue or Tear Down
 
 **Continue:** repeat send → verify-delivered (Phase 3) → wait + manual-verify (Phase 4) → capped-tail capture (Phase 5). Wait for idle before sending again, and keep the overall budget across rounds — if the loop keeps re-waiting without progress, escalate rather than poll forever.
 
 **Broadcast to a fleet:** send to every session first, then wait on each concurrently — never serialize a full send→wait→read per agent. `scripts/broadcast.sh` does this; see `references/tmux-recipes.md` ("Broadcast to multiple agents").
+
+**Long-running fleet status:** during multi-agent work that runs for several minutes, emit a fleet status report about every 5 minutes until all agents are done or blocked. Use the read-only Status table from Phase 5: per-agent state, current task/progress, started time, and working directory. This is a monitor/wake cadence only — never interrupt a working pane, never send keys as part of the report, and keep the same wait/budget rules from Phase 4.
 
 **Tear down (confirmation required):**
 
@@ -168,6 +202,8 @@ Relay that answer to the user. If the read starts mid-sentence, widen to `-S -80
 - **Trust/auth dialog** — `wait_for_idle.py` returns exit 3, not 0. Never send a message (would be read as menu input); surface the dialog.
 - **Reply ends in a numbered list** ("1. yes 2. no") — not mistaken for a prompt; block detection uses only verified dialog strings.
 - **Duplicate session name** — `tmux new-session` exits 1; resolve a free name first (Phase 1).
+- **Interactive startup would hang the run** — default to autonomous detached startup; only enter interactive mode when the user explicitly opts in, then print an attach command instead of blocking the orchestrator.
+- **Status cannot identify an agent** — list it as `unknown` rather than guessing; `inspect` must resolve the exact session before printing an attach command.
 - **Reply text contains "running"/"loading"** — busy detection scans only spinner chrome, never reply prose.
 - **Message never landed** — Phase 3's post-send-activity check catches this before waiting and reports `NOT-DELIVERED`; send a lone `Enter`, re-check, re-type if still nothing.
 - **Agent stalled** (unchanged pane, no spinner, no completion) — distinct from "still working" or a dropped delivery; surface it, don't silently re-wait.
@@ -178,7 +214,7 @@ Relay that answer to the user. If the read starts mid-sentence, widen to `-S -80
 ## Reference
 
 - `references/delivery-and-waiting.md` — full rationale behind delivery verification (Phase 3) and waiting (Phase 4).
-- `references/tmux-recipes.md` — broadcasting to a fleet, sending multi-line/code messages, splitting panes, showing an agent's live terminal, reading scrollback, troubleshooting.
+- `references/tmux-recipes.md` — broadcasting to a fleet, periodic fleet status, status/inspect details, sending multi-line/code messages, splitting panes, showing an agent's live terminal, reading scrollback, troubleshooting.
 
 ## Step Completion Report
 
@@ -193,6 +229,7 @@ After a messaging or lifecycle operation, emit:
   Reply settled:       √ pass (3 quiet cycles · verdict advisory)
   Reply verified:      √ pass (manual capped-tail read)
   Reply captured:      √ pass (-S -40, not truncated)
+  Fleet status:        √ pass (if long-running fleet work: ~5 min cadence; otherwise — n/a)
   Destructive action:  — none (or: confirmed by user)
   ____________________________
   Result:              PASS

--- a/skills/tmux-agent-comms/docs/README.md
+++ b/skills/tmux-agent-comms/docs/README.md
@@ -11,10 +11,12 @@
 
 ## Highlights
 
-- **Launch a fleet** — create named, detached tmux sessions and boot an agent (Claude Code, Gemini CLI, any CLI) inside each.
+- **Launch a fleet** — create predictable, detached tmux sessions (`<folder>-<short-task-name>`) and boot an agent (Claude Code, Gemini CLI, Codex, pi-agent, any CLI) inside each.
+- **Start non-blocking by default** — use autonomous detached startup, with `TAC_STARTUP_MODE` or a per-launch request to opt into interactive startup only when needed.
 - **Message any agent** — send a prompt to a target session with proper escaping, including the separate-`Enter` gotcha for stubborn TUIs.
 - **Read replies reliably** — a bundled `wait_for_idle.py` polls the pane until output settles instead of guessing with a fixed `sleep`, then returns the answer.
-- **Broadcast & collect** — fan one instruction out to several agents and gather each reply.
+- **Broadcast & collect** — fan one instruction out to several agents and gather each reply, with periodic fleet status during long-running work.
+- **Status & inspect** — list every managed agent in a table, inspect one agent, and get the exact attach command for a human terminal.
 - **Show an agent's terminal on demand** — attach to (or switch to) a spawned agent's session to see its live CLI and type into it directly, for trust prompts, debugging, or hands-on steering, without giving up the default detached workflow.
 - **Safe teardown** — kill individual sessions (or the whole server) behind explicit user confirmation, so no agent's work is lost by accident.
 
@@ -25,17 +27,20 @@
 | "Launch three Claude agents in tmux for reviewer, tests, and docs" | Create three named detached sessions and start an agent in each |
 | "Send 'summarize src/' to the reviewer agent and show me its reply" | Send the message, wait for the pane to settle, capture and relay the answer |
 | "Ask all my agents to pull the latest main" | Broadcast the message to every session and collect each response |
+| "Show status for my tmux agents" | Print a table with state, progress, start time, and working directory |
+| "Inspect the reviewer agent" | Show details for that agent and the exact `tmux attach-session` command |
 | "Shut down the tests agent" | Confirm, then `kill-session` that target |
 
 ## How It Works
 
 ```mermaid
 graph TD
-    A["Create or discover sessions"] --> B["Resolve exact target (has-session)"]
+    A["Create/discover named sessions"] --> B["Resolve exact target (has-session)"]
     B --> C["Send message (escaped + Enter)"]
+    B --> S["Status / inspect (read-only)"]
     C --> D["Wait until pane settles (wait_for_idle.py)"]
     D --> E["Capture & relay reply"]
-    E --> F["Continue or tear down (confirmed)"]
+    E --> F["Continue, report fleet status, or tear down (confirmed)"]
     style A fill:#4CAF50,color:#fff
     style F fill:#2196F3,color:#fff
 ```
@@ -70,7 +75,7 @@ Spin up several agents, each scoped to a job, and kick them all off at once.
 /tmux-agent-comms launch three Claude agents in tmux named reviewer, tests, and docs in this repo, then ask each to report what it would work on first
 ```
 
-The skill creates three named detached sessions, boots an agent in each, waits for each to clear its boot/trust prompt, then messages them. Naming sessions by job (`reviewer`, `tests`, `docs`) keeps later messages self-documenting.
+The skill creates three predictably named detached sessions (for example, `myrepo-reviewer`, `myrepo-tests`, `myrepo-docs`), boots an agent in each, waits for each to clear its boot/trust prompt, then messages them. The `<folder>-<short-task-name>` convention keeps later status, inspect, and attach commands self-documenting.
 
 ### 3. Broadcast one instruction to the whole fleet
 
@@ -80,7 +85,18 @@ Send the same message to every agent and collect all the replies together — th
 /tmux-agent-comms tell all my running agents to pull the latest main and report status
 ```
 
-You get one labeled block per agent with its reply and a state tag (`idle` / `TIMEOUT` / `BLOCKED`), so you can see at a glance which agents are done and which need attention.
+You get one labeled block per agent with its reply and a state tag (`idle` / `TIMEOUT` / `BLOCKED`), so you can see at a glance which agents are done and which need attention. For long runs, the orchestrator also reports fleet status about every 5 minutes without interrupting working panes.
+
+### 3b. Check or inspect running agents
+
+Use status when you want the whole fleet at a glance, or inspect when you need one agent's details and attach command.
+
+```
+/tmux-agent-comms show status for all managed agents
+/tmux-agent-comms inspect the reviewer agent and show me how to attach
+```
+
+Status returns a table with session, state, progress, start time, and working directory. Inspect resolves one exact session and prints a human-run command such as `tmux attach-session -t myrepo-reviewer`.
 
 ### 4. Hand a long prompt or a code block to an agent
 
@@ -117,7 +133,7 @@ The skill confirms the target with you, then `kill-session`. (A full reset of ev
 
 | Path | Description |
 |---|---|
-| `references/tmux-recipes.md` | Broadcast patterns, multi-line/code message sending, pane splitting, scrollback, chrome-stripping, and a troubleshooting table |
+| `references/tmux-recipes.md` | Broadcast patterns, periodic fleet status, status/inspect behavior, multi-line/code message sending, pane splitting, scrollback, chrome-stripping, and a troubleshooting table |
 | `scripts/wait_for_idle.py` | Polls a pane until idle; prints just the reply delta (token-lean) and reports idle / blocked-on-prompt / timeout via exit codes 0/3/2 |
 | `scripts/broadcast.sh` | Sends one message to a fleet and collects every reply concurrently, one labeled block per agent |
 

--- a/skills/tmux-agent-comms/docs/README.md
+++ b/skills/tmux-agent-comms/docs/README.md
@@ -41,8 +41,8 @@ graph TD
     C --> D["Wait until pane settles (wait_for_idle.py)"]
     D --> E["Capture & relay reply"]
     E --> F["Continue, report fleet status, or tear down (confirmed)"]
-    style A fill:#4CAF50,color:#fff
-    style F fill:#2196F3,color:#fff
+    style A fill:#2E7D32,color:#fff
+    style F fill:#1565C0,color:#fff
 ```
 
 ## Usage
@@ -85,7 +85,7 @@ Send the same message to every agent and collect all the replies together — th
 /tmux-agent-comms tell all my running agents to pull the latest main and report status
 ```
 
-You get one labeled block per agent with its reply and a state tag (`idle` / `TIMEOUT` / `BLOCKED`), so you can see at a glance which agents are done and which need attention. For long runs, the orchestrator also reports fleet status about every 5 minutes without interrupting working panes.
+You get one labeled block per agent with its reply and a state tag (`idle` / `TIMEOUT` / `BLOCKED`), so you can see at a glance which agents are done and which need attention. Status uses the same meaning in scan-friendly words: `idle` maps to `done`, `BLOCKED` maps to `blocked`, and `TIMEOUT` maps to `unknown` unless a fresh capture is still changing (`in-progress`). For long runs, the orchestrator also reports fleet status about every 5 minutes without interrupting working panes.
 
 ### 3b. Check or inspect running agents
 

--- a/skills/tmux-agent-comms/evals/evals.json
+++ b/skills/tmux-agent-comms/evals/evals.json
@@ -10,13 +10,31 @@
     {
       "id": 2,
       "prompt": "Spin up two tmux agents for me — one named 'tests' and one named 'docs' — and launch claude in each, in the current project directory.",
-      "expected_output": "Creates two detached named sessions (tmux new-session -d -s tests / -s docs), uses -c for the project directory, launches the agent in each, and waits for each to finish booting before considering them ready. No destructive commands.",
+      "expected_output": "Creates two detached sessions using the <folder>-<short-task-name> convention (e.g. <folder>-tests and <folder>-docs), uses -c for the project directory, launches the agent in non-blocking/autonomous mode by default, and waits for each to finish booting before considering them ready. No destructive commands.",
       "files": []
     },
     {
       "id": 3,
       "prompt": "I'm done with all my tmux agents, just kill everything.",
       "expected_output": "Treats teardown as destructive: confirms with the user before killing, prefers killing the named sessions individually over kill-server unless a full reset is explicitly wanted, and warns that unsaved agent state is lost.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Launch three tmux agents for this repo (reviewer, tests, docs) and keep me updated while they work for a while.",
+      "expected_output": "Creates detached sessions using the <folder>-<short-task-name> naming convention, honors TAC_STARTUP_MODE/per-launch interactive overrides while defaulting to non-blocking/autonomous startup, waits without serializing the fleet, and emits read-only fleet status reports about every 5 minutes showing each agent's state, task/progress, start time, and working directory without sending extra keys to working agents.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Show status for all my managed tmux agents.",
+      "expected_output": "Runs read-only tmux inspection commands, identifies managed sessions (especially <folder>-<short-task-name> sessions), and returns a table with agent ID, exact session name, state, progress summary, started time, and working directory. It does not send keys or interrupt agents.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "Inspect the reviewer tmux agent and tell me how to attach to it.",
+      "expected_output": "Resolves reviewer to exactly one tmux session, shows detailed fields and a bounded tail/pane summary, and prints the exact human-run tmux attach-session command. The orchestrator does not execute attach-session itself.",
       "files": []
     }
   ]

--- a/skills/tmux-agent-comms/references/tmux-recipes.md
+++ b/skills/tmux-agent-comms/references/tmux-recipes.md
@@ -7,7 +7,7 @@ Patterns the SKILL.md points to when a task goes beyond the basic send → wait 
 Send one instruction to a fleet and collect each reply. Use the bundled script — it sends to every session first, then waits on all of them **concurrently** (each reply settles in its own background process), so wall-clock is the slowest single agent, not the sum:
 
 ```bash
-TAC_TIMEOUT=180 bash scripts/broadcast.sh "pull latest main and report status" reviewer tests docs
+TAC_TIMEOUT=180 bash scripts/broadcast.sh "pull latest main and report status" myrepo-reviewer myrepo-tests myrepo-docs
 ```
 
 It prints one labeled block per agent with the reply delta and a state tag (`idle` / `TIMEOUT` / `BLOCKED`), and exits non-zero if any agent timed out or is blocked. `TAC_WAIT_ARGS` passes extra flags to the waiter (e.g. `TAC_WAIT_ARGS=--full`).
@@ -15,10 +15,52 @@ It prints one labeled block per agent with the reply delta and a state tag (`idl
 **Wait for boot before the first broadcast.** Freshly spawned agents may still be on a splash or trust prompt. Confirm each is ready first (exit 0, not 3):
 
 ```bash
-for s in reviewer tests docs; do python3 scripts/wait_for_idle.py "$s" --timeout 30 --no-print; echo "$s ready=$?"; done
+for s in myrepo-reviewer myrepo-tests myrepo-docs; do python3 scripts/wait_for_idle.py "$s" --timeout 30 --no-print; echo "$s ready=$?"; done
 ```
 
 If `broadcast.sh` is unavailable, fan the message out in one loop, then wait in a **second** loop (never one combined loop — that serializes the waits behind each send).
+
+## Periodic fleet status during long runs
+
+When orchestrating multiple agents for more than a few minutes, keep the user informed on a guidance cadence of about **every 5 minutes**. The cadence is read-only: inspect panes, summarize, and continue waiting. Do **not** send keystrokes, attach, or otherwise interrupt agents that are still working.
+
+A useful status report is a compact table:
+
+| Agent | Session | State | Task / progress | Started | Workdir |
+| --- | --- | --- | --- | --- | --- |
+| reviewer | myrepo-reviewer | in-progress | reviewing auth tests | 14:02 | `/repo` |
+| docs | myrepo-docs | blocked | trust prompt visible | 14:03 | `/repo` |
+
+Collect raw fields with tmux formats, then fill the progress column from a bounded tail capture:
+
+```bash
+tmux list-sessions -F '#{session_name}|#{t:session_created}'
+tmux list-panes -a -F '#{session_name}|#{pane_current_path}|#{pane_current_command}'
+tmux capture-pane -t myrepo-reviewer -p -S -40
+```
+
+Classify conservatively: spinner / `esc to interrupt` or changing captures means `in-progress`; known dialog text or `wait_for_idle.py --no-print` exit 3 means `blocked`; quiet pane with completed answer/prompt means `done`; otherwise `unknown`. Preserve the existing wait budget from SKILL.md Phase 4 — the status cadence is for user visibility, not an infinite poll loop.
+
+## Status and inspect commands
+
+Use **status** to summarize every managed agent. Treat managed agents as sessions launched during this run plus sessions following the `<folder>-<short-task-name>` naming convention for the current workspace. If unrelated tmux sessions exist, omit them or list them separately as `unmanaged` rather than mixing them into the fleet.
+
+Minimum status columns:
+
+- Agent ID: usually the short task slug (for `myrepo-reviewer`, agent ID is `reviewer`).
+- Session: exact tmux session name.
+- State: `in-progress`, `done`, `blocked`, or `unknown`.
+- Progress: one short phrase from the current task or last meaningful line.
+- Started: `#{t:session_created}` from `tmux list-sessions`.
+- Workdir: `#{pane_current_path}` from the active pane.
+
+Use **inspect `<agent-id>`** to drill into one session. Resolve the agent ID to one exact session first; on ambiguity, show candidates and ask the user to choose before printing an attach target. Include the status fields, pane command, pane index if useful, a bounded tail (`-S -40`, widened only if truncated), and this copy-paste command for the human:
+
+```bash
+tmux attach-session -t <exact-session-name>
+```
+
+Never execute the attach command from the orchestrator; it requires the user's real terminal.
 
 ## Sending multi-line or code-heavy messages
 

--- a/skills/tmux-agent-comms/references/tmux-recipes.md
+++ b/skills/tmux-agent-comms/references/tmux-recipes.md
@@ -39,7 +39,7 @@ tmux list-panes -a -F '#{session_name}|#{pane_current_path}|#{pane_current_comma
 tmux capture-pane -t myrepo-reviewer -p -S -40
 ```
 
-Classify conservatively: spinner / `esc to interrupt` or changing captures means `in-progress`; known dialog text or `wait_for_idle.py --no-print` exit 3 means `blocked`; quiet pane with completed answer/prompt means `done`; otherwise `unknown`. Preserve the existing wait budget from SKILL.md Phase 4 — the status cadence is for user visibility, not an infinite poll loop.
+Classify conservatively and quickly: spinner / `esc to interrupt` or two short captures that differ means `in-progress`; known dialog text or `wait_for_idle.py --timeout 3 --quiet-cycles 1 --no-print` exit 3 means `blocked`; quiet pane with completed answer/prompt means `done`; otherwise `unknown`. Preserve the existing wait budget from SKILL.md Phase 4 — the status cadence is for user visibility, not an infinite poll loop, and status must not spend a full waiter timeout on every active agent.
 
 ## Status and inspect commands
 


### PR DESCRIPTION
## Summary
- add read-only periodic fleet status reporting guidance for long-running tmux agent work
- document autonomous/non-blocking startup as the default with interactive opt-in
- add status/inspect behavior, attach-command output, and <folder>-<short-task-name> session naming
- update README, recipes, and evals for the new workflow

## Validation
- python3 ~/.claude/skills/skill-creator/scripts/quick_validate.py skills/tmux-agent-comms
- python3 -m json.tool skills/tmux-agent-comms/evals/evals.json
- git diff --check

Closes #66
Closes #68
Closes #69