### PR TITLE
feat(herdr-agent-comms): add Herdr multi-agent fleet skill

### DIFF
--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: one project workspace, one tab pe
 license: MIT
 effort: medium
 metadata:
-  version: 1.0.0
+  version: 1.0.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -187,16 +187,25 @@ herdr wait agent-status "$pane_id" --status working --timeout 15000 \
 
 ## Phase 5: Wait for the Reply, Then Read It
 
-Use Herdr status waits (not fixed `sleep`):
+Use Herdr status waits (not fixed `sleep`). Completion may be **`done`** (unseen, usually background) **or `idle`** (seen / focused tab) — wait for either:
 
 ```bash
-# background tab/workspace → completion is often "done"
-herdr wait agent-status "$pane_id" --status done --timeout 180000
-# if the user is watching that tab, completion may be "idle" instead:
-# herdr wait agent-status "$pane_id" --status idle --timeout 180000
+# After delivery verified (Phase 4). Poll until idle|done|blocked or budget spent.
+deadline=$((SECONDS + 180))
+while (( SECONDS < deadline )); do
+  st=$(herdr pane get "$pane_id" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
+  case "$st" in
+    done|idle) echo "settled:$st"; break ;;
+    blocked) echo "blocked"; break ;;
+    working) herdr wait agent-status "$pane_id" --status done --timeout 15000 \
+               || herdr wait agent-status "$pane_id" --status idle --timeout 15000 || true ;;
+    *) sleep 2 ;;
+  esac
+done
+# Or: python3 scripts/wait_for_idle.py "$pane_id" --timeout 180
 ```
 
-Treat **either `idle` or `done` as completed** when inspecting `herdr pane get` / `herdr agent get` — difference is only whether the result was seen.
+Treat **either `idle` or `done` as completed** — difference is only whether the result was seen. Never wait only on `done` for the full budget: a focused-tab finish stays `idle` and will time out.
 
 Then read a capped recent transcript:
 
