### PR TITLE
feat(skills): add fork-upstream-sync agent skill

### DIFF
--- a/skills/fork-upstream-sync/SKILL.md
+++ b/skills/fork-upstream-sync/SKILL.md
@@ -4,7 +4,7 @@ description: "Sync a GitHub fork with upstream while keeping unmerged feature br
 license: MIT
 effort: medium
 metadata:
-  version: 1.0.1
+  version: 1.0.3
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -34,7 +34,15 @@ git fetch upstream
 git fetch origin
 ```
 
-If the working tree is dirty, stash first, sync, then pop the stash.
+If the working tree is dirty:
+
+```bash
+git stash push -u -m "pre-sync: $(git rev-parse --abbrev-ref HEAD)"
+# ...run the fetch/rebase/reset steps for the chosen path...
+git stash pop
+```
+
+On `git stash pop` conflict, stop — the stash is preserved (`git stash list`); resolve manually before continuing.
 
 If `upstream` is missing, `origin` is missing, or the user has not said which upstream org/repo to use, stop and ask. Never force-push `main` without `--force-with-lease`.
 
@@ -57,7 +65,7 @@ After each major phase, emit a short report with checks for upstream remote, com
 
 1. Identify PR head branch and upstream base (`main`).
 2. `git checkout <feature-branch>` then `git rebase upstream/main`.
-3. On each conflict, resolve files. When upstream and your feature both added valid code, keep **both** (union), not either/or.
+3. On each conflict, resolve files. When upstream and your feature both added valid code, keep **both** (union), not either/or. If a conflict can't be confidently resolved, `git rebase --abort` and stop to ask the user rather than guessing.
 4. `git add` resolved files, then `GIT_EDITOR=true git rebase --continue`.
 5. For locale JSON conflicts, keep the rebased side then run the repo catalog fix if documented (for example `pnpm run sync:localization-catalog --fix`).
 6. `git push origin <feature-branch> --force-with-lease`.
@@ -74,9 +82,10 @@ After Path B:
 ```bash
 git checkout main
 git reset --hard upstream/main
-git merge --ff-only <feature-branch>
-git push origin main --force-with-lease
+git merge --ff-only <feature-branch> && git push origin main --force-with-lease
 ```
+
+If `--ff-only` fails, `main` is already reset to bare `upstream/main` — **do not push**. The feature branch is behind the new `upstream/main`; re-run Path B to rebase it, then retry this merge. Pushing here without the fast-forward would force-publish plain `upstream/main`, silently dropping your integration WIP from `origin/main`.
 
 **Done when:** `upstream/main` is ancestor of `main`, `main` SHA equals feature branch SHA, and ahead count matches your feature commits.
 
@@ -104,9 +113,10 @@ git fetch upstream origin
 git checkout <feature-branch> && git rebase upstream/main
 git push origin <feature-branch> --force-with-lease
 git checkout main && git reset --hard upstream/main
-git merge --ff-only <feature-branch>
-git push origin main --force-with-lease
+git merge --ff-only <feature-branch> && git push origin main --force-with-lease
 ```
+
+If `--ff-only` fails, do not push — re-run the rebase step against the current `upstream/main`, then retry.
 
 ## What not to do
 

--- a/skills/fork-upstream-sync/SKILL.md
+++ b/skills/fork-upstream-sync/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: fork-upstream-sync
+description: "Sync a GitHub fork with upstream while keeping unmerged feature branches and open PRs mergeable. Use for rebase on upstream, PR conflicts, integration main. Don't use for git init, releases, or non-fork repos."
+license: MIT
+effort: medium
+metadata:
+  version: 1.0.1
+  author: Luong NGUYEN <luongnv89@gmail.com>
+---
+
+# Fork Upstream Sync
+
+**Integration main** means fork `main` = `upstream/main` plus your unmerged commits in linear history (not a merge commit that duplicates feature work).
+
+## Branch selector
+
+Pick one path per user request:
+
+| Path | When |
+|------|------|
+| **A — Bootstrap** | No `upstream` remote yet, or first-time fork sync |
+| **B — PR branch** | Open PR is `CONFLICTING` or `DIRTY`; rebase feature branch on `upstream/main` |
+| **C — Integration main** | Fork `main` should match upstream plus same tip as feature branch |
+| **D — Post-merge** | Upstream merged your PR; drop duplicate commits on fork `main` |
+
+Paths B then C is the usual full sync (PR mergeable, fork `main` carries your WIP).
+
+## Repo sync before edits (mandatory)
+
+Before any rebase, reset, or force push:
+
+```bash
+git fetch upstream
+git fetch origin
+```
+
+If the working tree is dirty, stash first, sync, then pop the stash.
+
+If `upstream` is missing, `origin` is missing, or the user has not said which upstream org/repo to use, stop and ask. Never force-push `main` without `--force-with-lease`.
+
+## Step completion reports
+
+After each major phase, emit a short report with checks for upstream remote, commits behind upstream, PR mergeable status, conflicts resolved, and whether integration `main` matches the feature branch tip. End with Result PASS, FAIL, or PARTIAL.
+
+---
+
+## Path A — Bootstrap upstream remote
+
+1. Confirm parent repo (for example `gh repo view --json parent,isFork`).
+2. Add remote if absent: `git remote add upstream git@github.com:ORG/REPO.git`, then `git fetch upstream`.
+
+**Done when:** `git rev-parse upstream/main` succeeds and `git remote -v` lists `upstream`.
+
+---
+
+## Path B — Rebase feature branch on upstream
+
+1. Identify PR head branch and upstream base (`main`).
+2. `git checkout <feature-branch>` then `git rebase upstream/main`.
+3. On each conflict, resolve files. When upstream and your feature both added valid code, keep **both** (union), not either/or.
+4. `git add` resolved files, then `GIT_EDITOR=true git rebase --continue`.
+5. For locale JSON conflicts, keep the rebased side then run the repo catalog fix if documented (for example `pnpm run sync:localization-catalog --fix`).
+6. `git push origin <feature-branch> --force-with-lease`.
+7. Verify with `gh pr view <n> --repo ORG/REPO --json mergeable,mergeStateStatus` (expect MERGEABLE; CI may lag).
+
+**Done when:** rebase completes, no conflict markers in tree, PR is MERGEABLE or user accepts waiting on CI.
+
+---
+
+## Path C — Rebuild fork integration main
+
+After Path B:
+
+```bash
+git checkout main
+git reset --hard upstream/main
+git merge --ff-only <feature-branch>
+git push origin main --force-with-lease
+```
+
+**Done when:** `upstream/main` is ancestor of `main`, `main` SHA equals feature branch SHA, and ahead count matches your feature commits.
+
+---
+
+## Path D — Post-merge cleanup
+
+When upstream `main` already contains your merged PR:
+
+```bash
+git fetch upstream
+git checkout main
+git reset --hard upstream/main
+git push origin main --force-with-lease
+```
+
+**Done when:** `main` SHA equals `upstream/main` SHA.
+
+---
+
+## Routine cheat sheet
+
+```bash
+git fetch upstream origin
+git checkout <feature-branch> && git rebase upstream/main
+git push origin <feature-branch> --force-with-lease
+git checkout main && git reset --hard upstream/main
+git merge --ff-only <feature-branch>
+git push origin main --force-with-lease
+```
+
+## What not to do
+
+- Do not merge `upstream/main` into fork `main` with a merge commit while also keeping a parallel rebased feature branch.
+- Do not force-push without `--force-with-lease`.
+- Do not treat `origin` as upstream; `origin` is your fork, `upstream` is the parent.
+
+## Optional verification
+
+```bash
+git log --oneline -1 upstream/main main <feature-branch>
+git rev-list --count upstream/main..main
+```