@@ -286,7 +295,8 @@ spawn() {
 p1="$(spawn reviewer 'pi --thinking medium' 'Review recent commits for risk; bullet findings only.')"
 p2="$(spawn tests 'pi --thinking low' 'Outline a minimal test plan for the last change.')"
 
-herdr wait agent-status "$p1" --status done --timeout 180000 || herdr wait agent-status "$p1" --status idle --timeout 1000
+python3 scripts/wait_for_idle.py "$p1" --timeout 180
+# (or the Phase 5 idle|done poll loop)
 herdr pane read "$p1" --source recent-unwrapped --lines 80
 herdr agent focus reviewer   # human can jump in to steer
 ```

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -1,0 +1,331 @@
+---
+name: herdr-agent-comms
+description: "Manage AI agent fleets in Herdr: one project workspace, one tab per agent, message/wait/read via herdr CLI, steer any pane. Use for Herdr multi-agent fleets. Don't use for tmux, screen, or non-Herdr terminals."
+license: MIT
+effort: medium
+metadata:
+  version: 1.0.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
+compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
+---
+
+# Herdr Agent Comms
+
+Manage and talk to AI agents (Claude Code, pi, Codex, OpenCode, or any CLI) running as **visible Herdr tabs**: **create** a project workspace, **spawn** one agent per tab, **send** tasks, **wait** on agent status, **capture** replies, and **tear down** when done.
+
+Mental model (Herdr concepts, not tmux):
+
+| Concept | Role in this skill |
+|---|---|
+| **Workspace** | One per project/repo — all agents for that project live here |
+| **Tab** | One per agent — each sub-agent is a dedicated tab you can jump into |
+| **Pane** | Real terminal inside the tab; primary control target (`wN:pM`) |
+| **Agent name** | Stable handle for send/wait/read (`reviewer`, `tests`, …) |
+
+You orchestrate from outside (or from another Herdr pane) with the `herdr` CLI. Prefer Herdr's agent-status waits over polling scrollback. Relay each agent's answer, not its whole screen.
+
+This skill is the **Herdr counterpart** of `tmux-agent-comms`. Use this when agents should live in Herdr; use `tmux-agent-comms` for plain tmux.
+
+## When to Use
+
+Spinning up a multi-agent fleet in Herdr, putting every agent for a project in one workspace, messaging or steering an agent tab, broadcasting to a fleet, or reading what an agent replied. Don't use for tmux/screen sessions or GUI apps.
+
+## Workflow
+
+Six phases, in order: ensure server + resolve workspace, spawn agent tabs, resolve targets, send, wait + read, continue or tear down.
+
+**Jump straight to the phase for your task** — don't read the rest:
+
+| Your task | Start at |
+|---|---|
+| Spin up N agents for a project (agent/model/thinking/skill + task) | Phase 1 → Phase 2 |
+| Message an agent that's already running | Phase 3 |
+| Just read a running agent's pane (no send) | Phase 5 |
+| Broadcast the same message to a fleet | Phase 6 ("Broadcast") |
+| Shut agents / tabs down | Phase 6 ("Tear down") |
+
+## Prerequisites
+
+1. **`herdr` installed**: `command -v herdr` must succeed. If missing, install (`curl -fsSL https://herdr.dev/install.sh | sh` or `brew install herdr`) and stop.
+2. **Server reachable**: `herdr status` must show a running server. If not, tell the user to attach once with `herdr` from a real terminal (do **not** run bare `herdr` from a non-TTY agent shell — it tries to launch the TUI).
+3. **Never nest tmux** inside a Herdr pane if you need agent detection — run agents directly in panes.
+4. **Installed binary is authority** for flags: when unsure, run `herdr <group>` with no subcommand (e.g. `herdr agent`, `herdr pane`) — never bare `herdr` for discovery.
+
+## Critical Rules
+
+1. **Confirm before destructive actions.** Closing panes/tabs/workspaces or `herdr server stop` can lose agent work — never without explicit user go-ahead. Reading panes is always safe.
+2. **Parse IDs from JSON.** Workspace/tab/pane IDs are opaque (`w26`, `w26:t2`, `w26:p4`). Never invent them from sidebar order.
+3. **One workspace per project; one tab per agent.** Default spawn path creates a **new tab** per agent inside the project workspace (not a split in the orchestrator tab). Use splits only when the user asks for side-by-side panes.
+4. **Prefer `--no-focus` for background fleet work** so spawning doesn't yank the user's focus. Use `herdr agent focus <name>` / `herdr tab focus <tab_id>` when the user wants to jump in and steer.
+5. **Wait on agent status, don't race.** After send, wait for `working` then `idle`/`done` (Phase 4). Don't send a follow-up while status is `working`.
+6. **`pane run` submits text + Enter.** Prefer it over separate `send-text`/`send-keys` for prompts. `agent send` is literal text only (no Enter) — use when you must type without submitting.
+7. **Blocked agents need humans.** Status `blocked` means a trust/auth/permission dialog — surface it; don't type the next task into the dialog.
+
+## Phase 1: Ensure Server and Project Workspace
+
+```bash
+command -v herdr >/dev/null || { echo "herdr missing"; exit 1; }
+herdr status
+herdr workspace list
+```
+
+Resolve the project directory (`project_dir`) and a short workspace label (default: basename of `project_dir`).
+
+**Reuse** an existing workspace whose label or cwd matches the project when possible:
+
+```bash
+herdr workspace list   # JSON: workspaces[].workspace_id, label, ...
+```
+
+**Create** only when none matches:
+
+```bash
+herdr workspace create --cwd "$project_dir" --label "$label" --no-focus
+# read result.workspace.workspace_id (or equivalent) from JSON
+```
+
+Optional: install the integration for agents you resume often (`herdr integration install pi|claude|codex|opencode|hermes`) so status is authoritative. Not required for every run.
+
+**Done when:** you have a concrete `workspace_id` for the project and the server is running.
+
+## Phase 2: Spawn Agent Tabs (fleet)
+
+For each agent in the fleet, create a **new tab** in that workspace, launch the CLI in its root pane, name the agent, wait until ready, then submit the task.
+
+### 2a — Create tab + launch
+
+```bash
+name=reviewer
+project_dir=/path/to/project
+ws="$workspace_id"          # from Phase 1
+agent_cmd='pi --model anthropic/claude-sonnet-4-6 --thinking medium'
+# optional skills for pi:  --skill /path/to/SKILL.md
+
+# free name if taken
+herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
+
+tab_json="$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label "$name" --no-focus)"
+pane_id="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["result"]["root_pane"]["pane_id"])')"
+tab_id="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["result"]["tab"]["tab_id"])')"
+
+herdr pane rename "$pane_id" "$name"
+herdr agent rename "$pane_id" "$name"
+herdr pane run "$pane_id" "$agent_cmd"
+```
+
+Alternative one-liner when you already have a tab and only need a split (user asked for panes, not tabs):
+
+```bash
+herdr agent start "$name" --cwd "$project_dir" --workspace "$ws" --tab "$tab_id" --split right --no-focus -- pi --model ...
+```
+
+Default for this skill is **tab-per-agent**, not split-per-agent.
+
+### 2b — Build `agent_cmd` (common CLIs)
+
+| Agent | Executable | Model / thinking / skill knobs |
+|---|---|---|
+| **pi** | `pi` | `--model <provider/id>`, `--thinking <off\|…\|max>`, `--skill <path>` (repeatable) |
+| **Claude Code** | `claude` | model via settings/`--model` if available; skills via project/plugin — don't invent flags |
+| **Codex** | `codex` | interactive default; verify flags with `codex --help` |
+| **OpenCode** | `opencode` | verify with `opencode --help` |
+
+Launch the **interactive** TUI (no `-p`/`exec` non-interactive mode) unless the user asked for fire-and-exit. Do **not** pass the long task as argv on first launch by default — boot first, then `pane run` the task (matches Herdr's own agent guide).
+
+### 2c — Ready, then assign work
+
+```bash
+# boot → idle (or blocked on trust)
+herdr wait agent-status "$pane_id" --status idle --timeout 60000
+# if timeout: herdr pane get / herdr agent explain "$pane_id"
+# if blocked: surface to user (Rule 7)
+
+herdr pane run "$pane_id" "Review the open PR diff and report only actionable findings."
+herdr wait agent-status "$pane_id" --status working --timeout 30000 || true
+```
+
+**Fleet spawn:** create every tab first (all `--no-focus`), launch every agent, then wait/read concurrently — don't fully serialize spawn→wait→read per agent when the user wants parallel work. `scripts/broadcast.sh` fans messages after spawn.
+
+**Human visibility:** tabs appear in the project workspace sidebar immediately. Tell the user they can click the tab or run `herdr agent focus <name>` / `herdr tab focus <tab_id>` to steer live. Detach the Herdr client with `prefix+q` (`ctrl+b` then `q`); agents keep running.
+
+**Done when:** each requested agent has `pane_id` + `tab_id` + agent `name`, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
+
+## Phase 3: Resolve the Exact Target
+
+Prefer the **agent name** when unique; fall back to `pane_id`:
+
+```bash
+herdr agent list
+herdr agent get reviewer          # or: herdr pane get w26:p4
+```
+
+If the name is missing, list agents and surface the closest match — don't silently retarget. Record both `name` and `pane_id` for later steps (`wait agent-status` wants a pane id; `agent send`/`agent wait` accept names).
+
+**Done when:** one concrete target id is chosen and exists in `agent list` / `pane get`.
+
+## Phase 4: Send a Message
+
+```bash
+# preferred — text + Enter
+herdr pane run "$pane_id" "summarize the changes in src/"
+
+# by name (literal text only — add Enter yourself if needed)
+herdr agent send reviewer "summarize the changes in src/"
+herdr pane send-keys "$pane_id" enter
+```
+
+**Escaping:** pass the message as a single argv to `herdr` (quoted for the shell). For multi-line or code-heavy payloads, write a temp file and send a short instruction that reads it — see `references/herdr-recipes.md`.
+
+**Verify delivery:** after send, status should leave `idle` for `working` (or stay `blocked` if a dialog ate the input):
+
+```bash
+herdr wait agent-status "$pane_id" --status working --timeout 15000 \
+  && echo delivered || echo NOT-DELIVERED
+```
+
+`NOT-DELIVERED` → lone Enter via `herdr pane send-keys "$pane_id" enter`, re-check; if still idle with no new output, re-send. Inspect with `herdr pane read "$pane_id" --source recent-unwrapped --lines 40`.
+
+## Phase 5: Wait for the Reply, Then Read It
+
+Use Herdr status waits (not fixed `sleep`):
+
+```bash
+# background tab/workspace → completion is often "done"
+herdr wait agent-status "$pane_id" --status done --timeout 180000
+# if the user is watching that tab, completion may be "idle" instead:
+# herdr wait agent-status "$pane_id" --status idle --timeout 180000
+```
+
+Treat **either `idle` or `done` as completed** when inspecting `herdr pane get` / `herdr agent get` — difference is only whether the result was seen.
+
+Then read a capped recent transcript:
+
+```bash
+herdr pane read "$pane_id" --source recent-unwrapped --lines 80
+# or: herdr agent read reviewer --source recent-unwrapped --lines 80
+```
+
+Sources: `visible` (viewport), `recent` (rendered scrollback), `recent-unwrapped` (preferred for transcripts), `detection` (bottom buffer for debug).
+
+**Branch on outcomes:**
+
+| Signal | Action |
+|---|---|
+| status `done`/`idle` after work | Relay the read output |
+| status `blocked` | Surface dialog; don't send more |
+| wait timeout | `pane get` + `pane read` + `agent explain`; escalate — don't poll forever |
+| status still `working` | Keep waiting under a hard overall budget (e.g. 2–3 re-waits) |
+
+Optional helper when status stays `unknown` (no integration / undetected CLI): `python3 scripts/wait_for_idle.py <pane_id>` polls `pane read` for content stability — see script `--help`.
+
+**Done when:** you either relay a reply delta or report blocked/timeout with evidence.
+
+## Phase 6: Continue, Broadcast, or Tear Down
+
+**Continue (steer):** focus if the human wants the live TUI, or keep messaging from the CLI:
+
+```bash
+herdr agent focus reviewer          # jump UI to that agent
+herdr pane run "$pane_id" "Also check the failing test."
+# then Phase 5 again
+```
+
+**Broadcast to a fleet:** send to every target first, then wait concurrently:
+
+```bash
+scripts/broadcast.sh "pull latest main and report status" reviewer tests docs
+# or pane ids: scripts/broadcast.sh "..." w26:p4 w26:p6
+```
+
+**Fleet status (read-only):**
+
+```bash
+herdr agent list
+herdr workspace list
+```
+
+**Tear down (confirmation required):**
+
+```bash
+herdr tab close "$tab_id"           # preferred — one agent tab
+herdr pane close "$pane_id"         # single pane
+herdr workspace close "$ws"         # whole project workspace — confirm
+# herdr server stop                 # kills everything — last resort, confirm
+```
+
+Never `server stop` from inside an active session unless the user explicitly wants the server and all panes dead.
+
+## Example
+
+Spin two agents in the current project workspace and collect answers:
+
+```bash
+project_dir="$(pwd)"
+label="$(basename "$project_dir")"
+ws="$(herdr workspace list | python3 -c "
+import sys,json,os
+d=json.load(sys.stdin); label=os.environ['L']
+for w in d['result']['workspaces']:
+    if w.get('label')==label: print(w['workspace_id']); break
+" )"
+# if empty: create with herdr workspace create --cwd "$project_dir" --label "$label" --no-focus
+
+spawn() {
+  local name="$1" cmd="$2" task="$3"
+  local tab_json pane
+  tab_json="$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label "$name" --no-focus)"
+  pane="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')"
+  herdr pane rename "$pane" "$name"
+  herdr agent rename "$pane" "$name"
+  herdr pane run "$pane" "$cmd"
+  herdr wait agent-status "$pane" --status idle --timeout 60000
+  herdr pane run "$pane" "$task"
+  printf '%s\n' "$pane"
+}
+
+p1="$(spawn reviewer 'pi --thinking medium' 'Review recent commits for risk; bullet findings only.')"
+p2="$(spawn tests 'pi --thinking low' 'Outline a minimal test plan for the last change.')"
+
+herdr wait agent-status "$p1" --status done --timeout 180000 || herdr wait agent-status "$p1" --status idle --timeout 1000
+herdr pane read "$p1" --source recent-unwrapped --lines 80
+herdr agent focus reviewer   # human can jump in to steer
+```
+
+## Edge Cases
+
+- **Not inside Herdr / no server** — CLI still talks to the socket if the server runs; if `herdr status` fails, user must start `herdr` once in a real terminal.
+- **Nested `herdr` launch** — if `HERDR_ENV=1`, never run bare `herdr` (blocked by design). Use CLI subcommands only.
+- **Trust/auth dialog** — status `blocked`; surface it, don't submit the task.
+- **`idle` vs `done`** — both mean "finished or waiting for input"; `done` = unseen completion in background. Accept either after work.
+- **Name collision** — `agent rename` / `agent start` names must be unique; suffix with epoch if taken.
+- **Wrong workspace** — never spawn project B agents into project A's workspace; re-resolve Phase 1.
+- **Status `unknown`** — install integration or use `scripts/wait_for_idle.py` + `pane read`.
+- **User wants to steer** — `herdr agent focus <name>` or tell them to click the tab; keep sending CLI follow-ups only when not fighting their keyboard.
+- **Closing the wrong tab** — only close tabs/panes this skill created, unless the user names the target.
+
+## Reference
+
+- `references/herdr-recipes.md` — fleet layouts, multi-line sends, focus/steer, scrollback, troubleshooting.
+- `references/delivery-and-waiting.md` — delivery checks, idle/done/blocked, budgets.
+- Official concepts: https://herdr.dev/docs/concepts/ · CLI: https://herdr.dev/docs/cli-reference/ · cheatsheet: https://luongnv.com/awesome-cheatsheets/cheatsheets/herdr/
+
+## Step Completion Report
+
+After a messaging or lifecycle operation, emit:
+
+```
+◆ Herdr Agent Comms ([what you did])
+··································································
+  Server:              √ pass (herdr status)
+  Workspace:           √ pass (w26 · project label)
+  Target resolved:     √ pass (name: reviewer · pane: w26:p4 · tab: w26:t2)
+  Message sent:        √ pass (pane run)
+  Message delivered:   √ pass (status → working)
+  Reply settled:       √ pass (status done|idle)
+  Reply captured:      √ pass (recent-unwrapped, not truncated)
+  Destructive action:  — none (or: confirmed by user)
+  ____________________________
+  Result:              PASS
+```
+
+Adapt rows to the operation — a spawn reports `Tabs created`; a teardown reports `Confirmed` and `Tabs closed`. Use `⚠` for dropped delivery or escalated stall.

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -1,25 +1,25 @@
 ---
 name: herdr-agent-comms
-description: "Manage AI agent fleets in Herdr: one project workspace, one tab per agent, message/wait/read via herdr CLI, steer any pane. Use for Herdr multi-agent fleets. Don't use for tmux, screen, or non-Herdr terminals."
+description: "Manage AI agent fleets in Herdr: one project workspace, split panes in one view, message/wait/read via herdr CLI, steer any pane. Use for Herdr multi-agent fleets. Don't use for tmux, screen, or non-Herdr terminals."
 license: MIT
 effort: medium
 metadata:
-  version: 1.0.1
+  version: 1.1.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
 
 # Herdr Agent Comms
 
-Manage and talk to AI agents (Claude Code, pi, Codex, OpenCode, or any CLI) running as **visible Herdr tabs**: **create** a project workspace, **spawn** one agent per tab, **send** tasks, **wait** on agent status, **capture** replies, and **tear down** when done.
+Manage and talk to AI agents (Claude Code, pi, Codex, OpenCode, or any CLI) as **split panes in one fleet view**: **create** a project workspace, **spawn** agents into a shared tab via splits, **send** tasks, **wait** on agent status, **capture** replies, and **tear down** when done.
 
 Mental model (Herdr concepts, not tmux):
 
 | Concept | Role in this skill |
 |---|---|
 | **Workspace** | One per project/repo — all agents for that project live here |
-| **Tab** | One per agent — each sub-agent is a dedicated tab you can jump into |
-| **Pane** | Real terminal inside the tab; primary control target (`wN:pM`) |
+| **Fleet tab** | One shared tab (label e.g. `fleet`) holding the whole multi-agent view |
+| **Pane** | One agent = one split pane; primary control target (`wN:pM`) |
 | **Agent name** | Stable handle for send/wait/read (`reviewer`, `tests`, …) |
 
 You orchestrate from outside (or from another Herdr pane) with the `herdr` CLI. Prefer Herdr's agent-status waits over polling scrollback. Relay each agent's answer, not its whole screen.
@@ -28,11 +28,11 @@ This skill is the **Herdr counterpart** of `tmux-agent-comms`. Use this when age
 
 ## When to Use
 
-Spinning up a multi-agent fleet in Herdr, putting every agent for a project in one workspace, messaging or steering an agent tab, broadcasting to a fleet, or reading what an agent replied. Don't use for tmux/screen sessions or GUI apps.
+Spinning up a multi-agent fleet in Herdr, putting every agent for a project in one workspace as **side-by-side / tiled panes**, messaging or steering any pane, broadcasting to a fleet, or reading what an agent replied. Don't use for tmux/screen sessions or GUI apps.
 
 ## Workflow
 
-Six phases, in order: ensure server + resolve workspace, spawn agent tabs, resolve targets, send, wait + read, continue or tear down.
+Six phases, in order: ensure server + resolve workspace, spawn split-pane fleet, resolve targets, send, wait + read, continue or tear down.
 
 **Jump straight to the phase for your task** — don't read the rest:
 
@@ -42,7 +42,7 @@ Six phases, in order: ensure server + resolve workspace, spawn agent tabs, resol
 | Message an agent that's already running | Phase 3 |
 | Just read a running agent's pane (no send) | Phase 5 |
 | Broadcast the same message to a fleet | Phase 6 ("Broadcast") |
-| Shut agents / tabs down | Phase 6 ("Tear down") |
+| Shut agents / fleet tab down | Phase 6 ("Tear down") |
 
 ## Prerequisites
 
@@ -55,8 +55,8 @@ Six phases, in order: ensure server + resolve workspace, spawn agent tabs, resol
 
 1. **Confirm before destructive actions.** Closing panes/tabs/workspaces or `herdr server stop` can lose agent work — never without explicit user go-ahead. Reading panes is always safe.
 2. **Parse IDs from JSON.** Workspace/tab/pane IDs are opaque (`w26`, `w26:t2`, `w26:p4`). Never invent them from sidebar order.
-3. **One workspace per project; one tab per agent.** Default spawn path creates a **new tab** per agent inside the project workspace (not a split in the orchestrator tab). Use splits only when the user asks for side-by-side panes.
-4. **Prefer `--no-focus` for background fleet work** so spawning doesn't yank the user's focus. Use `herdr agent focus <name>` / `herdr tab focus <tab_id>` when the user wants to jump in and steer.
+3. **One workspace per project; one fleet tab; split pane per agent.** Default spawn path puts **all fleet agents in a single tab** as tiled splits so the human sees everyone at once. Create a **new tab per agent only** when the user explicitly asks for full-viewport isolation.
+4. **Prefer `--no-focus` while spawning** so layout churn doesn't steal the keyboard from the human. After the fleet is up, `herdr tab focus <fleet_tab>` (or click the fleet tab) shows the whole board; `herdr agent focus <name>` zooms to one pane to type.
 5. **Wait on agent status, don't race.** After send, wait for `working` then `idle`/`done` (Phase 4). Don't send a follow-up while status is `working`.
 6. **`pane run` submits text + Enter.** Prefer it over separate `send-text`/`send-keys` for prompts. `agent send` is literal text only (no Enter) — use when you must type without submitting.
 7. **Blocked agents need humans.** Status `blocked` means a trust/auth/permission dialog — surface it; don't type the next task into the dialog.
@@ -88,38 +88,52 @@ Optional: install the integration for agents you resume often (`herdr integratio
 
 **Done when:** you have a concrete `workspace_id` for the project and the server is running.
 
-## Phase 2: Spawn Agent Tabs (fleet)
+## Phase 2: Spawn Split-Pane Fleet
 
-For each agent in the fleet, create a **new tab** in that workspace, launch the CLI in its root pane, name the agent, wait until ready, then submit the task.
+Put **all agents in one fleet tab** as tiled splits so the human sees every agent in a single view.
 
-### 2a — Create tab + launch
+### 2a — Create one fleet tab, then split per agent
 
 ```bash
-name=reviewer
 project_dir=/path/to/project
 ws="$workspace_id"          # from Phase 1
-agent_cmd='pi --model anthropic/claude-sonnet-4-6 --thinking medium'
-# optional skills for pi:  --skill /path/to/SKILL.md
+fleet_label=fleet           # or "${label}-fleet"
 
-# free name if taken
+# One shared tab for the whole fleet
+tab_json="$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label "$fleet_label" --no-focus)"
+fleet_tab="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')"
+root_pane="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')"
+
+# --- agent 1: use the tab's root pane ---
+name=reviewer
+agent_cmd='pi --thinking medium'
 herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
+herdr pane rename "$root_pane" "$name"
+herdr agent rename "$root_pane" "$name"
+herdr pane run "$root_pane" "$agent_cmd"
+# record: pane_id=$root_pane
 
-tab_json="$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label "$name" --no-focus)"
-pane_id="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["result"]["root_pane"]["pane_id"])')"
-tab_id="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["result"]["tab"]["tab_id"])')"
+# --- agents 2..N: split inside the same fleet tab ---
+# Alternate right/down for a usable tile (2-up: right; 3+: right then down…).
+# Always --no-focus so the human keeps their keyboard.
+name=tests
+herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
+start_json="$(herdr agent start "$name" \
+  --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
+  --split right --no-focus -- pi --thinking low)"
+pane_id="$(printf '%s' "$start_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["agent"]["pane_id"])')"
+# if argv after -- is only the launcher, boot is done; else still wait idle before task
 
-herdr pane rename "$pane_id" "$name"
-herdr agent rename "$pane_id" "$name"
-herdr pane run "$pane_id" "$agent_cmd"
+name=docs
+herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
+herdr agent start "$name" \
+  --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
+  --split down --no-focus -- pi --thinking low
 ```
 
-Alternative one-liner when you already have a tab and only need a split (user asked for panes, not tabs):
+**Split direction rule:** prefer `right` when the target pane is wider than tall; prefer `down` when it is tall/narrow. If you cannot inspect layout, **alternate** `right`, `down`, `right`, … Avoid stacking every split in the same direction (creates unusable slivers).
 
-```bash
-herdr agent start "$name" --cwd "$project_dir" --workspace "$ws" --tab "$tab_id" --split right --no-focus -- pi --model ...
-```
-
-Default for this skill is **tab-per-agent**, not split-per-agent.
+**Optional (user asked for full-viewport isolation):** one tab per agent via `herdr tab create` per name — see `references/herdr-recipes.md` ("Tab-per-agent layout"). Not the default.
 
 ### 2b — Build `agent_cmd` (common CLIs)
 
@@ -132,10 +146,12 @@ Default for this skill is **tab-per-agent**, not split-per-agent.
 
 Launch the **interactive** TUI (no `-p`/`exec` non-interactive mode) unless the user asked for fire-and-exit. Do **not** pass the long task as argv on first launch by default — boot first, then `pane run` the task (matches Herdr's own agent guide).
 
+When using `herdr agent start … -- <argv>`, put only the launcher (+ model/thinking/skill flags) after `--`, not the long task prompt.
+
 ### 2c — Ready, then assign work
 
 ```bash
-# boot → idle (or blocked on trust)
+# boot → idle (or blocked on trust) — per pane
 herdr wait agent-status "$pane_id" --status idle --timeout 60000
 # if timeout: herdr pane get / herdr agent explain "$pane_id"
 # if blocked: surface to user (Rule 7)
@@ -144,11 +160,18 @@ herdr pane run "$pane_id" "Review the open PR diff and report only actionable fi
 herdr wait agent-status "$pane_id" --status working --timeout 30000 || true
 ```
 
-**Fleet spawn:** create every tab first (all `--no-focus`), launch every agent, then wait/read concurrently — don't fully serialize spawn→wait→read per agent when the user wants parallel work. `scripts/broadcast.sh` fans messages after spawn.
+**Fleet spawn:** create the fleet tab once, spawn every split (`--no-focus`), launch every agent, then wait/read concurrently — don't fully serialize spawn→wait→read per agent when the user wants parallel work. `scripts/broadcast.sh` fans messages after spawn.
 
-**Human visibility:** tabs appear in the project workspace sidebar immediately. Tell the user they can click the tab or run `herdr agent focus <name>` / `herdr tab focus <tab_id>` to steer live. Detach the Herdr client with `prefix+q` (`ctrl+b` then `q`); agents keep running.
+**Human visibility:** after spawn, focus the fleet tab so all panes are on screen:
 
-**Done when:** each requested agent has `pane_id` + `tab_id` + agent `name`, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
+```bash
+herdr tab focus "$fleet_tab"
+# or zoom one agent: herdr agent focus reviewer
+```
+
+Detach the Herdr client with `prefix+q` (`ctrl+b` then `q`); agents keep running.
+
+**Done when:** each requested agent has `pane_id` + shared `fleet_tab` + agent `name`, all panes are in that tab, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
 
 ## Phase 3: Resolve the Exact Target
 
@@ -256,8 +279,8 @@ herdr workspace list
 **Tear down (confirmation required):**
 
 ```bash
-herdr tab close "$tab_id"           # preferred — one agent tab
-herdr pane close "$pane_id"         # single pane
+herdr pane close "$pane_id"         # one agent pane
+herdr tab close "$fleet_tab"        # preferred — whole fleet view at once
 herdr workspace close "$ws"         # whole project workspace — confirm
 # herdr server stop                 # kills everything — last resort, confirm
 ```
@@ -266,11 +289,12 @@ Never `server stop` from inside an active session unless the user explicitly wan
 
 ## Example
 
-Spin two agents in the current project workspace and collect answers:
+Spin two agents side-by-side in one fleet tab and collect answers:
 
 ```bash
 project_dir="$(pwd)"
 label="$(basename "$project_dir")"
+export L="$label"
 ws="$(herdr workspace list | python3 -c "
 import sys,json,os
 d=json.load(sys.stdin); label=os.environ['L']
@@ -279,26 +303,28 @@ for w in d['result']['workspaces']:
 " )"
 # if empty: create with herdr workspace create --cwd "$project_dir" --label "$label" --no-focus
 
-spawn() {
-  local name="$1" cmd="$2" task="$3"
-  local tab_json pane
-  tab_json="$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label "$name" --no-focus)"
-  pane="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')"
-  herdr pane rename "$pane" "$name"
-  herdr agent rename "$pane" "$name"
-  herdr pane run "$pane" "$cmd"
-  herdr wait agent-status "$pane" --status idle --timeout 60000
-  herdr pane run "$pane" "$task"
-  printf '%s\n' "$pane"
-}
+tab_json="$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label fleet --no-focus)"
+fleet_tab="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')"
+p1="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')"
 
-p1="$(spawn reviewer 'pi --thinking medium' 'Review recent commits for risk; bullet findings only.')"
-p2="$(spawn tests 'pi --thinking low' 'Outline a minimal test plan for the last change.')"
+herdr pane rename "$p1" reviewer
+herdr agent rename "$p1" reviewer
+herdr pane run "$p1" 'pi --thinking medium'
 
+j2="$(herdr agent start tests --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
+  --split right --no-focus -- pi --thinking low)"
+p2="$(printf '%s' "$j2" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["agent"]["pane_id"])')"
+
+for p in "$p1" "$p2"; do
+  herdr wait agent-status "$p" --status idle --timeout 60000
+done
+herdr pane run "$p1" 'Review recent commits for risk; bullet findings only.'
+herdr pane run "$p2" 'Outline a minimal test plan for the last change.'
+
+herdr tab focus "$fleet_tab"   # show both panes in one view
 python3 scripts/wait_for_idle.py "$p1" --timeout 180