--- a/skills/fork-upstream-sync/docs/README.md
+++ b/skills/fork-upstream-sync/docs/README.md
@@ -1,0 +1,27 @@
+<!--
+  DO NOT READ THIS FILE — This README.md is for human catalog browsing only.
+  It ships inside the .skill package but is NEVER auto-loaded into agent context.
+  The runtime loader only reads SKILL.md + references/ + scripts/ + agents/ when the skill triggers.
+  If you're an AI agent, read the SKILL.md file instead for skill instructions.
+-->
+
+# Fork Upstream Sync
+
+> Keep your GitHub fork `main` aligned with upstream while your open PR and unmerged work stay on top.
+
+## Highlights
+
+- Adds and uses an `upstream` remote (parent repo), separate from fork `origin`
+- Rebases feature branches so upstream PRs show MERGEABLE again
+- Builds integration main: `upstream/main` plus your commits (linear history)
+- Post-merge path to reset fork `main` to pure upstream
+
+## When to use
+
+- Sync my fork with upstream
+- PR has merge conflicts with main
+- Fork main up to date but keep not-yet-merged feature
+
+## Author
+
+Luong NGUYEN — luongnv89@gmail.com

--- a/skills/fork-upstream-sync/evals/evals.json
+++ b/skills/fork-upstream-sync/evals/evals.json
@@ -1,0 +1,36 @@
+{
+  "skill": "fork-upstream-sync",
+  "evals": [
+    {
+      "id": "sync-fork-keep-feature",
+      "prompt": "This repo is a fork of stablyai/orca. Sync with upstream so my main is current, but keep my markdown preview feature that is still in PR #7121 on branch feat/1-markdown-light-preview.",
+      "expected_behavior": [
+        "Adds or uses upstream remote and fetches upstream/main",
+        "Rebases feature branch onto upstream/main and resolves conflicts with union where needed",
+        "Rebuilds fork main as upstream/main fast-forwarded with feature branch tip",
+        "Uses force-with-lease when pushing",
+        "Reports mergeable PR status or equivalent verification"
+      ]
+    },
+    {
+      "id": "pr-conflicts-only",
+      "prompt": "My open PR branch conflicts with upstream main. Fix the branch so the PR can merge; do not change unrelated files.",
+      "expected_behavior": [
+        "Rebases from upstream/main onto PR head branch only",
+        "Resolves conflicts and continues rebase until complete",
+        "Force-pushes PR branch with lease",
+        "Does not reset fork main unless user asked for integration main"
+      ]
+    },
+    {
+      "id": "post-merge-cleanup",
+      "prompt": "Upstream merged my PR. Make my fork main identical to upstream main.",
+      "expected_behavior": [
+        "Fetches upstream",
+        "Resets local main to upstream/main",
+        "Force-pushes origin main with lease",
+        "Confirms main SHA matches upstream/main"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **fork-upstream-sync** — an agent skill for contributors who maintain a GitHub fork of an upstream repo and need to:

- Stay current with `upstream/main`
- Keep unmerged feature branches (and open PRs) rebased and **MERGEABLE**
- Maintain **integration main** on the fork: `upstream/main` + local WIP in linear history

Born from the stablyai/orca fork sync workflow (PR #7121 + integration `main`).

## Contents

- `skills/fork-upstream-sync/SKILL.md` — paths A–D (bootstrap, PR rebase, integration main, post-merge)
- `docs/README.md` — human catalog
- `evals/evals.json` — 3 eval prompts

## Checklist

- [x] `quick_validate.py` passes
- [x] Repo sync before edits (mandatory) section included
- [x] Description ≤250 chars with negative triggers