-# (or the Phase 5 idle|done poll loop)
 herdr pane read "$p1" --source recent-unwrapped --lines 80
-herdr agent focus reviewer   # human can jump in to steer
+herdr agent focus reviewer     # optional: zoom to type into one pane
 ```
 
 ## Edge Cases
@@ -310,8 +336,9 @@ herdr agent focus reviewer   # human can jump in to steer
 - **Name collision** — `agent rename` / `agent start` names must be unique; suffix with epoch if taken.
 - **Wrong workspace** — never spawn project B agents into project A's workspace; re-resolve Phase 1.
 - **Status `unknown`** — install integration or use `scripts/wait_for_idle.py` + `pane read`.
-- **User wants to steer** — `herdr agent focus <name>` or tell them to click the tab; keep sending CLI follow-ups only when not fighting their keyboard.
-- **Closing the wrong tab** — only close tabs/panes this skill created, unless the user names the target.
+- **Too many splits** — more than ~4 panes in one tab gets cramped; still default to splits unless the user asks for tab-per-agent, or create a second fleet tab for overflow.
+- **User wants to steer** — `herdr tab focus` for the whole board, `herdr agent focus <name>` for one pane; keep sending CLI follow-ups only when not fighting their keyboard.
+- **Closing the wrong pane/tab** — only close panes/tabs this skill created, unless the user names the target.
 
 ## Reference
 
@@ -328,7 +355,7 @@ After a messaging or lifecycle operation, emit:
 ··································································
   Server:              √ pass (herdr status)
   Workspace:           √ pass (w26 · project label)
-  Target resolved:     √ pass (name: reviewer · pane: w26:p4 · tab: w26:t2)
+  Target resolved:     √ pass (name: reviewer · pane: w26:p4 · fleet tab: w26:t2)
   Message sent:        √ pass (pane run)
   Message delivered:   √ pass (status → working)
   Reply settled:       √ pass (status done|idle)
@@ -338,4 +365,4 @@ After a messaging or lifecycle operation, emit:
   Result:              PASS
 ```
 
-Adapt rows to the operation — a spawn reports `Tabs created`; a teardown reports `Confirmed` and `Tabs closed`. Use `⚠` for dropped delivery or escalated stall.
+Adapt rows to the operation — a spawn reports `Fleet tab + splits created`; a teardown reports `Confirmed` and `Panes/tab closed`. Use `⚠` for dropped delivery or escalated stall.

--- a/skills/herdr-agent-comms/docs/README.md
+++ b/skills/herdr-agent-comms/docs/README.md
@@ -1,0 +1,84 @@
+<!--
+  DO NOT READ THIS FILE — This README.md is for human catalog browsing only.
+  It ships inside the .skill package but is NEVER auto-loaded into agent context.
+  The runtime loader only reads SKILL.md + references/ + scripts/ + agents/ when the skill triggers.
+  If you're an AI agent, read the SKILL.md file instead for skill instructions.
+-->
+
+# Herdr Agent Comms
+
+> Spawn, manage, and talk to AI agents as Herdr tabs — one project workspace, one tab per agent, messaging via the `herdr` CLI with status-aware waits.
+
+## Highlights
+
+- **Project workspace** — all agents for a repo share one Herdr workspace (sidebar rollup).
+- **Tab per agent** — each sub-agent is a visible tab you can click or `herdr agent focus`.
+- **Fleet spawn** — agent CLI + model + thinking + optional skills, then assign tasks in parallel.
+- **Message & steer** — `pane run` / `agent send`, wait on `working` → `done`/`idle`, read transcripts.
+- **Broadcast** — fan one instruction to many agents; concurrent waits.
+- **Safe teardown** — close tabs/panes only after confirmation; never surprise `server stop`.
+
+## When to Use
+
+| Say this... | Skill will... |
+|---|---|
+| "Spin up 3 Herdr agents for this repo: reviewer, tests, docs" | Create/reuse project workspace, one tab each, launch agents |
+| "Ask the reviewer agent what it found" | Resolve target, send, wait on status, relay reply |
+| "Broadcast 'pull main' to all fleet agents" | Fan-out send + concurrent collect |
+| "Jump me into the tests agent so I can steer" | `herdr agent focus tests` |
+
+## How It Works
+
+```mermaid
+graph TD
+    A["Ensure herdr server + project workspace"] --> B["Create tab per agent + launch CLI"]
+    B --> C["Rename agent · wait idle · submit task"]
+    C --> D["Send / broadcast via pane run"]
+    D --> E["Wait agent-status done|idle"]
+    E --> F["Read recent-unwrapped · relay"]
+    F --> G["Focus to steer or tear down confirmed"]
+    style A fill:#4CAF50,color:#fff
+    style G fill:#2196F3,color:#fff
+```
+
+## Usage
+
+```
+/herdr-agent-comms
+```
+
+Or describe the goal in natural language — "launch a Herdr fleet", "message my Herdr reviewer tab".
+
+## Popular Use Cases
+
+### 1. Fleet with model/thinking/skill knobs
+
+```
+/herdr-agent-comms spin up 2 pi agents in this project:
+- reviewer: model sonnet, thinking medium, skill code-review — review the last commit
+- tests: thinking low — propose a minimal test plan
+```
+
+### 2. Message a running agent
+
+```
+/herdr-agent-comms ask reviewer to summarize open risks; show me the reply
+```
+
+### 3. Steer live
+
+```
+/herdr-agent-comms focus the tests agent so I can type into it
+```
+
+## Requirements
+
+- Herdr installed (`herdr --version`) and server running (`herdr status`)
+- Agent CLIs on PATH (`pi`, `claude`, `codex`, …) as needed
+- Optional: `herdr integration install <agent>` for better status
+
+## Related
+
+- Sibling skill: `tmux-agent-comms` (same workflow for plain tmux)
+- Cheatsheet: https://luongnv.com/awesome-cheatsheets/cheatsheets/herdr/
+- Docs: https://herdr.dev/docs/

--- a/skills/herdr-agent-comms/docs/README.md
+++ b/skills/herdr-agent-comms/docs/README.md
@@ -7,36 +7,36 @@
 
 # Herdr Agent Comms
 
-> Spawn, manage, and talk to AI agents as Herdr tabs — one project workspace, one tab per agent, messaging via the `herdr` CLI with status-aware waits.
+> Spawn, manage, and talk to AI agents as **split panes in one fleet view** — one project workspace, tiled agents you can see at once, messaging via the `herdr` CLI with status-aware waits.
 
 ## Highlights
 
 - **Project workspace** — all agents for a repo share one Herdr workspace (sidebar rollup).
-- **Tab per agent** — each sub-agent is a visible tab you can click or `herdr agent focus`.
+- **Split-pane fleet** — one fleet tab; each agent is a visible pane (side-by-side / tiled).
 - **Fleet spawn** — agent CLI + model + thinking + optional skills, then assign tasks in parallel.
 - **Message & steer** — `pane run` / `agent send`, wait on `working` → `done`/`idle`, read transcripts.
 - **Broadcast** — fan one instruction to many agents; concurrent waits.
-- **Safe teardown** — close tabs/panes only after confirmation; never surprise `server stop`.
+- **Safe teardown** — close panes or the fleet tab only after confirmation; never surprise `server stop`.
 
 ## When to Use
 
 | Say this... | Skill will... |
 |---|---|
-| "Spin up 3 Herdr agents for this repo: reviewer, tests, docs" | Create/reuse project workspace, one tab each, launch agents |
+| "Spin up 3 Herdr agents for this repo: reviewer, tests, docs" | Create/reuse project workspace, one fleet tab, split panes, launch agents |
 | "Ask the reviewer agent what it found" | Resolve target, send, wait on status, relay reply |
 | "Broadcast 'pull main' to all fleet agents" | Fan-out send + concurrent collect |
-| "Jump me into the tests agent so I can steer" | `herdr agent focus tests` |
+| "Show me all agents / focus the tests pane so I can steer" | `herdr tab focus` fleet · `herdr agent focus tests` |
 
 ## How It Works
 
 ```mermaid
 graph TD
-    A["Ensure herdr server + project workspace"] --> B["Create tab per agent + launch CLI"]
-    B --> C["Rename agent · wait idle · submit task"]
-    C --> D["Send / broadcast via pane run"]
-    D --> E["Wait agent-status done|idle"]
-    E --> F["Read recent-unwrapped · relay"]
-    F --> G["Focus to steer or tear down confirmed"]
+    A["Ensure herdr server + project workspace"] --> B["Create one fleet tab"]
+    B --> C["Root pane + split panes per agent"]
+    C --> D["Rename · wait idle · submit tasks"]
+    D --> E["Send / broadcast via pane run"]
+    E --> F["Wait agent-status done|idle"]
+    F --> G["Read recent-unwrapped · focus to steer"]
     style A fill:#4CAF50,color:#fff
     style G fill:#2196F3,color:#fff
 ```
@@ -47,14 +47,14 @@ graph TD
 /herdr-agent-comms
 ```
 
-Or describe the goal in natural language — "launch a Herdr fleet", "message my Herdr reviewer tab".
+Or describe the goal in natural language — "launch a Herdr fleet side by side", "message my Herdr reviewer pane".
 
 ## Popular Use Cases
 
-### 1. Fleet with model/thinking/skill knobs
+### 1. Fleet with model/thinking/skill knobs (all visible)
 
 ```
-/herdr-agent-comms spin up 2 pi agents in this project:
+/herdr-agent-comms spin up 2 pi agents in this project as split panes:
 - reviewer: model sonnet, thinking medium, skill code-review — review the last commit
 - tests: thinking low — propose a minimal test plan
 ```

--- a/skills/herdr-agent-comms/evals/evals.json
+++ b/skills/herdr-agent-comms/evals/evals.json
@@ -9,8 +9,8 @@
     },
     {
       "id": 2,
-      "prompt": "Spin up two Herdr agents for this project named 'tests' and 'docs'. Use pi with thinking low for both. Put them in the same project workspace, each in its own tab.",
-      "expected_output": "Checks herdr status, reuses or creates one workspace for the project, creates two tabs (not splits) with --no-focus, launches pi --thinking low in each, renames agents, waits until idle/ready. No server stop.",
+      "prompt": "Spin up two Herdr agents for this project named 'tests' and 'docs'. Use pi with thinking low for both. Put them in the same project workspace so I can see both panes at once.",
+      "expected_output": "Checks herdr status, reuses or creates one workspace for the project, creates one fleet tab and split panes (not one tab per agent) with --no-focus, launches pi --thinking low in each, renames agents, waits until idle/ready. No server stop.",
       "files": []
     },
     {
@@ -21,8 +21,8 @@
     },
     {
       "id": 4,
-      "prompt": "Launch three Herdr agents (reviewer, tests, docs) for this repo with different tasks in parallel and keep them visible so I can jump into any tab to steer.",
-      "expected_output": "One workspace, three tabs, parallel-friendly spawn (no-focus), submits distinct tasks, explains human can click tabs or herdr agent focus to steer, does not nest tmux.",
+      "prompt": "Launch three Herdr agents (reviewer, tests, docs) for this repo with different tasks in parallel and keep them visible in one view so I can jump into any pane to steer.",
+      "expected_output": "One workspace, one fleet tab with three split panes, parallel-friendly spawn (no-focus), submits distinct tasks, explains human can herdr tab focus the fleet or herdr agent focus a pane to steer, does not nest tmux.",
       "files": []
     },
     {

--- a/skills/herdr-agent-comms/evals/evals.json
+++ b/skills/herdr-agent-comms/evals/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "herdr-agent-comms",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I have a Herdr agent named 'reviewer' already running. Ask it to summarize the open PRs and show me what it says back.",
+      "expected_output": "Resolves the reviewer target via herdr agent get/list, sends with pane run (or agent send + enter), waits on agent-status (working then done/idle) rather than a blind sleep, reads recent-unwrapped, and relays the reply.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Spin up two Herdr agents for this project named 'tests' and 'docs'. Use pi with thinking low for both. Put them in the same project workspace, each in its own tab.",
+      "expected_output": "Checks herdr status, reuses or creates one workspace for the project, creates two tabs (not splits) with --no-focus, launches pi --thinking low in each, renames agents, waits until idle/ready. No server stop.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I'm done with all my Herdr fleet agents for this project — shut them down.",
+      "expected_output": "Treats teardown as destructive: confirms first, prefers closing the skill-created tabs/panes (or workspace if user wants) over herdr server stop unless explicitly requested, warns about lost state.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Launch three Herdr agents (reviewer, tests, docs) for this repo with different tasks in parallel and keep them visible so I can jump into any tab to steer.",
+      "expected_output": "One workspace, three tabs, parallel-friendly spawn (no-focus), submits distinct tasks, explains human can click tabs or herdr agent focus to steer, does not nest tmux.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "Broadcast 'pull latest main and report status' to all my Herdr fleet agents and collect replies.",
+      "expected_output": "Uses broadcast.sh or equivalent send-all-then-wait-concurrent pattern, reports per-agent idle/timeout/blocked, does not serialize full send-wait-read per agent.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "My SSH session died — can you reattach my tmux coding agents?",
+      "expected_output": "Should NOT trigger herdr-agent-comms as the primary skill (tmux domain). Negative trigger: redirect to tmux-agent-comms or plain tmux help.",
+      "files": []
+    }
+  ]
+}

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -1,0 +1,120 @@
+# Delivery and waiting (Herdr)
+
+Rationale for Phase 4–5 of `herdr-agent-comms`. Prefer Herdr agent-status waits over scrollback polling.
+
+## Why status beats sleep
+
+A fixed `sleep N` either wastes time or reads a half-written reply. Herdr already classifies panes:
+
+| Status | Meaning |
+|---|---|
+| `working` | Agent is busy (spinner / tools) |
+| `blocked` | Needs human input (trust, auth, permissions) |
+| `done` | Finished; result not yet "seen" (usually background tab) |
+| `idle` | Waiting for input; result considered seen or never worked |
+| `unknown` | Not detected / no integration |
+
+`herdr wait agent-status <pane_id> --status <state> [--timeout MS]` returns when the pane **is already** in that state or **transitions** into it. Timeouts exit non-zero (typically `1`).
+
+## Delivery verification
+
+After `pane run` / send:
+
+1. Expect transition toward `working` within ~15s for a real task.
+2. If still `idle`/`done` with no new transcript lines → likely not submitted → lone `enter`, then re-check.
+3. If `blocked` → dialog ate focus; do not treat as delivered task.
+
+```bash
+herdr pane run "$pane" "do the thing"
+if herdr wait agent-status "$pane" --status working --timeout 15000; then
+  echo delivered
+else
+  herdr pane send-keys "$pane" enter
+  herdr wait agent-status "$pane" --status working --timeout 10000 || echo NOT-DELIVERED
+fi
+```
+
+On-screen text alone does not prove submission (typed but not Enter'd looks the same). Status `working` (or new output while leaving idle) is the reliable signal.
+
+## Completion: idle vs done
+
+Both mean "not working anymore." After a task:
+
+- Background tab/workspace → often **`done`**
+- Active tab with focused client → often **`idle`**
+- Focusing the pane turns `done` → `idle`
+
+Orchestrator pattern:
+
+```bash
+# Prefer done for background fleets; fall back to idle
+herdr wait agent-status "$pane" --status done --timeout 180000 \
+  || herdr wait agent-status "$pane" --status idle --timeout 5000
+```
+
+Or poll `herdr pane get` / `herdr agent get` and accept either terminal status when `agent_status` ∈ {`idle`,`done`} after you observed `working`.
+
+## Blocked
+
+`blocked` is **not** success. Typical causes: workspace trust, API key, permission prompt, plan-mode confirmation.
+
+Rules:
+
+- Never send the next task while blocked (it becomes menu input).
+- `herdr agent focus <name>` so the human sees the dialog.
+- After the human resolves it, re-check status, then continue.
+
+## Timeouts and anti-deadloop
+
+Set budgets before waiting:
+
+| Budget | Suggested default |
+|---|---|
+| Boot to idle | 60s |
+| Delivery → working | 15s |
+| Task completion | 180s (tune per task) |
+| Re-waits after timeout | max 2–3, then escalate |
+
+On timeout:
+
+1. `herdr pane get "$pane"`
+2. `herdr pane read "$pane" --source recent-unwrapped --lines 80`
+3. `herdr agent explain "$pane"` if status looks wrong
+4. Report stall to the user — do **not** loop forever
+
+## When status is `unknown`
+
+Integrations missing or exotic CLI:
+
+1. `herdr integration install <agent>` when supported
+2. Fall back to content stability: `python3 scripts/wait_for_idle.py <pane_id>`
+3. Still use capped `pane read` for the reply
+
+The helper mirrors tmux-agent-comms' wait semantics (exit 0 idle / 2 timeout / 3 blocked markers) but reads via `herdr pane read` instead of `tmux capture-pane`.
+
+## Concurrent fleet waits
+
+Send all first, wait all second:
+
+```bash
+for p in "${panes[@]}"; do herdr pane run "$p" "$msg"; done
+for p in "${panes[@]}"; do
+  herdr wait agent-status "$p" --status done --timeout 180000 &
+done
+wait
+```
+
+Serializing full send→wait→read per agent makes total time the sum of agents; concurrent waits make it the max.
+
+## Manual verify before high-stakes relay
+
+Status is advisory relative to your goal. Before the user acts on a result:
+
+```bash
+herdr pane read "$pane" --source recent-unwrapped --lines 40 > /tmp/a.txt
+sleep 3
+herdr pane read "$pane" --source recent-unwrapped --lines 40 > /tmp/b.txt
+cmp -s /tmp/a.txt /tmp/b.txt && echo stable || echo still-changing
+```
+
+Still-changing or spinner chrome → keep waiting. Stable + no blocked markers → safe to relay.

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -44,15 +44,27 @@ Both mean "not working anymore." After a task:
 - Active tab with focused client → often **`idle`**
 - Focusing the pane turns `done` → `idle`
 
-Orchestrator pattern:
+Orchestrator pattern — **accept either terminal state**; do not spend the whole budget on `done` alone (focused tabs finish as `idle`):
 
 ```bash
-# Prefer done for background fleets; fall back to idle
-herdr wait agent-status "$pane" --status done --timeout 180000 \
-  || herdr wait agent-status "$pane" --status idle --timeout 5000
+# Preferred helper (requires saw working / transcript change before success):
+python3 scripts/wait_for_idle.py "$pane" --timeout 180
+
+# Manual: poll pane get for idle|done|blocked while re-waiting in short slices
+deadline=$((SECONDS + 180))
+while (( SECONDS < deadline )); do
+  st=$(herdr pane get "$pane" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
+  case "$st" in
+    done|idle) break ;;
+    blocked) echo blocked; break ;;
+    working) herdr wait agent-status "$pane" --status done --timeout 15000 \
+               || herdr wait agent-status "$pane" --status idle --timeout 15000 || true ;;
+    *) sleep 2 ;;
+  esac
+done
 ```
 
-Or poll `herdr pane get` / `herdr agent get` and accept either terminal status when `agent_status` ∈ {`idle`,`done`} after you observed `working`.
+`scripts/wait_for_idle.py` defaults to **post-send** semantics: already-idle panes are not success until `working` (or a transcript change) is observed. Use `--ready` only for boot waits.
 
 ## Blocked
 

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -106,15 +106,40 @@ The helper mirrors tmux-agent-comms' wait semantics (exit 0 idle / 2 timeout / 3
 
 ## Concurrent fleet waits
 
-Send all first, wait all second:
+Send all first, wait all second. Prefer the helper (handles `idle` **or** `done`, and post-send semantics):
 
 ```bash
 for p in "${panes[@]}"; do herdr pane run "$p" "$msg"; done
 for p in "${panes[@]}"; do
-  herdr wait agent-status "$p" --status done --timeout 180000 &
+  python3 scripts/wait_for_idle.py "$p" --timeout 180 &
 done
 wait
 ```
+
+Or with raw waits — **do not** wait only on `done` (focused fleet tabs usually finish as `idle`):
+
+```bash
+for p in "${panes[@]}"; do herdr pane run "$p" "$msg"; done
+for p in "${panes[@]}"; do
+  (
+    deadline=$((SECONDS + 180))
+    while (( SECONDS < deadline )); do
+      st=$(herdr pane get "$p" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
+      case "$st" in
+        done|idle) exit 0 ;;
+        blocked) exit 3 ;;
+        working) herdr wait agent-status "$p" --status done --timeout 15000 \
+                   || herdr wait agent-status "$p" --status idle --timeout 15000 || true ;;
+        *) sleep 2 ;;
+      esac
+    done
+    exit 2
+  ) &
+done
+wait
+```
+
+Or simply: `scripts/broadcast.sh "$msg" reviewer tests docs`.
 
 Serializing full send→wait→read per agent makes total time the sum of agents; concurrent waits make it the max.
 

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -150,27 +150,32 @@ If the answer clearly started above the window, increase `--lines` stepwise (80 
 
 ## Broadcast pattern (manual)
 
-Same idea as `scripts/broadcast.sh`:
+Same idea as `scripts/broadcast.sh` (preferred one-liner: `scripts/broadcast.sh "$msg" reviewer tests docs`):
 
 ```bash
 targets=(reviewer tests docs)
 msg="Pull latest main and report branch + dirty state."
 
+# Resolve names → pane ids once (agent send is text-only; pane run submits Enter)
+panes=()
 for t in "${targets[@]}"; do
-  # Prefer resolving to pane ids then pane run (text + Enter)
-  herdr agent send "$t" "$msg"
+  p=$(herdr agent get "$t" | python3 -c 'import sys,json; d=json.load(sys.stdin); a=d.get("result",{}).get("agent") or d.get("result",{}); print(a["pane_id"])')
+  panes+=("$p")
 done
 
+# Send once per pane (do NOT also agent-send the same message)
 for pane in "${panes[@]}"; do
-  herdr pane run "$pane" "$msg" &
+  herdr pane run "$pane" "$msg"
 done
-wait
 
+# Concurrent completion: idle OR done (focused fleet tabs finish as idle)
 for pane in "${panes[@]}"; do
-  herdr wait agent-status "$pane" --status done --timeout 180000 &
+  python3 scripts/wait_for_idle.py "$pane" --timeout 180 &
 done
 wait
 ```
+
+Never wait only on `done` for the full budget after `herdr tab focus` — the fleet view is focused, so agents settle as `idle`.
 
 ## Troubleshooting
 

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -1,28 +1,73 @@
 # Herdr recipes for agent fleets
 
-Read this when you need layouts beyond the default tab-per-agent spawn, multi-line sends, human steer/focus, scrollback recovery, or troubleshooting.
+Read this when you need layout variants, multi-line sends, human steer/focus, scrollback recovery, or troubleshooting.
 
 ## Default fleet layout (this skill)
 
+**One fleet tab, split pane per agent** — all agents visible in a single view:
+
 ```
 Session (default)
-└── Workspace: <project>          ← one per repo
-    ├── Tab: reviewer  → pane wN:pA  (agent "reviewer")
-    ├── Tab: tests     → pane wN:pB  (agent "tests")
-    └── Tab: docs      → pane wN:pC  (agent "docs")
+└── Workspace: <project>                 ← one per repo
+    └── Tab: fleet
+        ├── pane wN:pA  agent "reviewer"
+        ├── pane wN:pB  agent "tests"     (split right)
+        └── pane wN:pC  agent "docs"      (split down)
 ```
 
-Why tabs not splits: each agent gets a full viewport; the human jumps with a click or `herdr agent focus <name>`; sidebar status rolls up per workspace.
+Why splits by default: the human sees the whole fleet without switching tabs; sidebar still rolls status up per workspace. Use tab-per-agent only when the user wants a full viewport per agent.
 
-### Create workspace + three agent tabs
+### Create workspace + three-agent fleet (splits)
 
 ```bash
 project_dir=/path/to/project
 label=$(basename "$project_dir")
 ws=$(herdr workspace create --cwd "$project_dir" --label "$label" --no-focus \
   | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["workspace"]["workspace_id"])')
-# If the create payload nests differently on your herdr version, print the JSON once and pick the workspace_id field.
 
+tab_json=$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label fleet --no-focus)
+fleet_tab=$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')
+root=$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')
+
+# Agent 1 on root pane
+herdr pane rename "$root" reviewer
+herdr agent rename "$root" reviewer
+herdr pane run "$root" "pi --thinking medium"
+
+# Agent 2 / 3 via agent start + split (same tab)
+herdr agent start tests --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
+  --split right --no-focus -- pi --thinking low
+herdr agent start docs --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
+  --split down --no-focus -- pi --thinking low
+
+herdr tab focus "$fleet_tab"   # show the whole board
+```
+
+### Split direction heuristics
+
+| Situation | Direction |
+|---|---|
+| 2 agents | first extra: `right` |
+| 3 agents | `right` then `down` |
+| Wide pane | prefer `right` |
+| Tall/narrow pane | prefer `down` |
+| Unknown geometry | alternate `right`, `down`, `right`, … |
+
+Inspect geometry when available:
+
+```bash
+herdr pane layout --pane "$pane_id"
+```
+
+Avoid repeating the same direction for every split (creates unusable slivers).
+
+### When to use tab-per-agent instead
+
+- User asks for "full screen per agent" / "own tab each"
+- Agent TUIs need a wide viewport (diff-heavy review)
+- More agents than fit usefully in one tile (~5+)
+
+```bash
 for name in reviewer tests docs; do
   j=$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label "$name" --no-focus)
   pane=$(printf '%s' "$j" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')
@@ -32,15 +77,11 @@ for name in reviewer tests docs; do
 done
 ```
 
-### When to use splits instead
-
-- User asks for "side by side" / "split pane"
-- Comparing two agents' output in one view
-- Logs + agent in the same tab
+### Adding a log / shell pane beside the fleet
 
 ```bash
-herdr agent start logs --cwd "$project_dir" --workspace "$ws" --tab "$tab_id" \
-  --split right --no-focus -- bash -lc 'tail -f /tmp/app.log'
+herdr agent start logs --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
+  --split down --no-focus -- bash -lc 'tail -f /tmp/app.log'
 ```
 
 ## Sending multi-line or code-heavy messages
@@ -84,13 +125,13 @@ Remember: `agent send` does **not** append Enter; `pane run` does.
 
 | Goal | Command |
 |---|---|
-| Jump UI to agent | `herdr agent focus reviewer` |
-| Jump to tab | `herdr tab focus w26:t2` |
+| Show whole fleet board | `herdr tab focus "$fleet_tab"` |
+| Jump UI to one agent pane | `herdr agent focus reviewer` |
 | Jump to workspace | `herdr workspace focus w26` |
 | Attach/takeover terminal | `herdr agent attach reviewer` (optional `--takeover`) |
 | Read without stealing focus | `herdr agent read reviewer --source recent-unwrapped --lines 80` |
 
-Orchestrator rule: use `--no-focus` on create/split/start so fleet spawn doesn't yank the human away. Focus only when they ask to steer or when you need them to dismiss a `blocked` dialog.
+Orchestrator rule: use `--no-focus` on create/split/start so fleet spawn doesn't yank the human away mid-layout. After spawn, **focus the fleet tab once** so all panes are visible. Focus a single agent only when they ask to type into it or to dismiss a `blocked` dialog.
 
 Detach Herdr client (leave agents running): `prefix+q` (`ctrl+b` then `q`). Reattach: `herdr` in a terminal.
 
@@ -116,10 +157,9 @@ targets=(reviewer tests docs)
 msg="Pull latest main and report branch + dirty state."
 
 for t in "${targets[@]}"; do
+  # Prefer resolving to pane ids then pane run (text + Enter)
   herdr agent send "$t" "$msg"
-  # resolve pane for Enter if needed — agent send is text-only
 done
-# Better: map names → pane_ids once, then pane run each.
 
 for pane in "${panes[@]}"; do
   herdr pane run "$pane" "$msg" &
@@ -142,6 +182,7 @@ wait
 | `pane run` typed but agent idle | Send `herdr pane send-keys $pane enter`; re-wait `working` |
 | Status stuck `working` | `pane read`; overall wait budget; escalate stall |
 | `blocked` | Human must answer dialog; `agent focus` to show it |
+| Panes too narrow | Fewer agents per tab, or tab-per-agent layout; alternate split directions |
 | Wrong project files | Confirm `--cwd` and workspace label before spawn |
 | Name not found | `herdr agent list`; names are unique session-wide |
 | Accidentally focused spawn | Pass `--no-focus` on `tab create` / `agent start` / `pane split` |
@@ -168,11 +209,11 @@ HERDR_LOG=herdr=debug herdr   # human client only
 
 | tmux | Herdr |
 |---|---|
-| `tmux new-session -s name` | `herdr tab create` (+ `agent rename`) or `herdr agent start` |
+| `tmux new-session -s name` | `herdr agent start … --split …` (or root pane of fleet tab) |
 | session name | agent `name` + `pane_id` |
 | `tmux send-keys … Enter` | `herdr pane run` |
 | `tmux capture-pane -p -S -40` | `herdr pane read … --source recent-unwrapped --lines 40` |
 | `tmux has-session` | `herdr agent get` / `herdr pane get` |
-| `tmux kill-session` | `herdr tab close` / `herdr pane close` |
+| `tmux kill-session` | `herdr pane close` / `herdr tab close` (fleet tab) |
 | `tmux kill-server` | `herdr server stop` (confirm!) |
-| app terminal tab | Herdr tab (already visible in workspace UI) |
+| multiple app terminal tabs | one fleet tab with tiled panes (default) |

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -1,0 +1,178 @@
+# Herdr recipes for agent fleets
+
+Read this when you need layouts beyond the default tab-per-agent spawn, multi-line sends, human steer/focus, scrollback recovery, or troubleshooting.
+
+## Default fleet layout (this skill)
+
+```
+Session (default)
+└── Workspace: <project>          ← one per repo
+    ├── Tab: reviewer  → pane wN:pA  (agent "reviewer")
+    ├── Tab: tests     → pane wN:pB  (agent "tests")
+    └── Tab: docs      → pane wN:pC  (agent "docs")
+```
+
+Why tabs not splits: each agent gets a full viewport; the human jumps with a click or `herdr agent focus <name>`; sidebar status rolls up per workspace.
+
+### Create workspace + three agent tabs
+
+```bash
+project_dir=/path/to/project
+label=$(basename "$project_dir")
+ws=$(herdr workspace create --cwd "$project_dir" --label "$label" --no-focus \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["workspace"]["workspace_id"])')
+# If the create payload nests differently on your herdr version, print the JSON once and pick the workspace_id field.
+
+for name in reviewer tests docs; do
+  j=$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label "$name" --no-focus)
+  pane=$(printf '%s' "$j" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')
+  herdr pane rename "$pane" "$name"
+  herdr agent rename "$pane" "$name"
+  herdr pane run "$pane" "pi --thinking medium"
+done
+```
+
+### When to use splits instead
+
+- User asks for "side by side" / "split pane"
+- Comparing two agents' output in one view
+- Logs + agent in the same tab
+
+```bash
+herdr agent start logs --cwd "$project_dir" --workspace "$ws" --tab "$tab_id" \
+  --split right --no-focus -- bash -lc 'tail -f /tmp/app.log'
+```
+
+## Sending multi-line or code-heavy messages
+
+`herdr pane run <pane> <command>` takes one shell-quoted string. Nested quotes and newlines break easily.
+
+**Pattern A — short instruction that reads a file:**
+
+```bash
+task_file=$(mktemp)
+cat >"$task_file" <<'EOF'
+Review these files:
+- src/a.ts
+- src/b.ts
+
+Return only:
+1. bugs
+2. missing tests
+EOF
+herdr pane run "$pane_id" "Read $task_file and follow its instructions. Delete the file when done."
+```
+
+**Pattern B — `send-text` then Enter** (when you must avoid shell expansion inside `pane run`):
+
+```bash
+herdr pane send-text "$pane_id" "line one"
+# For multi-line, prefer Pattern A. send-text is literal; then:
+herdr pane send-keys "$pane_id" enter
+```
+
+**Pattern C — agent name:**
+
+```bash
+herdr agent send reviewer "summarize src/"
+herdr pane send-keys "$pane_id" enter
+```
+
+Remember: `agent send` does **not** append Enter; `pane run` does.
+
+## Human steer / focus
+
+| Goal | Command |
+|---|---|
+| Jump UI to agent | `herdr agent focus reviewer` |
+| Jump to tab | `herdr tab focus w26:t2` |
+| Jump to workspace | `herdr workspace focus w26` |
+| Attach/takeover terminal | `herdr agent attach reviewer` (optional `--takeover`) |
+| Read without stealing focus | `herdr agent read reviewer --source recent-unwrapped --lines 80` |
+
+Orchestrator rule: use `--no-focus` on create/split/start so fleet spawn doesn't yank the human away. Focus only when they ask to steer or when you need them to dismiss a `blocked` dialog.
+
+Detach Herdr client (leave agents running): `prefix+q` (`ctrl+b` then `q`). Reattach: `herdr` in a terminal.
+
+## Reading scrollback robustly
+
+```bash
+herdr pane read "$pane_id" --source recent-unwrapped --lines 80
+herdr pane read "$pane_id" --source recent-unwrapped --lines 200   # widen if truncated
+herdr pane read "$pane_id" --source visible --lines 50             # viewport only
+herdr pane read "$pane_id" --source detection                      # detector bottom buffer
+```
+
+Prefer `recent-unwrapped` for agent transcripts (soft wraps joined). Use `--format ansi` only when colors are evidence.
+
+If the answer clearly started above the window, increase `--lines` stepwise (80 → 160 → 300). There is no unbounded dump flag — widen deliberately.
+
+## Broadcast pattern (manual)
+
+Same idea as `scripts/broadcast.sh`:
+
+```bash
+targets=(reviewer tests docs)
+msg="Pull latest main and report branch + dirty state."
+
+for t in "${targets[@]}"; do
+  herdr agent send "$t" "$msg"
+  # resolve pane for Enter if needed — agent send is text-only
+done
+# Better: map names → pane_ids once, then pane run each.
+
+for pane in "${panes[@]}"; do
+  herdr pane run "$pane" "$msg" &
+done
+wait
+
+for pane in "${panes[@]}"; do
+  herdr wait agent-status "$pane" --status done --timeout 180000 &
+done
+wait
+```
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| CLI errors "server not running" | `herdr status`; user starts `herdr` once in a real TTY |
+| Agent always `unknown` | `herdr integration install <agent>`; `herdr agent explain <target>` |
+| Nested tmux breaks detection | Don't run tmux inside Herdr panes |
+| `pane run` typed but agent idle | Send `herdr pane send-keys $pane enter`; re-wait `working` |
+| Status stuck `working` | `pane read`; overall wait budget; escalate stall |
+| `blocked` | Human must answer dialog; `agent focus` to show it |
+| Wrong project files | Confirm `--cwd` and workspace label before spawn |
+| Name not found | `herdr agent list`; names are unique session-wide |
+| Accidentally focused spawn | Pass `--no-focus` on `tab create` / `agent start` / `pane split` |
+
+### Debug one pane
+
+```bash
+herdr pane get "$pane_id"
+herdr agent explain "$pane_id"
+herdr agent explain "$pane_id" --json
+herdr pane process-info --pane "$pane_id"
+```
+
+### Logs
+
+```
+~/.config/herdr/herdr.log
+~/.config/herdr/herdr-client.log
+~/.config/herdr/herdr-server.log
+HERDR_LOG=herdr=debug herdr   # human client only
+```
+
+## Mapping from tmux-agent-comms
+
+| tmux | Herdr |
+|---|---|
+| `tmux new-session -s name` | `herdr tab create` (+ `agent rename`) or `herdr agent start` |
+| session name | agent `name` + `pane_id` |
+| `tmux send-keys … Enter` | `herdr pane run` |
+| `tmux capture-pane -p -S -40` | `herdr pane read … --source recent-unwrapped --lines 40` |
+| `tmux has-session` | `herdr agent get` / `herdr pane get` |
+| `tmux kill-session` | `herdr tab close` / `herdr pane close` |
+| `tmux kill-server` | `herdr server stop` (confirm!) |
+| app terminal tab | Herdr tab (already visible in workspace UI) |

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Broadcast one message to several Herdr agents, then collect each reply.
+#
+# Sends to EVERY target first (fast), then waits on all of them CONCURRENTLY.
+# Wall-clock is the slowest single agent, not the sum.
+#
+# Usage:
+#   scripts/broadcast.sh "message" target1 target2 [target3 ...]
+#
+# Targets: agent names (reviewer) or pane ids (w26:p4)
+#
+# Options (env vars):
+#   HAC_TIMEOUT       per-agent wait timeout in seconds (default: 180)
+#   HAC_WAIT_ARGS     extra args passed to wait_for_idle.py (e.g. "--full")
+#
+# Exit 0 if all agents settled idle/done; otherwise 1.
+
+set -u
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+waiter="$here/wait_for_idle.py"
+timeout="${HAC_TIMEOUT:-180}"
+
+if [ "$#" -lt 2 ]; then
+  echo "Error: need a message and at least one target." >&2
+  echo "Usage: scripts/broadcast.sh \"message\" target1 [target2 ...]" >&2
+  exit 1
+fi
+if ! command -v herdr >/dev/null 2>&1; then
+  echo "Error: herdr is not installed or not on PATH." >&2
+  exit 1
+fi
+if [ ! -f "$waiter" ]; then
+  echo "Error: helper not found at $waiter — run broadcast.sh from the skill dir." >&2
+  exit 1
+fi
+
+msg="$1"; shift
+targets=("$@")
+
+resolve_pane() {
+  local t="$1"
+  if herdr pane get "$t" >/dev/null 2>&1; then
+    printf '%s\n' "$t"
+    return 0
+  fi
+  herdr agent get "$t" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    a = d.get("result", {}).get("agent") or d.get("result", {})
+    print(a["pane_id"])
+except Exception:
+    sys.exit(1)
+'
+}
+
+# Phase 1: resolve all targets first
+panes=()
+labels=()
+missing=()
+for t in "${targets[@]}"; do
+  if p="$(resolve_pane "$t")"; then
+    panes+=("$p")
+    labels+=("$t")
+  else
+    missing+=("$t")
+  fi
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "Error: these targets don't resolve: ${missing[*]}" >&2
+  echo "List them with: herdr agent list" >&2
+  exit 1
+fi
+
+# Phase 2: fan out (pane run = text + Enter)
+for p in "${panes[@]}"; do
+  herdr pane run "$p" "$msg" >/dev/null || {
+    echo "Error: pane run failed for $p" >&2
+    exit 1
+  }
+done
+
+# Phase 3: wait concurrently
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/hac_broadcast.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+pids=()
+for i in "${!panes[@]}"; do
+  p="${panes[$i]}"
+  # shellcheck disable=SC2086
+  (
+    python3 "$waiter" "$p" --timeout "$timeout" ${HAC_WAIT_ARGS:-} \
+      >"$tmpdir/$i.out" 2>"$tmpdir/$i.err"
+    echo "$?" >"$tmpdir/$i.code"
+  ) &
+  pids+=("$!")
+done
+for pid in "${pids[@]}"; do wait "$pid"; done
+
+# Phase 4: emit labeled blocks
+overall=0
+for i in "${!panes[@]}"; do
+  label="${labels[$i]}"
+  p="${panes[$i]}"
+  code="$(cat "$tmpdir/$i.code" 2>/dev/null || echo "?")"
+  case "$code" in
+    0) state="idle/done" ;;
+    2) state="TIMEOUT"; overall=1 ;;
+    3) state="BLOCKED (needs human)"; overall=1 ;;
+    *) state="error"; overall=1 ;;
+  esac
+  echo "===== $label ($p) [$state, exit $code] ====="
+  cat "$tmpdir/$i.out" 2>/dev/null
+  if [ "$code" != "0" ]; then
+    cat "$tmpdir/$i.err" 2>/dev/null >&2
+  fi
+  echo
+done
+
+exit "$overall"

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Wait until a Herdr agent pane is idle/done (or content-stable), then print what's new.
+
+Primary path: `herdr wait agent-status` for idle|done|blocked when Herdr detects the agent.
+Fallback: poll `herdr pane read` until the transcript stops changing (unknown agents).
+
+Exit codes:
+    0  idle/done (settled, ready for the next message)
+    1  usage / environment error (herdr missing, bad target)
+    2  timed out before the pane settled
+    3  blocked: needs human input
+
+Usage:
+    python3 wait_for_idle.py <target> [options]
+
+    <target>   pane id (w26:p4) or unique agent name (reviewer)
+
+Options:
+    --timeout SEC        give up after this many seconds (default: 120)
+    --quiet-cycles N     consecutive unchanged reads to call it settled (default: 3)
+    --interval SEC       seconds between captures (default: 2)
+    --lines N            pane read line window (default: 60)
+    --full               print entire last capture, not just new lines
+    --no-print           print nothing (exit code only)
+    --prefer-status      use herdr status waits first (default: on)
+    --no-status          skip status waits; content-stability only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import time
+
+
+def run(cmd: list[str], timeout: float | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def resolve_pane(target: str) -> str:
+    """Return a pane_id for a pane id or agent name."""
+    if ":" in target and target.split(":", 1)[0].startswith("w"):
+        # likely pane id wN:pM or tab id wN:tM — prefer as-is if pane get works
+        cp = run(["herdr", "pane", "get", target])
+        if cp.returncode == 0:
+            try:
+                d = json.loads(cp.stdout)
+                return d["result"]["pane"]["pane_id"]
+            except (json.JSONDecodeError, KeyError):
+                pass
+
+    cp = run(["herdr", "agent", "get", target])
+    if cp.returncode == 0:
+        try:
+            d = json.loads(cp.stdout)
+            agent = d.get("result", {}).get("agent") or d.get("result", {})
+            pane = agent.get("pane_id")
+            if pane:
+                return pane
+        except (json.JSONDecodeError, AttributeError, KeyError):
+            pass
+
+    # scan list
+    cp = run(["herdr", "agent", "list"])
+    if cp.returncode != 0:
+        raise SystemExit(f"herdr agent list failed: {cp.stderr or cp.stdout}")
+    try:
+        d = json.loads(cp.stdout)
+        agents = d["result"]["agents"]
+    except (json.JSONDecodeError, KeyError) as e:
+        raise SystemExit(f"could not parse agent list: {e}") from e
+
+    matches = [
+        a
+        for a in agents
+        if a.get("name") == target
+        or a.get("pane_id") == target
+        or a.get("terminal_id") == target
+    ]
+    if len(matches) == 1:
+        return matches[0]["pane_id"]
+    if len(matches) > 1:
+        raise SystemExit(f"ambiguous target {target!r}: {[m.get('pane_id') for m in matches]}")
+    raise SystemExit(f"target not found: {target!r}")
+
+
+def agent_status(pane_id: str) -> str | None:
+    cp = run(["herdr", "pane", "get", pane_id])
+    if cp.returncode != 0:
+        return None
+    try:
+        d = json.loads(cp.stdout)
+        return d["result"]["pane"].get("agent_status")
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def pane_read(pane_id: str, lines: int) -> str:
+    cp = run(
+        [
+            "herdr",
+            "pane",
+            "read",
+            pane_id,
+            "--source",
+            "recent-unwrapped",
+            "--lines",
+            str(lines),
+        ]
+    )
+    if cp.returncode != 0:
+        return cp.stdout or cp.stderr or ""
+    # CLI may return plain text or JSON depending on version — prefer raw stdout text
+    out = cp.stdout or ""
+    try:
+        d = json.loads(out)
+        # common shapes
+        r = d.get("result", d)
+        for key in ("text", "content", "output", "data"):
+            if isinstance(r.get(key), str):
+                return r[key]
+        if isinstance(r.get("lines"), list):
+            return "\n".join(str(x) for x in r["lines"])
+    except json.JSONDecodeError:
+        pass
+    return out
+
+
+def wait_status(pane_id: str, status: str, timeout_ms: int) -> bool:
+    cp = run(
+        [
+            "herdr",
+            "wait",
+            "agent-status",
+            pane_id,
+            "--status",
+            status,
+            "--timeout",
+            str(timeout_ms),
+        ]
+    )
+    return cp.returncode == 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("target", help="pane id or agent name")
+    ap.add_argument("--timeout", type=float, default=120.0)
+    ap.add_argument("--quiet-cycles", type=int, default=3)
+    ap.add_argument("--interval", type=float, default=2.0)
+    ap.add_argument("--lines", type=int, default=60)
+    ap.add_argument("--full", action="store_true")
+    ap.add_argument("--no-print", action="store_true")
+    ap.add_argument("--prefer-status", action=argparse.BooleanOptionalAction, default=True)
+    args = ap.parse_args()
+
+    if not shutil.which("herdr"):
+        print("Error: herdr not on PATH", file=sys.stderr)
+        return 1
+
+    try:
+        pane_id = resolve_pane(args.target)
+    except SystemExit as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    deadline = time.time() + args.timeout
+    baseline = pane_read(pane_id, args.lines)
+
+    # Fast path: already terminal
+    st = agent_status(pane_id)
+    if st == "blocked":
+        if not args.no_print:
+            print(baseline if args.full else "")
+        return 3
+    if st in ("idle", "done") and args.prefer_status:
+        # might still be pre-task idle; only treat as done if caller waited after send
+        # Content path still runs if we want delta — but status is authoritative for blocked
+        pass
+
+    if args.prefer_status and st not in (None, "unknown"):
+        remaining_ms = max(1, int((deadline - time.time()) * 1000))
+        # wait for blocked first with short timeout? better: loop statuses
+        # Wait until not working: race done and idle via polling get
+        while time.time() < deadline:
+            st = agent_status(pane_id)
+            if st == "blocked":
+                if not args.no_print:
+                    print(pane_read(pane_id, args.lines) if args.full else "")
+                return 3
+            if st in ("idle", "done"):
+                final = pane_read(pane_id, args.lines)
+                if not args.no_print:
+                    if args.full:
+                        print(final)
+                    else:
+                        # print suffix not in baseline
+                        if final.startswith(baseline):
+                            print(final[len(baseline) :].lstrip("\n"))
+                        else:
+                            print(final)
+                return 0
+            if st == "working":
+                # block until done or idle
+                slice_ms = min(30_000, max(1, int((deadline - time.time()) * 1000)))
+                if wait_status(pane_id, "done", slice_ms) or wait_status(pane_id, "idle", 1_000):
+                    continue
+                continue
+            # unknown — fall through to content stability after loop break
+            break
+        else:
+            return 2
+
+    # Content-stability fallback
+    last = baseline
+    quiet = 0
+    while time.time() < deadline:
+        time.sleep(args.interval)
+        st = agent_status(pane_id)
+        if st == "blocked":
+            if not args.no_print:
+                print(last if args.full else "")
+            return 3
+        cur = pane_read(pane_id, args.lines)
+        if cur == last:
+            quiet += 1
+            if quiet >= args.quiet_cycles:
+                if st == "working":
+                    quiet = 0  # still working chrome-stable briefly
+                    continue
+                if not args.no_print:
+                    if args.full:
+                        print(cur)
+                    else:
+                        if cur.startswith(baseline):
+                            print(cur[len(baseline) :].lstrip("\n"))
+                        else:
+                            print(cur)
+                return 0
+        else:
+            quiet = 0
+            last = cur
+    return 2
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except subprocess.TimeoutExpired:
+        sys.exit(2)

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
-"""Wait until a Herdr agent pane is idle/done (or content-stable), then print what's new.
+"""Wait until a Herdr agent pane finishes work, then print what's new.
 
-Primary path: `herdr wait agent-status` for idle|done|blocked when Herdr detects the agent.
+Primary path: poll `herdr pane get` / status waits for working → idle|done|blocked.
 Fallback: poll `herdr pane read` until the transcript stops changing (unknown agents).
 
+By default this is a **post-send completion wait**: it will not treat a pre-existing
+idle/done pane as success until it has seen `working` (or a transcript change).
+Use --ready for boot/ready waits that may already be idle.
+
 Exit codes:
-    0  idle/done (settled, ready for the next message)
+    0  idle/done after work (or already ready with --ready)
     1  usage / environment error (herdr missing, bad target)
     2  timed out before the pane settled
     3  blocked: needs human input
@@ -22,8 +26,9 @@ Options:
     --lines N            pane read line window (default: 60)
     --full               print entire last capture, not just new lines
     --no-print           print nothing (exit code only)
-    --prefer-status      use herdr status waits first (default: on)
-    --no-status          skip status waits; content-stability only
+    --prefer-status      use herdr status first (default: on)
+    --no-prefer-status   content-stability only (alias: --no-status)
+    --ready              accept already-idle/done without requiring prior working
 """
 
 from __future__ import annotations
@@ -49,7 +54,6 @@ def run(cmd: list[str], timeout: float | None = None) -> subprocess.CompletedPro
 def resolve_pane(target: str) -> str:
     """Return a pane_id for a pane id or agent name."""
     if ":" in target and target.split(":", 1)[0].startswith("w"):
-        # likely pane id wN:pM or tab id wN:tM — prefer as-is if pane get works
         cp = run(["herdr", "pane", "get", target])
         if cp.returncode == 0:
             try:
@@ -69,7 +73,6 @@ def resolve_pane(target: str) -> str:
         except (json.JSONDecodeError, AttributeError, KeyError):
             pass
 
-    # scan list
     cp = run(["herdr", "agent", "list"])
     if cp.returncode != 0:
         raise SystemExit(f"herdr agent list failed: {cp.stderr or cp.stdout}")
@@ -119,11 +122,9 @@ def pane_read(pane_id: str, lines: int) -> str:
     )
     if cp.returncode != 0:
         return cp.stdout or cp.stderr or ""
-    # CLI may return plain text or JSON depending on version — prefer raw stdout text
     out = cp.stdout or ""
     try:
         d = json.loads(out)
-        # common shapes
         r = d.get("result", d)
         for key in ("text", "content", "output", "data"):
             if isinstance(r.get(key), str):
@@ -136,6 +137,8 @@ def pane_read(pane_id: str, lines: int) -> str:
 
 
 def wait_status(pane_id: str, status: str, timeout_ms: int) -> bool:
+    if timeout_ms <= 0:
+        return False
     cp = run(
         [
             "herdr",
@@ -151,8 +154,20 @@ def wait_status(pane_id: str, status: str, timeout_ms: int) -> bool:
     return cp.returncode == 0
 
 
+def print_delta(baseline: str, final: str, full: bool) -> None:
+    if full:
+        print(final)
+        return
+    if final.startswith(baseline):
+        print(final[len(baseline) :].lstrip("\n"))
+    else:
+        print(final)
+
+
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument("target", help="pane id or agent name")
     ap.add_argument("--timeout", type=float, default=120.0)
     ap.add_argument("--quiet-cycles", type=int, default=3)
@@ -160,8 +175,25 @@ def main() -> int:
     ap.add_argument("--lines", type=int, default=60)
     ap.add_argument("--full", action="store_true")
     ap.add_argument("--no-print", action="store_true")
-    ap.add_argument("--prefer-status", action=argparse.BooleanOptionalAction, default=True)
+    ap.add_argument(
+        "--prefer-status",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="use herdr agent-status first (default: true)",
+    )
+    ap.add_argument(
+        "--no-status",
+        action="store_true",
+        help="alias for --no-prefer-status",
+    )
+    ap.add_argument(
+        "--ready",
+        action="store_true",
+        help="accept already-idle/done without requiring a prior working transition",
+    )
     args = ap.parse_args()
+    if args.no_status:
+        args.prefer_status = False
 
     if not shutil.which("herdr"):
         print("Error: herdr not on PATH", file=sys.stderr)
@@ -175,47 +207,57 @@ def main() -> int:
 
     deadline = time.time() + args.timeout
     baseline = pane_read(pane_id, args.lines)
+    saw_work = False  # working status or transcript change
 
-    # Fast path: already terminal
     st = agent_status(pane_id)
     if st == "blocked":
         if not args.no_print:
             print(baseline if args.full else "")
         return 3
-    if st in ("idle", "done") and args.prefer_status:
-        # might still be pre-task idle; only treat as done if caller waited after send
-        # Content path still runs if we want delta — but status is authoritative for blocked
-        pass
+
+    if args.ready and st in ("idle", "done") and args.prefer_status:
+        if not args.no_print:
+            print_delta(baseline, baseline, args.full)
+        return 0
 
     if args.prefer_status and st not in (None, "unknown"):
-        remaining_ms = max(1, int((deadline - time.time()) * 1000))
-        # wait for blocked first with short timeout? better: loop statuses
-        # Wait until not working: race done and idle via polling get
         while time.time() < deadline:
             st = agent_status(pane_id)
             if st == "blocked":
                 if not args.no_print:
-                    print(pane_read(pane_id, args.lines) if args.full else "")
+                    print_delta(baseline, pane_read(pane_id, args.lines), args.full)
                 return 3
-            if st in ("idle", "done"):
-                final = pane_read(pane_id, args.lines)
-                if not args.no_print:
-                    if args.full:
-                        print(final)
-                    else:
-                        # print suffix not in baseline
-                        if final.startswith(baseline):
-                            print(final[len(baseline) :].lstrip("\n"))
-                        else:
-                            print(final)
-                return 0
+
             if st == "working":
-                # block until done or idle
+                saw_work = True
                 slice_ms = min(30_000, max(1, int((deadline - time.time()) * 1000)))
-                if wait_status(pane_id, "done", slice_ms) or wait_status(pane_id, "idle", 1_000):
-                    continue
+                # Prefer short waits so we can notice idle or done either way
+                half = max(1, slice_ms // 2)
+                if not wait_status(pane_id, "done", half):
+                    wait_status(pane_id, "idle", max(1, int((deadline - time.time()) * 1000)))
                 continue
-            # unknown — fall through to content stability after loop break
+
+            if st in ("idle", "done"):
+                cur = pane_read(pane_id, args.lines)
+                if cur != baseline:
+                    saw_work = True
+                if saw_work or args.ready:
+                    if not args.no_print:
+                        print_delta(baseline, cur, args.full)
+                    return 0
+                # Pre-task idle: wait for working (or transcript change via status loop)
+                slice_ms = min(5_000, max(1, int((deadline - time.time()) * 1000)))
+                if wait_status(pane_id, "working", slice_ms):
+                    saw_work = True
+                    continue
+                # Also check blocked while waiting to start
+                if agent_status(pane_id) == "blocked":
+                    if not args.no_print:
+                        print_delta(baseline, pane_read(pane_id, args.lines), args.full)
+                    return 3
+                continue
+
+            # unknown mid-flight — fall through to content stability
             break
         else:
             return 2
@@ -228,27 +270,29 @@ def main() -> int:
         st = agent_status(pane_id)
         if st == "blocked":
             if not args.no_print:
-                print(last if args.full else "")
+                print_delta(baseline, last, args.full)
             return 3
+        if st == "working":
+            saw_work = True
         cur = pane_read(pane_id, args.lines)
-        if cur == last:
-            quiet += 1
-            if quiet >= args.quiet_cycles:
-                if st == "working":
-                    quiet = 0  # still working chrome-stable briefly
-                    continue
-                if not args.no_print:
-                    if args.full:
-                        print(cur)
-                    else:
-                        if cur.startswith(baseline):
-                            print(cur[len(baseline) :].lstrip("\n"))
-                        else:
-                            print(cur)
-                return 0
-        else:
+        if cur != last:
+            if cur != baseline:
+                saw_work = True
             quiet = 0
             last = cur
+            continue
+        quiet += 1
+        if quiet >= args.quiet_cycles:
+            if st == "working":
+                quiet = 0
+                continue
+            if not saw_work and not args.ready:
+                # still pre-task idle with no transcript change — keep waiting
+                quiet = 0
+                continue
+            if not args.no_print:
+                print_delta(baseline, cur, args.full)
+            return 0
     return 2
 
 


### PR DESCRIPTION
## Summary

Adds `skills/herdr-agent-comms/`, a new skill for managing multi-agent fleets in **Herdr**.

This is the **Herdr counterpart of `tmux-agent-comms`**: same fleet-orchestration goals (spawn, message, wait, read, tear down), expressed with Herdr primitives instead of tmux sessions.

### What it does

- **Workspace-per-project** — all agents for a project live in one Herdr workspace
- **Split-pane fleet (default)** — one fleet tab with tiled panes per agent (tab-per-agent is opt-in only)
- **herdr CLI messaging** — send/wait/read/steer via `herdr agent`, `herdr pane`, etc.
- Prefer agent-status waits over scrollback polling; broadcast + idle-wait helpers included

### Key files

| Path | Role |
|---|---|
| `skills/herdr-agent-comms/SKILL.md` | Main skill (phases, rules, workflows) |
| `skills/herdr-agent-comms/references/delivery-and-waiting.md` | Send/wait/read patterns |
| `skills/herdr-agent-comms/references/herdr-recipes.md` | Common herdr CLI recipes |
| `skills/herdr-agent-comms/scripts/broadcast.sh` | Broadcast helper |
| `skills/herdr-agent-comms/scripts/wait_for_idle.py` | Idle-wait helper |
| `skills/herdr-agent-comms/docs/README.md` | Human docs |
| `skills/herdr-agent-comms/evals/evals.json` | Trigger evals |

### Validation

`python3 ~/.claude/skills/skill-creator/scripts/quick_validate.py skills/herdr-agent-comms` → **Skill is valid!**

## Test plan

- [ ] Install/load the skill and confirm it triggers for Herdr fleet tasks
- [ ] Confirm it does **not** trigger for plain tmux (use `tmux-agent-comms` instead)
- [ ] Dry-run Phase 1–2 against a real `herdr status` environment when available
- [ ] Exercise `scripts/broadcast.sh` and `scripts/wait_for_idle.py` smoke paths
