### PR TITLE
feat(herdr-agent-comms): split sub-agents from the root pane

### DIFF
--- a/.github/workflows/herdr-agent-comms-tests.yml
+++ b/.github/workflows/herdr-agent-comms-tests.yml
@@ -1,0 +1,46 @@
+name: herdr-agent-comms tests
+
+on:
+  pull_request:
+    paths:
+      - "skills/herdr-agent-comms/scripts/**"
+      - "skills/herdr-agent-comms/tests/**"
+      - ".github/workflows/herdr-agent-comms-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/herdr-agent-comms/scripts/**"
+      - "skills/herdr-agent-comms/tests/**"
+      - ".github/workflows/herdr-agent-comms-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Syntax-check shell scripts
+        run: |
+          bash -n skills/herdr-agent-comms/scripts/broadcast.sh
+          bash -n skills/herdr-agent-comms/tests/bin/herdr
+
+      - name: Byte-compile Python scripts
+        run: |
+          python3 -m py_compile \
+            skills/herdr-agent-comms/scripts/next_grid_split.py \
+            skills/herdr-agent-comms/scripts/wait_for_idle.py \
+            skills/herdr-agent-comms/tests/fake_herdr.py
+
+      - name: Run unit/fixture tests (mock herdr CLI, no live TUI needed)
+        run: |
+          cd skills/herdr-agent-comms
+          python3 -m unittest discover -s tests -p 'test_*.py' -v

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.6.0
+  version: 1.7.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -30,11 +30,11 @@ Tab (root's tab)
 │ root(you)│ reviewer │ tests    │ docs     │
 └──────────┴──────────┴──────────┴──────────┘
 ```
-(All columns — root and every sub-agent — are always the same width. Adding a
-column means splitting the current rightmost pane `right`, then resizing every
-existing column down to `1/N` where N is the new total column count.
-`next_grid_split.py` computes this plan; see Phase 2a and "Equal-width columns"
-below for the caveat on `herdr pane resize` semantics.)
+(All columns — root and every sub-agent — end up the same width, ±1 terminal
+cell. Adding a column means splitting the current rightmost pane `right`
+(`--ratio (N-1)/N`), then running an iterative equalizer that re-converges
+every column to `1/N`. `next_grid_split.py` does both (`--equalize`); see
+Phase 2a and "Equal-width columns" below for the verified `herdr` semantics.)
 
 You orchestrate with the `herdr` CLI. Prefer agent-status waits over scrollback polling. Relay each agent's answer, not its whole screen.
 
@@ -111,9 +111,9 @@ Optional: `herdr integration install pi|claude|codex|opencode|hermes` for better
 
 Every sub-agent joins the **same tab as the root agent** as part of a **tiled grid**. The root agent is **not** moved, renamed into a worker, or replaced.
 
-### 2a — Split the rightmost column, resize all to equal width → launch sub-agent
+### 2a — Split the rightmost column, equalize widths → launch sub-agent
 
-Every column — root included — must end up the **same width**. Do **not** just split and move on: after the split, resize every existing column down to the new `1/N` share:
+Every column — root included — must end up the **same width**. A split alone can't do this for 3+ columns (it only resizes the pane you split), so each spawn is **split the rightmost column, then run the iterative equalizer**. `next_grid_split.py` handles both steps; the `herdr` split/resize semantics it relies on are verified live against herdr 0.7.4 — see `references/herdr-recipes.md` ("Equal-width columns — verified semantics") for the details and the manual fallback.
 
 ```bash
 project_dir=/path/to/project   # usually root pane cwd
@@ -121,9 +121,8 @@ root_pane="$HERDR_PANE_ID"     # from Phase 1
 
 # Resolve scripts/ robustly: $0 is unreliable when an agent runs this inline
 # (it points at the shell, not the skill), so probe known install locations
-# instead of deriving from $0. Repo-local copies win over global installs so
-# a repo checked out at a pinned commit isn't silently overridden by
-# whatever version happens to be installed globally.
+# instead. Repo-local copies win over global installs so a repo pinned at a
+# commit isn't silently overridden by whatever is installed globally.
 here=""
 for cand in \
   "skills/herdr-agent-comms/scripts" \
@@ -141,71 +140,49 @@ agent_cmd='pi --thinking medium'
 # free name if taken
 herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
 
-# Plan: line 1 is "split <rightmost_pane> right --ratio <share>", the rest
-# are "resize <pane_id> <share>" for every pre-existing column (root
-# included). See "Equal-width columns" below for the --ratio/--amount
-# semantics caveat — confirm against your herdr version if in doubt.
+# Plan line: "split <rightmost_pane> right --ratio <existing_child_ratio>".
+# The ratio = (N-1)/N so the NEW pane is born at the 1/N target share.
 plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
 read -r _ split_from _dir _ratio_flag ratio < <(head -1 <<<"$plan")
 split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
-# JSON shape: result.pane.pane_id (verify once with your herdr version if needed)
 sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r.get("root_pane") or r)["pane_id"])')"
 
-# Resize every pre-existing column (from the plan's remaining lines) to the
-# same share, AND the new pane too — don't rely on --ratio alone to have put
-# the new pane at the right width; a plain resize --amount pass on every
-# column (this one included) converges regardless of what --ratio meant.
-share="$(tail -n +2 <<<"$plan" | head -1 | awk '{print $3}')"
-herdr pane resize --pane "$sub_pane" --direction right --amount "$share" >/dev/null || true
-tail -n +2 <<<"$plan" | while read -r _ pane_id pshare; do
-  herdr pane resize --pane "$pane_id" --direction right --amount "$pshare" >/dev/null || true
-done
+# Equalize every column (root + all sub-agents) to the same width. This runs
+# an iterative boundary sweep against the live layout — a split alone leaves
+# the pre-existing columns wider than the new 1/N share.
+python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" || \
+  echo "Warning: columns are best-effort (see herdr pane layout)." >&2
 
 herdr pane rename "$sub_pane" "$name" >/dev/null
 herdr agent rename "$sub_pane" "$name" >/dev/null
 herdr pane run "$sub_pane" "$agent_cmd" >/dev/null
 ```
 
-**Second / third sub-agent** — re-run the planner each time (share shrinks as columns are added):
+**Second / third sub-agent** — identical: re-run the planner, split, then `--equalize` (the target share shrinks as columns are added, and the equalizer always converges to equal-within-1-cell). Just change `name` and `agent_cmd`.
 
-```bash
-name=tests
-herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
-read -r _ split_from _dir _ratio_flag ratio < <(head -1 <<<"$plan")
-split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
-sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
-herdr pane resize --pane "$sub_pane" --direction right --amount "$ratio" >/dev/null || true
-tail -n +2 <<<"$plan" | while read -r _ pane_id pshare; do
-  herdr pane resize --pane "$pane_id" --direction right --amount "$pshare" >/dev/null || true
-done
-herdr pane rename "$sub_pane" "$name" >/dev/null
-herdr agent rename "$sub_pane" "$name" >/dev/null
-herdr pane run "$sub_pane" 'pi --thinking low' >/dev/null
-```
+**Manual fallback** when the helper is unavailable: split the current rightmost column `right`, then equalize by hand — see `references/herdr-recipes.md` ("Equal-width columns"). Stay on `root_tab`.
 
-**Manual fallback** when the helper is unavailable: inspect `herdr pane layout --pane "$root_pane"`, order panes left to right by `rect.x`, split the rightmost one `right`, then resize every column (the new one plus every pre-existing one) to `1 / (existing_count + 1)`. Stay on `root_tab`.
-
-**Alternative** (same tab, not equal-width without manual resize): `herdr agent start` into the root tab:
+**Alternative** (same tab, not equal-width without an equalize pass): `herdr agent start` into the root tab, then run `next_grid_split.py --equalize`:
 
 ```bash
 herdr agent start "$name" --cwd "$project_dir" --workspace "$ws" --tab "$root_tab" \
   --split right --no-focus -- pi --thinking medium
+python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" || true
 ```
 
-Prefer **`next_grid_split.py` + `pane split` + `pane resize`** so the grid includes root and stays equal-width. This alternative skips the resize step, so follow it with a manual `herdr pane resize` pass on every column if you use it.
+Prefer **`next_grid_split.py` split + `--equalize`** so the grid includes root and stays equal-width. This alternative skips the equalize step unless you add it.
 
 **Grid rules:**
 1. One tab only: root + every sub-agent.
 2. Every split targets the current **rightmost** column.
 3. Direction: always `right` — this is a single row of equal-width columns, not a 2D grid. There is no `down` case in the default layout.
-4. After every split, resize **every** column (including root) down to `1 / N` where N is the new total column count. A split alone only sizes the new pane; it does not shrink the columns already in place.
+4. After every split, run the equalizer — a split alone only sizes the new pane; it does not shrink the columns already in place, so 3+ columns need the equalize pass.
 5. Always `--no-focus` so the root keeps the keyboard.
-6. Optional check: `herdr pane layout --pane "$root_pane"` should show N rects of equal `rect.width`, not one wide pane and thin strips.
+6. Optional check: `herdr pane layout --pane "$root_pane"` should show N rects of near-equal `rect.width` (equal within ~1 cell), not one wide pane and thin strips.
 
-**Equal-width columns — verification caveat:** the exact meaning of `herdr pane split --ratio` and `herdr pane resize --amount` (fraction of remaining space vs. absolute tab fraction vs. cells) has not been confirmed against a live `herdr` server in this skill's test suite — `next_grid_split.py`'s unit tests only cover the arithmetic (pane ordering, `1/N` share), not the live resize call. Run `herdr pane layout --pane "$root_pane"` after a spawn and confirm the rects are actually equal width before trusting this at scale; adjust the `--ratio`/`--amount` interpretation above if your installed `herdr` version disagrees.
+**Equal-width columns — behavior:** herdr `pane split --ratio` sizes only the split pane, and `pane resize --amount` is a *delta* (cells as a fraction of tab width) whose freed space redistributes proportionally across neighbors — so a single split or a single resize pass cannot equalize 3+ columns. The equalizer sweeps internal boundaries left to right, growing the neighbor-bearing pane toward each target, and iterates until the spread is ≤1 cell. This was verified live against herdr 0.7.4 (2→105/105, 3→70/70/70, 4→53/53/52/52, 5→42×5). Because widths are whole terminal cells, exact equality only holds when the tab width divides evenly; otherwise columns differ by ≤1 cell. Full semantics and the derivation are in `references/herdr-recipes.md`.
 
-**Forbidden by default:** `herdr tab create` per sub-agent; hijacking the root pane with the first worker's CLI; `herdr workspace create` just to host workers when a root pane already exists; splitting a column other than the current rightmost one (creates unequal widths the resize pass won't fix).
+**Forbidden by default:** `herdr tab create` per sub-agent; hijacking the root pane with the first worker's CLI; `herdr workspace create` just to host workers when a root pane already exists; splitting a column other than the current rightmost one.
 
 **Optional (user asks for isolation):** tab-per-agent — see `references/herdr-recipes.md`. Not the default.
 
@@ -425,17 +402,13 @@ spawn_sub() {
   local name="$1" cmd="$2"
   local plan split_from ratio split_json pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  # Plan: line 1 "split <rightmost> right --ratio <share>", rest "resize <pane> <share>".
+  # Plan line: "split <rightmost> right --ratio <(N-1)/N>" (new pane born at 1/N).
   plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
   read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
   split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
   pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
-  # Resize every column, including the new one — don't rely on --ratio alone
-  # to have sized the new pane correctly.
-  herdr pane resize --pane "$pane" --direction right --amount "$ratio" >/dev/null || true
-  tail -n +2 <<<"$plan" | while read -r _ pid pshare; do
-    herdr pane resize --pane "$pid" --direction right --amount "$pshare" >/dev/null || true
-  done
+  # Equalize all columns — a split alone leaves the pre-existing columns wide.
+  python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >/dev/null 2>&1 || true
   herdr pane rename "$pane" "$name" >/dev/null
   herdr agent rename "$pane" "$name" >/dev/null
   herdr pane run "$pane" "$cmd" >/dev/null
@@ -472,7 +445,7 @@ rm -f "$b1" "$b2"
 - **Wrong workspace** — never spawn project B agents into project A's workspace; re-resolve Phase 1.
 - **Status `unknown`** — install integration or use `scripts/wait_for_idle.py` + `pane read`.
 - **Too many splits** — more than ~4 panes in one tab gets cramped; keep the grid helper, or switch to tab-per-agent only if the user asks.
-- **Unequal-width columns** — you split without the resize pass, or split a pane other than the current rightmost column; re-run `scripts/next_grid_split.py` and apply its full plan (split + resize every column).
+- **Unequal-width columns** — you split without the equalize pass, or split a pane other than the current rightmost column; re-run `python3 scripts/next_grid_split.py --equalize --root-pane "$root_pane"` to re-converge the grid.
 - **User wants to steer** — `herdr agent focus <name>` for a sub-agent; keep CLI follow-ups only when not fighting their keyboard.
 - **Closing the wrong pane** — only close **sub-agent** panes this skill created; never close root unless asked.
 - **Accidental new fleet tab** — if you created a tab by mistake, move work into root's tab via grid splits and close the empty tab only with confirmation.
@@ -480,7 +453,7 @@ rm -f "$b1" "$b2"
 ## Reference
 
 - `references/herdr-recipes.md` — grid layouts, multi-line sends, focus/steer, scrollback, troubleshooting.
-- `scripts/next_grid_split.py` — plan the next split + resize-all-columns pass for an equal-width grid.
+- `scripts/next_grid_split.py` — plan the next split (`--ratio (N-1)/N`) and run the live iterative equalizer (`--equalize`) for an equal-width grid.
 - `references/delivery-and-waiting.md` — delivery checks, idle/done/blocked, budgets.
 - Official concepts: https://herdr.dev/docs/concepts/ · CLI: https://herdr.dev/docs/cli-reference/ · cheatsheet: https://luongnv.com/awesome-cheatsheets/cheatsheets/herdr/
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.3.1
+  version: 1.4.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -26,15 +26,16 @@ Default layout after spawning three sub-agents (balanced grid including root; **
 
 ```
 Tab (root's tab)
-┌───────────────────────────┐
-│ root (you)                │
-├─────────────┬─────────────┤
-│ reviewer    │ tests       │
-├─────────────┴─────────────┤
-│ docs                      │
-└───────────────────────────┘
+┌─────────────┬─────────────┐
+│ root (you)  │ reviewer    │
+├─────────────┼─────────────┤
+│ tests       │ docs        │
+└─────────────┴─────────────┘
 ```
-(Exact tiles depend on aspect ratios; first split prefers `down`.)
+(Exact tiles depend on aspect ratios and live geometry — `next_grid_split.py` always
+picks the largest pane, so later splits may target root or a sub-agent pane. The first
+split always prefers `down`, so root starts on top; the largest-pane rule tends to grid
+root and its workers into roughly equal tiles rather than one full column.)
 
 You orchestrate with the `herdr` CLI. Prefer agent-status waits over scrollback polling. Relay each agent's answer, not its whole screen.
 
@@ -118,8 +119,19 @@ Do **not** always split `$root_pane`. Always pick the current largest cell so ro
 ```bash
 project_dir=/path/to/project   # usually root pane cwd
 root_pane="$HERDR_PANE_ID"     # from Phase 1
-here="$(cd "$(dirname "$0")" 2>/dev/null; pwd)"  # skill scripts/ when known
-# or: here=skills/herdr-agent-comms/scripts
+
+# Resolve scripts/ robustly: $0 is unreliable when an agent runs this inline
+# (it points at the shell, not the skill), so probe known install locations
+# instead of deriving from $0.
+here=""
+for cand in \
+  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  ".claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts" \
+  "skills/herdr-agent-comms/scripts"; do
+  if [ -f "$cand/next_grid_split.py" ]; then here="$cand"; break; fi
+done
+[ -n "$here" ] || { echo "next_grid_split.py not found — set \$here manually" >&2; }
 name=reviewer
 agent_cmd='pi --thinking medium'
 # optional skills for pi:  --skill /path/to/SKILL.md
@@ -151,7 +163,7 @@ herdr agent rename "$sub_pane" "$name" >/dev/null
 herdr pane run "$sub_pane" 'pi --thinking low' >/dev/null
 ```
 
-**Manual fallback** when the helper is unavailable: inspect `herdr pane layout --pane "$root_pane"`, split the largest pane by `rect.width * rect.height`, use **`down` if height ≥ width else `right`**. Stay on `root_tab`.
+**Manual fallback** when the helper is unavailable: inspect `herdr pane layout --pane "$root_pane"`, split the largest pane by `rect.width * rect.height`. If this is the **first** split (only one pane exists), use `down` unconditionally — most terminals are wider than tall, so an aspect check alone would pick `right` and contradict vertical-panel-first. For later splits, use **`down` if height ≥ width else `right`**. Stay on `root_tab`.
 
 **Alternative** (same tab, less balanced): `herdr agent start` into the root tab:
 
@@ -165,7 +177,7 @@ Prefer **`next_grid_split.py` + `pane split`** so the grid includes root and sta
 **Grid rules:**
 1. One tab only: root + every sub-agent.
 2. Before each split, choose the **largest** pane in that tab (tie-break: root).
-3. Direction from that pane's aspect: **`down` when taller or square** (vertical panel first), `right` only when clearly wider.
+3. Direction: the **first** split is always `down` (vertical panel first, regardless of aspect — real terminals are usually wider than tall). Later splits follow the target pane's aspect: **`down` when taller or square**, `right` only when clearly wider.
 4. Always `--no-focus` so the root keeps the keyboard.
 5. Optional check: `herdr pane layout --pane "$root_pane"` should show multiple similar-sized rects, not one huge pane and thin strips.
 
@@ -261,7 +273,19 @@ fi
 Use Herdr status waits (not fixed `sleep`). Completion may be **`done`** (unseen, usually background) **or `idle`** (seen / focused tab) — wait for either. Prefer the helper with the Phase 4 pre-send baseline; without it, a fast agent can finish before the waiter snapshots the pane and leave the root waiting until timeout:
 
 ```bash
-python3 scripts/wait_for_idle.py "$pane_id" --timeout 180 --lines 80 \
+# $here is the scripts/ dir. If Phase 2 already resolved it, reuse it;
+# jumping straight here (e.g. "message an agent that's already running")
+# skips Phase 2, so probe install locations again rather than assume it's set.
+if [ -z "${here:-}" ]; then
+  for cand in \
+    "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+    ".claude/skills/herdr-agent-comms/scripts" \
+    "$HOME/.agents/skills/herdr-agent-comms/scripts" \
+    "skills/herdr-agent-comms/scripts"; do
+    if [ -f "$cand/wait_for_idle.py" ]; then here="$cand"; break; fi
+  done
+fi
+python3 "$here/wait_for_idle.py" "$pane_id" --timeout 180 --lines 80 \
   --baseline-file "$baseline_file" --completion-marker "$completion_marker"
 rc=$?
 rm -f "$baseline_file"
@@ -283,7 +307,7 @@ while (( SECONDS < deadline )); do
     *) sleep 2 ;;
   esac
 done
-# Or: python3 scripts/wait_for_idle.py "$pane_id" --timeout 180
+# Or use the helper instead (resolve $here first — see the block above).
 ```
 
 Treat **either `idle` or `done` as completed** — difference is only whether the result was seen. Never wait only on `done` for the full budget: a focused-tab finish stays `idle` and will time out.
@@ -357,7 +381,16 @@ root_tab="$HERDR_TAB_ID"
 ws="$HERDR_WORKSPACE_ID"
 project_dir="$(pwd)"
 
-here="skills/herdr-agent-comms/scripts"  # adjust if installed elsewhere
+# Resolve scripts/ by probing known install locations (not $0 — unreliable
+# when this snippet runs inline rather than as a saved script file).
+here=""
+for cand in \
+  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  ".claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts" \
+  "skills/herdr-agent-comms/scripts"; do
+  if [ -f "$cand/next_grid_split.py" ]; then here="$cand"; break; fi
+done
 spawn_sub() {
   local name="$1" cmd="$2"
   local split_from dir split_json pane
@@ -384,10 +417,10 @@ herdr pane run "$p1" "Review recent commits for risk; bullet findings only. When
 herdr pane run "$p2" "Outline a minimal test plan. When finished, concatenate and print: HERDR_DONE_ and $s2"
 
 # Same tab: root_pane + p1 + p2
-python3 scripts/wait_for_idle.py "$p1" --timeout 180 --lines 80 --baseline-file "$b1" --completion-marker "HERDR_DONE_$s1"
-python3 scripts/wait_for_idle.py "$p2" --timeout 180 --lines 80 --baseline-file "$b2" --completion-marker "HERDR_DONE_$s2"
+python3 "$here/wait_for_idle.py" "$p1" --timeout 180 --lines 80 --baseline-file "$b1" --completion-marker "HERDR_DONE_$s1"
+python3 "$here/wait_for_idle.py" "$p2" --timeout 180 --lines 80 --baseline-file "$b2" --completion-marker "HERDR_DONE_$s2"
 rm -f "$b1" "$b2"
-# optional: use scripts/broadcast.sh to baseline/send/wait concurrently
+# optional: use "$here/broadcast.sh" to baseline/send/wait concurrently
 # optional: herdr agent focus reviewer
 ```
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.9.0
+  version: 1.10.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -247,7 +247,8 @@ Capture the transcript **before sending**. This lets Phase 5 recognize a fast re
 
 ```bash
 baseline_file="$(mktemp)"
-herdr pane read "$pane_id" --source recent-unwrapped --lines 80 >"$baseline_file"
+herdr pane read "$pane_id" --source recent-unwrapped --lines 80 >"$baseline_file" \
+  || { echo "Error: could not capture baseline for $pane_id" >&2; exit 1; }
 marker_suffix="$(date +%s)_$$_$RANDOM"
 completion_marker="HERDR_DONE_$marker_suffix"
 
@@ -269,10 +270,17 @@ herdr pane run "$pane_id" "$task"
 ```bash
 if herdr wait agent-status "$pane_id" --status working --timeout 15000; then
   echo delivered
-elif ! cmp -s "$baseline_file" <(herdr pane read "$pane_id" --source recent-unwrapped --lines 80); then
-  echo delivered-transcript-activity
 else
-  echo NOT-DELIVERED
+  # Capture the post-send read EXPLICITLY and check it succeeded — a failed
+  # `herdr pane read` in a `<(...)` would look "different from baseline" and
+  # be misreported as activity. A failed read is an error, not delivery.
+  after="$(herdr pane read "$pane_id" --source recent-unwrapped --lines 80)" \
+    || { echo "Error: post-send pane read failed for $pane_id" >&2; exit 1; }
+  if ! printf '%s' "$after" | cmp -s "$baseline_file" -; then
+    echo delivered-transcript-activity
+  else
+    echo NOT-DELIVERED
+  fi
 fi
 ```
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.20.0
+  version: 1.21.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.15.0
+  version: 1.16.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -253,13 +253,6 @@ if [ -z "${here:-}" ]; then
     [ -f "$cand/preflight_send.py" ] && { here="$cand"; break; }
   done
 fi
-# FAIL-CLOSED preflight — same enum-validated check broadcast.sh runs. Refuse to
-# send into a working (rc 2), blocked (rc 3), or unverifiable/off-enum (rc 4)
-# pane; only idle/done/unknown (rc 0) is safe. Skipping this let a task be typed
-# into a blocked trust dialog and still report success.
-python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
-  || { echo "Error: $pane_id is not safe to send to (preflight failed) — see stderr" >&2; exit 1; }
-
 baseline_file="$(mktemp)"
 herdr pane read "$pane_id" --source recent-unwrapped --lines 80 >"$baseline_file" \
   || { echo "Error: could not capture baseline for $pane_id" >&2; exit 1; }
@@ -269,7 +262,15 @@ completion_marker="HERDR_DONE_$marker_suffix"
 task="summarize the changes in src/
 
 After fully finishing, concatenate and print these two parts without spaces: HERDR_DONE_ and $marker_suffix"
-herdr pane run "$pane_id" "$task" || { echo "Error: send failed for $pane_id" >&2; exit 1; }
+# FAIL-CLOSED preflight IMMEDIATELY before dispatch — same enum-validated check
+# broadcast.sh runs right before each pane run. Refuse to send into a working
+# (rc 2), blocked (rc 3), or unverifiable/off-enum (rc 4) pane; only idle/done/
+# unknown (rc 0) is safe. Placed here (not before baseline/marker prep) so a
+# target that turns working/blocked during that prep can't still be sent into —
+# skipping it let a task be typed into a blocked trust dialog and report success.
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id is not safe to send to (preflight failed) — see stderr" >&2; rm -f "$baseline_file"; exit 1; }
+herdr pane run "$pane_id" "$task" || { echo "Error: send failed for $pane_id" >&2; rm -f "$baseline_file"; exit 1; }
 
 # by name (literal, no Enter): herdr agent send reviewer "…"; then
 # herdr pane send-keys "$pane_id" enter
@@ -357,17 +358,7 @@ Optional helper when status stays `unknown` (no integration / undetected CLI): `
 
 ## Phase 6: Continue, Broadcast, or Tear Down
 
-**Continue (steer):** focus if the human wants the live TUI, or keep messaging from the CLI:
-
-```bash
-herdr agent focus reviewer          # jump UI to that agent
-# Preflight EVERY follow-up too: the pane may have gone working/blocked/
-# unverifiable since the last reply (Phase 4 resolved $here).
-python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
-  || { echo "Error: $pane_id not safe for follow-up (preflight failed) — see stderr" >&2; exit 1; }
-herdr pane run "$pane_id" "Also check the failing test." || { echo "send failed for $pane_id" >&2; exit 1; }
-# then Phase 5 again
-```
+**Continue (steer):** optionally `herdr agent focus reviewer` for the live TUI, then keep messaging from the CLI. A follow-up is a **brand-new send — re-run the entire Phase 4→5 workflow for it**, not a bare `pane run`. Every follow-up needs its own **fresh `$baseline_file`** (Phase 5 deleted the previous one) and **fresh `$completion_marker`** (the prior joined marker is already in the transcript and would falsely satisfy this wait), plus the Phase 4 preflight immediately before its `pane run` and the Phase 5 wait afterward. Reusing the deleted baseline or stale marker makes the follow-up's completion unprovable.
 
 **Broadcast to a fleet:** send to every target first, then wait concurrently:
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.14.0
+  version: 1.15.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -265,7 +265,6 @@ herdr pane read "$pane_id" --source recent-unwrapped --lines 80 >"$baseline_file
   || { echo "Error: could not capture baseline for $pane_id" >&2; exit 1; }
 marker_suffix="$(date +%s)_$$_$RANDOM"
 completion_marker="HERDR_DONE_$marker_suffix"
-
 # Keep the full marker out of the prompt so prompt echo cannot satisfy the wait.
 task="summarize the changes in src/
 
@@ -304,7 +303,12 @@ fi
 ```bash
 python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
   || { echo "Error: $pane_id not safe for recovery Enter (blocked/working/unverifiable) — see stderr" >&2; exit 1; }
-herdr pane send-keys "$pane_id" enter
+# Guard the keystroke itself, then re-wait for `working` and PROPAGATE failure:
+# a swallowed re-wait (bare `|| echo NOT-DELIVERED`) reports a non-delivery as
+# success. Still idle after the Enter → the send never landed; exit non-zero.
+herdr pane send-keys "$pane_id" enter || { echo "Error: recovery Enter failed for $pane_id" >&2; exit 1; }
+herdr wait agent-status "$pane_id" --status working --timeout 10000 \
+  || { echo "Error: $pane_id NOT-DELIVERED — still idle after recovery Enter; re-send the task." >&2; exit 1; }
 ```
 
 A transcript change proves delivery activity, but may be only the echoed prompt; do **not** submit an extra Enter. The split completion marker lets Phase 5 distinguish echo from a finished reply.
@@ -357,6 +361,10 @@ Optional helper when status stays `unknown` (no integration / undetected CLI): `
 
 ```bash
 herdr agent focus reviewer          # jump UI to that agent
+# Preflight EVERY follow-up too: the pane may have gone working/blocked/
+# unverifiable since the last reply (Phase 4 resolved $here).
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id not safe for follow-up (preflight failed) — see stderr" >&2; exit 1; }
 herdr pane run "$pane_id" "Also check the failing test." || { echo "send failed for $pane_id" >&2; exit 1; }
 # then Phase 5 again
 ```

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.12.0
+  version: 1.13.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -1,48 +1,57 @@
 ---
 name: herdr-agent-comms
-description: "Manage AI agent fleets in Herdr: one project workspace, split panes in one view, message/wait/read via herdr CLI, steer any pane. Use for Herdr multi-agent fleets. Don't use for tmux, screen, or non-Herdr terminals."
+description: "Manage AI agent fleets in Herdr: split sub-agents from the root agent pane into one tab, message/wait/read via herdr CLI, steer any pane. Use for Herdr multi-agent fleets. Don't use for tmux, screen, or non-Herdr terminals."
 license: MIT
 effort: medium
 metadata:
-  version: 1.1.0
+  version: 1.2.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
 
 # Herdr Agent Comms
 
-Manage and talk to AI agents (Claude Code, pi, Codex, OpenCode, or any CLI) as **split panes in one fleet view**: **create** a project workspace, **spawn** agents into a shared tab via splits, **send** tasks, **wait** on agent status, **capture** replies, and **tear down** when done.
+Manage and talk to AI agents (Claude Code, pi, Codex, OpenCode, or any CLI) by **splitting the root agent's pane**: the **root agent stays put**, each **sub-agent is a new split in the same tab**, then **send** / **wait** / **read** / **tear down** via the `herdr` CLI.
 
 Mental model (Herdr concepts, not tmux):
 
 | Concept | Role in this skill |
 |---|---|
-| **Workspace** | One per project/repo — all agents for that project live here |
-| **Fleet tab** | One shared tab (label e.g. `fleet`) holding the whole multi-agent view |
-| **Pane** | One agent = one split pane; primary control target (`wN:pM`) |
+| **Root agent** | Orchestrator pane (usually the caller: `$HERDR_PANE_ID`) — never replaced by a sub-agent |
+| **Root tab** | The root agent's tab — **single view** holding root + every sub-agent pane |
+| **Sub-agent pane** | Created only by splitting the root pane (or another pane in the root tab) |
 | **Agent name** | Stable handle for send/wait/read (`reviewer`, `tests`, …) |
 
-You orchestrate from outside (or from another Herdr pane) with the `herdr` CLI. Prefer Herdr's agent-status waits over polling scrollback. Relay each agent's answer, not its whole screen.
+Default layout after spawning two sub-agents:
+
+```
+Tab (root's tab)
+├── pane root     ← root / orchestrator agent (you)
+├── pane right    ← sub-agent reviewer
+└── pane down     ← sub-agent tests
+```
+
+You orchestrate with the `herdr` CLI. Prefer agent-status waits over scrollback polling. Relay each agent's answer, not its whole screen.
 
 This skill is the **Herdr counterpart** of `tmux-agent-comms`. Use this when agents should live in Herdr; use `tmux-agent-comms` for plain tmux.
 
 ## When to Use
 
-Spinning up a multi-agent fleet in Herdr, putting every agent for a project in one workspace as **side-by-side / tiled panes**, messaging or steering any pane, broadcasting to a fleet, or reading what an agent replied. Don't use for tmux/screen sessions or GUI apps.
+Spinning up sub-agents beside the root agent in **one tab**, messaging or steering any pane, broadcasting to a fleet, or reading replies. Don't use for tmux/screen sessions or GUI apps.
 
 ## Workflow
 
-Six phases, in order: ensure server + resolve workspace, spawn split-pane fleet, resolve targets, send, wait + read, continue or tear down.
+Six phases, in order: ensure server + resolve root, split sub-agents from root, resolve targets, send, wait + read, continue or tear down.
 
 **Jump straight to the phase for your task** — don't read the rest:
 
 | Your task | Start at |
 |---|---|
-| Spin up N agents for a project (agent/model/thinking/skill + task) | Phase 1 → Phase 2 |
+| Spin up N sub-agents beside the root agent | Phase 1 → Phase 2 |
 | Message an agent that's already running | Phase 3 |
 | Just read a running agent's pane (no send) | Phase 5 |
 | Broadcast the same message to a fleet | Phase 6 ("Broadcast") |
-| Shut agents / fleet tab down | Phase 6 ("Tear down") |
+| Shut sub-agents down (keep root) | Phase 6 ("Tear down") |
 
 ## Prerequisites
 
@@ -53,87 +62,99 @@ Six phases, in order: ensure server + resolve workspace, spawn split-pane fleet,
 
 ## Critical Rules
 
-1. **Confirm before destructive actions.** Closing panes/tabs/workspaces or `herdr server stop` can lose agent work — never without explicit user go-ahead. Reading panes is always safe.
+1. **Confirm before destructive actions.** Closing panes/tabs/workspaces or `herdr server stop` can lose agent work — never without explicit user go-ahead. Reading panes is always safe. **Never close the root pane** unless the user explicitly asks to kill the orchestrator.
 2. **Parse IDs from JSON.** Workspace/tab/pane IDs are opaque (`w26`, `w26:t2`, `w26:p4`). Never invent them from sidebar order.
-3. **One workspace per project; one fleet tab; split pane per agent.** Default spawn path puts **all fleet agents in a single tab** as tiled splits so the human sees everyone at once. Create a **new tab per agent only** when the user explicitly asks for full-viewport isolation.
-4. **Prefer `--no-focus` while spawning** so layout churn doesn't steal the keyboard from the human. After the fleet is up, `herdr tab focus <fleet_tab>` (or click the fleet tab) shows the whole board; `herdr agent focus <name>` zooms to one pane to type.
+3. **Split from the root agent — one tab.** Default spawn **splits the root agent's pane** so the human sees **root + all sub-agents in a single tab**. Do **not** create a separate fleet tab and do **not** put the first sub-agent on a new tab's root pane. New tabs only when the user explicitly asks for isolation.
+4. **Prefer `--no-focus` while spawning** so focus stays on the root agent. Use `herdr agent focus <name>` when the user wants to type into a sub-agent.
 5. **Wait on agent status, don't race.** After send, wait for `working` then `idle`/`done` (Phase 4). Don't send a follow-up while status is `working`.
 6. **`pane run` submits text + Enter.** Prefer it over separate `send-text`/`send-keys` for prompts. `agent send` is literal text only (no Enter) — use when you must type without submitting.
 7. **Blocked agents need humans.** Status `blocked` means a trust/auth/permission dialog — surface it; don't type the next task into the dialog.
 
-## Phase 1: Ensure Server and Project Workspace
+## Phase 1: Ensure Server and Resolve Root Agent
 
 ```bash
 command -v herdr >/dev/null || { echo "herdr missing"; exit 1; }
 herdr status
-herdr workspace list
 ```
 
-Resolve the project directory (`project_dir`) and a short workspace label (default: basename of `project_dir`).
-
-**Reuse** an existing workspace whose label or cwd matches the project when possible:
+Resolve **root** (orchestrator) context — this is the pane you split:
 
 ```bash
-herdr workspace list   # JSON: workspaces[].workspace_id, label, ...
+# Preferred when this skill runs inside Herdr (HERDR_ENV=1):
+root_pane="${HERDR_PANE_ID:?}"
+root_tab="${HERDR_TAB_ID:?}"
+ws="${HERDR_WORKSPACE_ID:?}"
+
+# Or resolve explicitly:
+# herdr pane current --current
+# herdr pane get w26:p1
 ```
 
-**Create** only when none matches:
+If `HERDR_ENV` is not set (orchestrating from outside Herdr):
+
+1. `herdr workspace list` / `herdr agent list`
+2. Pick the project workspace and an existing root agent pane the user named, **or** the focused pane
+3. Only if there is no usable root pane: create a workspace tab for the project and treat its root pane as root — still split sub-agents from that pane afterward (do not open one tab per sub-agent)
+
+Also resolve `project_dir` (default: cwd of the root pane from `herdr pane get`, else `pwd`).
+
+Optional: `herdr integration install pi|claude|codex|opencode|hermes` for better status. Not required every run.
+
+**Done when:** you have concrete `root_pane`, `root_tab`, `ws`, and the server is running. Root agent stays alive in `root_pane`.
+
+## Phase 2: Spawn Sub-Agents by Splitting the Root Pane
+
+Every sub-agent is a **split of the root pane** (same tab). The root agent is **not** moved, renamed into a worker, or replaced.
+
+### 2a — Split root → launch sub-agent
 
 ```bash
-herdr workspace create --cwd "$project_dir" --label "$label" --no-focus
-# read result.workspace.workspace_id (or equivalent) from JSON
-```
-
-Optional: install the integration for agents you resume often (`herdr integration install pi|claude|codex|opencode|hermes`) so status is authoritative. Not required for every run.
-
-**Done when:** you have a concrete `workspace_id` for the project and the server is running.
-
-## Phase 2: Spawn Split-Pane Fleet
-
-Put **all agents in one fleet tab** as tiled splits so the human sees every agent in a single view.
-
-### 2a — Create one fleet tab, then split per agent
-
-```bash
-project_dir=/path/to/project
-ws="$workspace_id"          # from Phase 1
-fleet_label=fleet           # or "${label}-fleet"
-
-# One shared tab for the whole fleet
-tab_json="$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label "$fleet_label" --no-focus)"
-fleet_tab="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')"
-root_pane="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')"
-
-# --- agent 1: use the tab's root pane ---
+project_dir=/path/to/project   # usually root pane cwd
+root_pane="$HERDR_PANE_ID"     # from Phase 1
 name=reviewer
 agent_cmd='pi --thinking medium'
-herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-herdr pane rename "$root_pane" "$name"
-herdr agent rename "$root_pane" "$name"
-herdr pane run "$root_pane" "$agent_cmd"
-# record: pane_id=$root_pane
+# optional skills for pi:  --skill /path/to/SKILL.md
 
-# --- agents 2..N: split inside the same fleet tab ---
-# Alternate right/down for a usable tile (2-up: right; 3+: right then down…).
-# Always --no-focus so the human keeps their keyboard.
-name=tests
+# free name if taken
 herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-start_json="$(herdr agent start "$name" \
-  --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
-  --split right --no-focus -- pi --thinking low)"
-pane_id="$(printf '%s' "$start_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["agent"]["pane_id"])')"
-# if argv after -- is only the launcher, boot is done; else still wait idle before task
 
-name=docs
-herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-herdr agent start "$name" \
-  --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
-  --split down --no-focus -- pi --thinking low
+# Split the ROOT pane (not an anonymous new tab). Always --no-focus.
+dir=right   # first sub-agent: right; later: alternate down / right
+split_json="$(herdr pane split "$root_pane" --direction "$dir" --cwd "$project_dir" --no-focus)"
+# JSON shape: result.pane.pane_id (verify once with your herdr version if needed)
+sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r.get("root_pane") or r)["pane_id"])')"
+
+herdr pane rename "$sub_pane" "$name"
+herdr agent rename "$sub_pane" "$name"
+herdr pane run "$sub_pane" "$agent_cmd"
 ```
 
-**Split direction rule:** prefer `right` when the target pane is wider than tall; prefer `down` when it is tall/narrow. If you cannot inspect layout, **alternate** `right`, `down`, `right`, … Avoid stacking every split in the same direction (creates unusable slivers).
+**Second / third sub-agent** — keep splitting from the **root pane** (or the last sub-pane if root is already too narrow); stay on `root_tab`:
 
-**Optional (user asked for full-viewport isolation):** one tab per agent via `herdr tab create` per name — see `references/herdr-recipes.md` ("Tab-per-agent layout"). Not the default.
+```bash
+name=tests
+herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
+split_json="$(herdr pane split "$root_pane" --direction down --cwd "$project_dir" --no-focus)"
+sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
+herdr pane rename "$sub_pane" "$name"
+herdr agent rename "$sub_pane" "$name"
+herdr pane run "$sub_pane" 'pi --thinking low'
+```
+
+**Alternative** (same tab, less precise about which pane is split): `herdr agent start` into the root tab:
+
+```bash
+herdr agent start "$name" --cwd "$project_dir" --workspace "$ws" --tab "$root_tab" \
+  --split right --no-focus -- pi --thinking medium
+```
+
+Prefer **`pane split "$root_pane"`** so the split is anchored on the root agent, not whichever pane last held focus.
+
+**Split direction rule:** prefer `right` when the source pane is wider than tall; prefer `down` when tall/narrow. If unknown, **alternate** `right`, `down`, `right`, …. Avoid repeating one direction until panes are unusable slivers. Optional geometry: `herdr pane layout --pane "$root_pane"`.
+
+**Forbidden by default:** `herdr tab create` per sub-agent; hijacking the root pane with the first worker's CLI; `herdr workspace create` just to host workers when a root pane already exists in the project workspace.
+
+**Optional (user asks for isolation):** tab-per-agent — see `references/herdr-recipes.md`. Not the default.
 
 ### 2b — Build `agent_cmd` (common CLIs)
 
@@ -144,34 +165,29 @@ herdr agent start "$name" \
 | **Codex** | `codex` | interactive default; verify flags with `codex --help` |
 | **OpenCode** | `opencode` | verify with `opencode --help` |
 
-Launch the **interactive** TUI (no `-p`/`exec` non-interactive mode) unless the user asked for fire-and-exit. Do **not** pass the long task as argv on first launch by default — boot first, then `pane run` the task (matches Herdr's own agent guide).
+Launch the **interactive** TUI (no `-p`/`exec` non-interactive mode) unless the user asked for fire-and-exit. Do **not** pass the long task as argv on first launch by default — boot first, then `pane run` the task.
 
 When using `herdr agent start … -- <argv>`, put only the launcher (+ model/thinking/skill flags) after `--`, not the long task prompt.
 
 ### 2c — Ready, then assign work
 
 ```bash
-# boot → idle (or blocked on trust) — per pane
-herdr wait agent-status "$pane_id" --status idle --timeout 60000
-# if timeout: herdr pane get / herdr agent explain "$pane_id"
+# boot → idle (or blocked on trust) — per SUB-agent pane
+herdr wait agent-status "$sub_pane" --status idle --timeout 60000
+# if timeout: herdr pane get / herdr agent explain "$sub_pane"
 # if blocked: surface to user (Rule 7)
 
-herdr pane run "$pane_id" "Review the open PR diff and report only actionable findings."
-herdr wait agent-status "$pane_id" --status working --timeout 30000 || true
+herdr pane run "$sub_pane" "Review the open PR diff and report only actionable findings."
+herdr wait agent-status "$sub_pane" --status working --timeout 30000 || true
 ```
 
-**Fleet spawn:** create the fleet tab once, spawn every split (`--no-focus`), launch every agent, then wait/read concurrently — don't fully serialize spawn→wait→read per agent when the user wants parallel work. `scripts/broadcast.sh` fans messages after spawn.
+**Fleet spawn:** split every sub-agent first (`--no-focus`), launch every CLI, then wait/read concurrently — don't fully serialize spawn→wait→read per agent when the user wants parallel work. `scripts/broadcast.sh` fans messages after spawn.
 
-**Human visibility:** after spawn, focus the fleet tab so all panes are on screen:
-
-```bash
-herdr tab focus "$fleet_tab"
-# or zoom one agent: herdr agent focus reviewer
-```
+**Human visibility:** root + sub-agents already share one tab. No extra tab focus required if the human is already on the root tab. Optional: `herdr agent focus reviewer` to type into one sub-agent; return focus to root when done orchestrating from the TUI.
 
 Detach the Herdr client with `prefix+q` (`ctrl+b` then `q`); agents keep running.
 
-**Done when:** each requested agent has `pane_id` + shared `fleet_tab` + agent `name`, all panes are in that tab, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
+**Done when:** each sub-agent has `sub_pane` + agent `name`, **same `root_tab` as the root pane**, root pane still holds the orchestrator, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
 
 ## Phase 3: Resolve the Exact Target
 
@@ -279,66 +295,62 @@ herdr workspace list
 **Tear down (confirmation required):**
 
 ```bash
-herdr pane close "$pane_id"         # one agent pane
-herdr tab close "$fleet_tab"        # preferred — whole fleet view at once
-herdr workspace close "$ws"         # whole project workspace — confirm
+herdr pane close "$sub_pane"        # one sub-agent — preferred
+# close every sub-agent pane this skill created; leave root_pane alone
+# herdr tab close "$root_tab"      # only if user wants the whole tab gone (kills root too)
+# herdr workspace close "$ws"      # whole project workspace — confirm
 # herdr server stop                 # kills everything — last resort, confirm
 ```
 
-Never `server stop` from inside an active session unless the user explicitly wants the server and all panes dead.
+Never `server stop` from inside an active session unless the user explicitly wants the server and all panes dead. Never close `root_pane` when only tearing down workers.
 
 ## Example
 
-Spin two agents side-by-side in one fleet tab and collect answers:
+From the root agent (inside Herdr), split two sub-agents into the same tab and collect answers:
 
 ```bash
+# Phase 1 — root is the caller
+root_pane="$HERDR_PANE_ID"
+root_tab="$HERDR_TAB_ID"
+ws="$HERDR_WORKSPACE_ID"
 project_dir="$(pwd)"
-label="$(basename "$project_dir")"
-export L="$label"
-ws="$(herdr workspace list | python3 -c "
-import sys,json,os
-d=json.load(sys.stdin); label=os.environ['L']
-for w in d['result']['workspaces']:
-    if w.get('label')==label: print(w['workspace_id']); break
-" )"
-# if empty: create with herdr workspace create --cwd "$project_dir" --label "$label" --no-focus
 
-tab_json="$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label fleet --no-focus)"
-fleet_tab="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')"
-p1="$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')"
+spawn_sub() {
+  local name="$1" dir="$2" cmd="$3" task="$4"
+  local split_json pane
+  herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
+  split_json="$(herdr pane split "$root_pane" --direction "$dir" --cwd "$project_dir" --no-focus)"
+  pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
+  herdr pane rename "$pane" "$name"
+  herdr agent rename "$pane" "$name"
+  herdr pane run "$pane" "$cmd"
+  herdr wait agent-status "$pane" --status idle --timeout 60000
+  herdr pane run "$pane" "$task"
+  printf '%s\n' "$pane"
+}
 
-herdr pane rename "$p1" reviewer
-herdr agent rename "$p1" reviewer
-herdr pane run "$p1" 'pi --thinking medium'
+p1="$(spawn_sub reviewer right 'pi --thinking medium' 'Review recent commits for risk; bullet findings only.')"
+p2="$(spawn_sub tests down 'pi --thinking low' 'Outline a minimal test plan for the last change.')"
 
-j2="$(herdr agent start tests --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
-  --split right --no-focus -- pi --thinking low)"
-p2="$(printf '%s' "$j2" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["agent"]["pane_id"])')"
-
-for p in "$p1" "$p2"; do
-  herdr wait agent-status "$p" --status idle --timeout 60000
-done
-herdr pane run "$p1" 'Review recent commits for risk; bullet findings only.'
-herdr pane run "$p2" 'Outline a minimal test plan for the last change.'
-
-herdr tab focus "$fleet_tab"   # show both panes in one view
+# Same tab: root_pane + p1 + p2
 python3 scripts/wait_for_idle.py "$p1" --timeout 180
 herdr pane read "$p1" --source recent-unwrapped --lines 80
-herdr agent focus reviewer     # optional: zoom to type into one pane
+# optional: herdr agent focus reviewer
 ```
 
 ## Edge Cases
 
-- **Not inside Herdr / no server** — CLI still talks to the socket if the server runs; if `herdr status` fails, user must start `herdr` once in a real terminal.
+- **Not inside Herdr / no server** — CLI still talks to the socket if the server runs; if `herdr status` fails, user must start `herdr` once in a real terminal. Outside Herdr, resolve an existing root pane before splitting.
 - **Nested `herdr` launch** — if `HERDR_ENV=1`, never run bare `herdr` (blocked by design). Use CLI subcommands only.
 - **Trust/auth dialog** — status `blocked`; surface it, don't submit the task.
 - **`idle` vs `done`** — both mean "finished or waiting for input"; `done` = unseen completion in background. Accept either after work.
 - **Name collision** — `agent rename` / `agent start` names must be unique; suffix with epoch if taken.
 - **Wrong workspace** — never spawn project B agents into project A's workspace; re-resolve Phase 1.
 - **Status `unknown`** — install integration or use `scripts/wait_for_idle.py` + `pane read`.
-- **Too many splits** — more than ~4 panes in one tab gets cramped; still default to splits unless the user asks for tab-per-agent, or create a second fleet tab for overflow.
-- **User wants to steer** — `herdr tab focus` for the whole board, `herdr agent focus <name>` for one pane; keep sending CLI follow-ups only when not fighting their keyboard.
-- **Closing the wrong pane/tab** — only close panes/tabs this skill created, unless the user names the target.
+- **Too many splits** — more than ~4 panes in one tab gets cramped; still split from root unless the user asks for tab-per-agent.
+- **User wants to steer** — `herdr agent focus <name>` for a sub-agent; keep CLI follow-ups only when not fighting their keyboard.
+- **Closing the wrong pane** — only close **sub-agent** panes this skill created; never close root unless asked.
+- **Accidental new fleet tab** — if you created a tab by mistake, move work into root's tab via splits from `root_pane` and close the empty tab only with confirmation.
 
 ## Reference
 
@@ -355,14 +367,15 @@ After a messaging or lifecycle operation, emit:
 ··································································
   Server:              √ pass (herdr status)
   Workspace:           √ pass (w26 · project label)
-  Target resolved:     √ pass (name: reviewer · pane: w26:p4 · fleet tab: w26:t2)
+  Root resolved:       √ pass (pane: w26:p1 · tab: w26:t1)
+  Target resolved:     √ pass (name: reviewer · pane: w26:p4 · same tab as root)
   Message sent:        √ pass (pane run)
   Message delivered:   √ pass (status → working)
   Reply settled:       √ pass (status done|idle)
   Reply captured:      √ pass (recent-unwrapped, not truncated)
-  Destructive action:  — none (or: confirmed by user)
+  Destructive action:  — none (or: confirmed by user; root kept)
   ____________________________
   Result:              PASS
 ```
 
-Adapt rows to the operation — a spawn reports `Fleet tab + splits created`; a teardown reports `Confirmed` and `Panes/tab closed`. Use `⚠` for dropped delivery or escalated stall.
+Adapt rows to the operation — a spawn reports `Root kept · N sub-panes split`; a teardown reports `Confirmed` and `Sub-panes closed (root kept)`. Use `⚠` for dropped delivery or escalated stall.

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.13.0
+  version: 1.14.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -245,6 +245,21 @@ If the name is missing, list agents and surface the closest match — don't sile
 Capture the transcript **before sending**. This lets Phase 5 recognize a fast reply even if the agent finishes before the waiter starts:
 
 ```bash
+# Resolve the scripts dir if not already set (Phase 4 can be reached directly).
+if [ -z "${here:-}" ]; then
+  for cand in "skills/herdr-agent-comms/scripts" ".agents/skills/herdr-agent-comms/scripts" \
+    ".claude/skills/herdr-agent-comms/scripts" "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+    "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
+    [ -f "$cand/preflight_send.py" ] && { here="$cand"; break; }
+  done
+fi
+# FAIL-CLOSED preflight — same enum-validated check broadcast.sh runs. Refuse to
+# send into a working (rc 2), blocked (rc 3), or unverifiable/off-enum (rc 4)
+# pane; only idle/done/unknown (rc 0) is safe. Skipping this let a task be typed
+# into a blocked trust dialog and still report success.
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id is not safe to send to (preflight failed) — see stderr" >&2; exit 1; }
+
 baseline_file="$(mktemp)"
 herdr pane read "$pane_id" --source recent-unwrapped --lines 80 >"$baseline_file" \
   || { echo "Error: could not capture baseline for $pane_id" >&2; exit 1; }
@@ -284,28 +299,25 @@ else
 fi
 ```
 
-`NOT-DELIVERED` → lone Enter via `herdr pane send-keys "$pane_id" enter`, re-check; if still idle with no new output, re-send. A transcript change proves delivery activity, but may be only the echoed prompt; do **not** submit an extra Enter. The split completion marker lets Phase 5 distinguish echo from a finished reply.
+`NOT-DELIVERED` → **re-run the preflight first**, then a lone Enter via `herdr pane send-keys "$pane_id" enter`; if still idle with no new output, re-send. Never send the Enter blind: the send may have flipped the pane into a `blocked` dialog (the input triggered a trust/permission prompt), and a bare Enter would answer *that* dialog, not deliver the task.
+
+```bash
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id not safe for recovery Enter (blocked/working/unverifiable) — see stderr" >&2; exit 1; }
+herdr pane send-keys "$pane_id" enter
+```
+
+A transcript change proves delivery activity, but may be only the echoed prompt; do **not** submit an extra Enter. The split completion marker lets Phase 5 distinguish echo from a finished reply.
 
 ## Phase 5: Wait for the Reply, Then Read It
 
 Use Herdr status waits (not fixed `sleep`). Completion may be **`done`** (unseen, usually background) **or `idle`** (seen / focused tab) — wait for either. Prefer the helper with the Phase 4 pre-send baseline; without it, a fast agent can finish before the waiter snapshots the pane and leave the root waiting until timeout:
 
 ```bash
-# $here is the scripts/ dir. If Phase 2 already resolved it, reuse it;
-# jumping straight here (e.g. "message an agent that's already running")
-# skips Phase 2, so probe install locations again rather than assume it's set.
-# Repo-local copies win over global installs (see Phase 2a).
-if [ -z "${here:-}" ]; then
-  for cand in \
-    "skills/herdr-agent-comms/scripts" \
-    ".agents/skills/herdr-agent-comms/scripts" \
-    ".claude/skills/herdr-agent-comms/scripts" \
-    "$HOME/.claude/skills/herdr-agent-comms/scripts" \
-    "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
-    if [ -f "$cand/wait_for_idle.py" ]; then here="$cand"; break; fi
-  done
-fi
-[ -n "${here:-}" ] || { echo "Error: wait_for_idle.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
+# $here is the scripts/ dir. Phase 4 resolved it; if you jumped straight here
+# (messaging an already-running agent), the Phase 4 resolver block above finds
+# it (repo-local copies win over global installs — see Phase 2a).
+[ -n "${here:-}" ] || { echo "Error: wait_for_idle.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Resolve \$here (see Phase 4) before retrying." >&2; exit 1; }
 python3 "$here/wait_for_idle.py" "$pane_id" --timeout 180 --lines 80 \
   --baseline-file "$baseline_file" --completion-marker "$completion_marker"
 rc=$?; rm -f "$baseline_file"   # capture rc BEFORE cleanup ($? = rm's otherwise)
@@ -313,28 +325,7 @@ rc=$?; rm -f "$baseline_file"   # capture rc BEFORE cleanup ($? = rm's otherwise
 [ "$rc" -eq 0 ] || { echo "Error: wait for $pane_id did not complete (rc $rc)" >&2; exit "$rc"; }
 ```
 
-Manual fallback after delivery is verified:
-
-```bash
-# Poll until idle|done|blocked or budget spent. FAIL-CLOSED status read: a
-# failed/malformed `herdr pane get` exits with an error instead of falling
-# through to `sleep` as if the pane were merely `unknown`.
-deadline=$((SECONDS + 180))
-while (( SECONDS < deadline )); do
-  out=$(herdr pane get "$pane_id" 2>/dev/null) || { echo "Error: status lookup failed for $pane_id" >&2; exit 1; }
-  st=$(printf '%s' "$out" | python3 -c 'import sys,json
-try: print(json.load(sys.stdin)["result"]["pane"].get("agent_status") or "unknown")
-except Exception: sys.exit(1)') || { echo "Error: could not parse status for $pane_id" >&2; exit 1; }
-  case "$st" in
-    done|idle) echo "settled:$st"; break ;;
-    blocked) echo "blocked"; break ;;
-    working) herdr wait agent-status "$pane_id" --status done --timeout 15000 \
-               || herdr wait agent-status "$pane_id" --status idle --timeout 15000 || true ;;
-    *) sleep 2 ;;
-  esac
-done
-# Or use the helper instead (resolve $here first — see the block above).
-```
+**Manual fallback** (after delivery is verified) — poll `herdr pane get` until `idle|done|blocked` with a FAIL-CLOSED, enum-validated status read (a failed/malformed/off-enum `pane get` errors out instead of `sleep`ing as if merely `unknown`). Full copy-paste block in `references/delivery-and-waiting.md`.
 
 Treat **either `idle` or `done` as completed** — difference is only whether the result was seen. Never wait only on `done` for the full budget: a focused-tab finish stays `idle` and will time out.
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.18.0
+  version: 1.19.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split sub-agents from the root ag
 license: MIT
 effort: medium
 metadata:
-  version: 1.2.0
+  version: 1.2.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.5.0
+  version: 1.6.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -18,24 +18,23 @@ Mental model (Herdr concepts, not tmux):
 | Concept | Role in this skill |
 |---|---|
 | **Root agent** | Orchestrator pane (usually the caller: `$HERDR_PANE_ID`) — never replaced by a sub-agent |
-| **Root tab** | The root agent's tab — **single grid** holding root + every sub-agent pane |
-| **Sub-agent pane** | Created by splitting the current largest pane in the root tab (often root first) |
+| **Root tab** | The root agent's tab — **single row of equal-width columns** holding root + every sub-agent pane |
+| **Sub-agent pane** | Created by splitting the rightmost column `right`, then resizing every column (including root) down to the new equal share |
 | **Agent name** | Stable handle for send/wait/read (`reviewer`, `tests`, …) |
 
-Default layout after spawning three sub-agents (balanced grid including root; **vertical panel first**):
+Default layout after spawning three sub-agents (**equal-width columns, root included**):
 
 ```
 Tab (root's tab)
-┌─────────────┬─────────────┐
-│ root (you)  │ reviewer    │
-├─────────────┼─────────────┤
-│ tests       │ docs        │
-└─────────────┴─────────────┘
+┌──────────┬──────────┬──────────┬──────────┐
+│ root(you)│ reviewer │ tests    │ docs     │
+└──────────┴──────────┴──────────┴──────────┘
 ```
-(Exact tiles depend on aspect ratios and live geometry — `next_grid_split.py` always
-picks the largest pane, so later splits may target root or a sub-agent pane. The first
-split always prefers `down`, so root starts on top; the largest-pane rule tends to grid
-root and its workers into roughly equal tiles rather than one full column.)
+(All columns — root and every sub-agent — are always the same width. Adding a
+column means splitting the current rightmost pane `right`, then resizing every
+existing column down to `1/N` where N is the new total column count.
+`next_grid_split.py` computes this plan; see Phase 2a and "Equal-width columns"
+below for the caveat on `herdr pane resize` semantics.)
 
 You orchestrate with the `herdr` CLI. Prefer agent-status waits over scrollback polling. Relay each agent's answer, not its whole screen.
 
@@ -70,7 +69,7 @@ Six phases, in order: ensure server + resolve root, split sub-agents from root, 
 
 1. **Confirm before destructive actions.** Closing panes/tabs/workspaces or `herdr server stop` can lose agent work — never without explicit user go-ahead. Reading panes is always safe. **Never close the root pane** unless the user explicitly asks to kill the orchestrator.
 2. **Parse IDs from JSON.** Workspace/tab/pane IDs are opaque (`w26`, `w26:t2`, `w26:p4`). Never invent them from sidebar order.
-3. **Grid layout in the root tab.** Default spawn builds a **tiled grid that includes the root agent**. Split the **largest current pane** (not always the same pane), alternating `right`/`down` by geometry so root and workers stay balanced. Do **not** create a separate fleet tab and do **not** put the first sub-agent on a new tab's root pane. New tabs only when the user explicitly asks for isolation.
+3. **Equal-width column grid in the root tab.** Default spawn builds a **row of equal-width columns that includes the root agent**. Every split is `right` on the current rightmost column, followed by resizing every column (including root) down to the new `1/N` share — never leave root or a worker wider than the others. Do **not** create a separate fleet tab and do **not** put the first sub-agent on a new tab's root pane. New tabs only when the user explicitly asks for isolation.
 4. **Prefer `--no-focus` while spawning** so focus stays on the root agent. Use `herdr agent focus <name>` when the user wants to type into a sub-agent.
 5. **Wait on agent status, don't race.** After send, wait for `working` then `idle`/`done` (Phase 4). Don't send a follow-up while status is `working`.
 6. **`pane run` submits text + Enter.** Prefer it over separate `send-text`/`send-keys` for prompts. `agent send` is literal text only (no Enter) — use when you must type without submitting.
@@ -112,9 +111,9 @@ Optional: `herdr integration install pi|claude|codex|opencode|hermes` for better
 
 Every sub-agent joins the **same tab as the root agent** as part of a **tiled grid**. The root agent is **not** moved, renamed into a worker, or replaced.
 
-### 2a — Split the largest pane → launch sub-agent
+### 2a — Split the rightmost column, resize all to equal width → launch sub-agent
 
-Do **not** always split `$root_pane`. Always pick the current largest cell so root and workers stay roughly equal size:
+Every column — root included — must end up the **same width**. Do **not** just split and move on: after the split, resize every existing column down to the new `1/N` share:
 
 ```bash
 project_dir=/path/to/project   # usually root pane cwd
@@ -142,49 +141,68 @@ agent_cmd='pi --thinking medium'
 # free name if taken
 herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
 
-# Choose largest pane + direction from live geometry (includes root).
-read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
-split_json="$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)"
+# Plan: line 1 is "split <rightmost_pane> right --ratio <share>", the rest
+# are "resize <pane_id> <share>" for every pre-existing column (root
+# included). See "Equal-width columns" below for the --ratio/--amount
+# semantics caveat — confirm against your herdr version if in doubt.
+plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
+read -r _ split_from _dir _ratio_flag ratio < <(head -1 <<<"$plan")
+split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
 # JSON shape: result.pane.pane_id (verify once with your herdr version if needed)
 sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r.get("root_pane") or r)["pane_id"])')"
+
+# Resize every pre-existing column (from the plan's remaining lines) to the
+# same share so the new pane doesn't leave the others too wide.
+tail -n +2 <<<"$plan" | while read -r _ pane_id share; do
+  [ "$pane_id" = "$sub_pane" ] && continue   # the new pane is already at `share` from --ratio
+  herdr pane resize --pane "$pane_id" --direction right --amount "$share" >/dev/null || true
+done
 
 herdr pane rename "$sub_pane" "$name" >/dev/null
 herdr agent rename "$sub_pane" "$name" >/dev/null
 herdr pane run "$sub_pane" "$agent_cmd" >/dev/null
 ```
 
-**Second / third sub-agent** — re-run the chooser each time (geometry changes after every split):
+**Second / third sub-agent** — re-run the planner each time (share shrinks as columns are added):
 
 ```bash
 name=tests
 herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
-split_json="$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)"
+plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
+read -r _ split_from _dir _ratio_flag ratio < <(head -1 <<<"$plan")
+split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
 sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
+tail -n +2 <<<"$plan" | while read -r _ pane_id share; do
+  [ "$pane_id" = "$sub_pane" ] && continue
+  herdr pane resize --pane "$pane_id" --direction right --amount "$share" >/dev/null || true
+done
 herdr pane rename "$sub_pane" "$name" >/dev/null
 herdr agent rename "$sub_pane" "$name" >/dev/null
 herdr pane run "$sub_pane" 'pi --thinking low' >/dev/null
 ```
 
-**Manual fallback** when the helper is unavailable: inspect `herdr pane layout --pane "$root_pane"`, split the largest pane by `rect.width * rect.height`. If this is the **first** split (only one pane exists), use `down` unconditionally — most terminals are wider than tall, so an aspect check alone would pick `right` and contradict vertical-panel-first. For later splits, use **`down` if height ≥ width else `right`**. Stay on `root_tab`.
+**Manual fallback** when the helper is unavailable: inspect `herdr pane layout --pane "$root_pane"`, order panes left to right by `rect.x`, split the rightmost one `right`, then resize every column (the new one plus every pre-existing one) to `1 / (existing_count + 1)`. Stay on `root_tab`.
 
-**Alternative** (same tab, less balanced): `herdr agent start` into the root tab:
+**Alternative** (same tab, not equal-width without manual resize): `herdr agent start` into the root tab:
 
 ```bash
 herdr agent start "$name" --cwd "$project_dir" --workspace "$ws" --tab "$root_tab" \
   --split right --no-focus -- pi --thinking medium
 ```
 
-Prefer **`next_grid_split.py` + `pane split`** so the grid includes root and stays balanced. Avoid always splitting the same pane (creates long slivers).
+Prefer **`next_grid_split.py` + `pane split` + `pane resize`** so the grid includes root and stays equal-width. This alternative skips the resize step, so follow it with a manual `herdr pane resize` pass on every column if you use it.
 
 **Grid rules:**
 1. One tab only: root + every sub-agent.
-2. Before each split, choose the **largest** pane in that tab (tie-break: root).
-3. Direction: the **first** split is always `down` (vertical panel first, regardless of aspect — real terminals are usually wider than tall). Later splits follow the target pane's aspect: **`down` when taller or square**, `right` only when clearly wider.
-4. Always `--no-focus` so the root keeps the keyboard.
-5. Optional check: `herdr pane layout --pane "$root_pane"` should show multiple similar-sized rects, not one huge pane and thin strips.
+2. Every split targets the current **rightmost** column.
+3. Direction: always `right` — this is a single row of equal-width columns, not a 2D grid. There is no `down` case in the default layout.
+4. After every split, resize **every** column (including root) down to `1 / N` where N is the new total column count. A split alone only sizes the new pane; it does not shrink the columns already in place.
+5. Always `--no-focus` so the root keeps the keyboard.
+6. Optional check: `herdr pane layout --pane "$root_pane"` should show N rects of equal `rect.width`, not one wide pane and thin strips.
 
-**Forbidden by default:** `herdr tab create` per sub-agent; hijacking the root pane with the first worker's CLI; `herdr workspace create` just to host workers when a root pane already exists; stacking every split from only `$root_pane` after the first cell is already small.
+**Equal-width columns — verification caveat:** the exact meaning of `herdr pane split --ratio` and `herdr pane resize --amount` (fraction of remaining space vs. absolute tab fraction vs. cells) has not been confirmed against a live `herdr` server in this skill's test suite — `next_grid_split.py`'s unit tests only cover the arithmetic (pane ordering, `1/N` share), not the live resize call. Run `herdr pane layout --pane "$root_pane"` after a spawn and confirm the rects are actually equal width before trusting this at scale; adjust the `--ratio`/`--amount` interpretation above if your installed `herdr` version disagrees.
+
+**Forbidden by default:** `herdr tab create` per sub-agent; hijacking the root pane with the first worker's CLI; `herdr workspace create` just to host workers when a root pane already exists; splitting a column other than the current rightmost one (creates unequal widths the resize pass won't fix).
 
 **Optional (user asks for isolation):** tab-per-agent — see `references/herdr-recipes.md`. Not the default.
 
@@ -219,7 +237,7 @@ herdr wait agent-status "$sub_pane" --status idle --timeout 60000
 
 Detach the Herdr client with `prefix+q` (`ctrl+b` then `q`); agents keep running.
 
-**Done when:** each sub-agent has `sub_pane` + agent `name`, **same `root_tab` as the root pane**, layout is a **grid that includes the root pane** (not stacked slivers), root pane still holds the orchestrator, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
+**Done when:** each sub-agent has `sub_pane` + agent `name`, **same `root_tab` as the root pane**, layout is a **row of equal-width columns that includes the root pane** (verified via `herdr pane layout` — not stacked slivers or one wide pane), root pane still holds the orchestrator, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
 
 ## Phase 3: Resolve the Exact Target
 
@@ -402,11 +420,17 @@ done
 [ -n "$here" ] || { echo "Error: next_grid_split.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 spawn_sub() {
   local name="$1" cmd="$2"
-  local split_from dir split_json pane
+  local plan split_from ratio split_json pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
-  split_json="$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)"
+  # Plan: line 1 "split <rightmost> right --ratio <share>", rest "resize <pane> <share>".
+  plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
+  read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
+  split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
   pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
+  tail -n +2 <<<"$plan" | while read -r _ pid share; do
+    [ "$pid" = "$pane" ] && continue
+    herdr pane resize --pane "$pid" --direction right --amount "$share" >/dev/null || true
+  done
   herdr pane rename "$pane" "$name" >/dev/null
   herdr agent rename "$pane" "$name" >/dev/null
   herdr pane run "$pane" "$cmd" >/dev/null
@@ -443,7 +467,7 @@ rm -f "$b1" "$b2"
 - **Wrong workspace** — never spawn project B agents into project A's workspace; re-resolve Phase 1.
 - **Status `unknown`** — install integration or use `scripts/wait_for_idle.py` + `pane read`.
 - **Too many splits** — more than ~4 panes in one tab gets cramped; keep the grid helper, or switch to tab-per-agent only if the user asks.
-- **Sliver layout** — you kept splitting one pane; re-run `scripts/next_grid_split.py` and split the largest cell instead.
+- **Unequal-width columns** — you split without the resize pass, or split a pane other than the current rightmost column; re-run `scripts/next_grid_split.py` and apply its full plan (split + resize every column).
 - **User wants to steer** — `herdr agent focus <name>` for a sub-agent; keep CLI follow-ups only when not fighting their keyboard.
 - **Closing the wrong pane** — only close **sub-agent** panes this skill created; never close root unless asked.
 - **Accidental new fleet tab** — if you created a tab by mistake, move work into root's tab via grid splits and close the empty tab only with confirmation.
@@ -451,7 +475,7 @@ rm -f "$b1" "$b2"
 ## Reference
 
 - `references/herdr-recipes.md` — grid layouts, multi-line sends, focus/steer, scrollback, troubleshooting.
-- `scripts/next_grid_split.py` — choose next largest pane + split direction for a balanced grid.
+- `scripts/next_grid_split.py` — plan the next split + resize-all-columns pass for an equal-width grid.
 - `references/delivery-and-waiting.md` — delivery checks, idle/done/blocked, budgets.
 - Official concepts: https://herdr.dev/docs/concepts/ · CLI: https://herdr.dev/docs/cli-reference/ · cheatsheet: https://luongnv.com/awesome-cheatsheets/cheatsheets/herdr/
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.11.0
+  version: 1.12.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -255,10 +255,9 @@ completion_marker="HERDR_DONE_$marker_suffix"
 task="summarize the changes in src/
 
 After fully finishing, concatenate and print these two parts without spaces: HERDR_DONE_ and $marker_suffix"
-herdr pane run "$pane_id" "$task"
+herdr pane run "$pane_id" "$task" || { echo "Error: send failed for $pane_id" >&2; exit 1; }
 
-# by name (literal text only — add Enter yourself if needed)
-# herdr agent send reviewer "summarize the changes in src/"
+# by name (literal, no Enter): herdr agent send reviewer "…"; then
 # herdr pane send-keys "$pane_id" enter
 ```
 
@@ -270,16 +269,18 @@ herdr pane run "$pane_id" "$task"
 if herdr wait agent-status "$pane_id" --status working --timeout 15000; then
   echo delivered
 else
-  # Capture the post-send read EXPLICITLY and check it succeeded — a failed
-  # `herdr pane read` in a `<(...)` would look "different from baseline" and
-  # be misreported as activity. A failed read is an error, not delivery.
-  after="$(herdr pane read "$pane_id" --source recent-unwrapped --lines 80)" \
-    || { echo "Error: post-send pane read failed for $pane_id" >&2; exit 1; }
-  if ! printf '%s' "$after" | cmp -s "$baseline_file" -; then
+  # Read post-send into a SECOND FILE and compare file-to-file. NOT
+  # `after="$(...)"` + cmp: `$(...)` strips trailing newlines the baseline
+  # keeps, so identical transcripts falsely compare as activity.
+  after_file="$(mktemp)"
+  herdr pane read "$pane_id" --source recent-unwrapped --lines 80 >"$after_file" \
+    || { echo "Error: post-send pane read failed for $pane_id" >&2; rm -f "$after_file"; exit 1; }
+  if ! cmp -s "$baseline_file" "$after_file"; then
     echo delivered-transcript-activity
   else
     echo NOT-DELIVERED
   fi
+  rm -f "$after_file"
 fi
 ```
 
@@ -307,9 +308,9 @@ fi
 [ -n "${here:-}" ] || { echo "Error: wait_for_idle.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 python3 "$here/wait_for_idle.py" "$pane_id" --timeout 180 --lines 80 \
   --baseline-file "$baseline_file" --completion-marker "$completion_marker"
-rc=$?
-rm -f "$baseline_file"
-# rc: 0 settled, 2 timeout, 3 blocked
+rc=$?; rm -f "$baseline_file"   # capture rc BEFORE cleanup ($? = rm's otherwise)
+# rc: 0 settled, 1 error, 2 timeout, 3 blocked. Propagate non-zero — not a reply.
+[ "$rc" -eq 0 ] || { echo "Error: wait for $pane_id did not complete (rc $rc)" >&2; exit "$rc"; }
 ```
 
 Manual fallback after delivery is verified:
@@ -365,7 +366,7 @@ Optional helper when status stays `unknown` (no integration / undetected CLI): `
 
 ```bash
 herdr agent focus reviewer          # jump UI to that agent
-herdr pane run "$pane_id" "Also check the failing test."
+herdr pane run "$pane_id" "Also check the failing test." || { echo "send failed for $pane_id" >&2; exit 1; }
 # then Phase 5 again
 ```
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -1,35 +1,40 @@
 ---
 name: herdr-agent-comms
-description: "Manage AI agent fleets in Herdr: split sub-agents from the root agent pane into one tab, message/wait/read via herdr CLI, steer any pane. Use for Herdr multi-agent fleets. Don't use for tmux, screen, or non-Herdr terminals."
+description: "Manage AI agent fleets in Herdr: split root + sub-agents into one tab as a tiled grid, message/wait/read via herdr CLI, steer any pane. Use for Herdr multi-agent fleets. Don't use for tmux, screen, or non-Herdr terminals."
 license: MIT
 effort: medium
 metadata:
-  version: 1.2.1
+  version: 1.3.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
 
 # Herdr Agent Comms
 
-Manage and talk to AI agents (Claude Code, pi, Codex, OpenCode, or any CLI) by **splitting the root agent's pane**: the **root agent stays put**, each **sub-agent is a new split in the same tab**, then **send** / **wait** / **read** / **tear down** via the `herdr` CLI.
+Manage and talk to AI agents (Claude Code, pi, Codex, OpenCode, or any CLI) by building a **grid layout in the root agent's tab**: the **root agent stays put**, each **sub-agent is a new tiled split**, then **send** / **wait** / **read** / **tear down** via the `herdr` CLI.
 
 Mental model (Herdr concepts, not tmux):
 
 | Concept | Role in this skill |
 |---|---|
 | **Root agent** | Orchestrator pane (usually the caller: `$HERDR_PANE_ID`) — never replaced by a sub-agent |
-| **Root tab** | The root agent's tab — **single view** holding root + every sub-agent pane |
-| **Sub-agent pane** | Created only by splitting the root pane (or another pane in the root tab) |
+| **Root tab** | The root agent's tab — **single grid** holding root + every sub-agent pane |
+| **Sub-agent pane** | Created by splitting the current largest pane in the root tab (often root first) |
 | **Agent name** | Stable handle for send/wait/read (`reviewer`, `tests`, …) |
 
-Default layout after spawning two sub-agents:
+Default layout after spawning three sub-agents (balanced grid including root; **vertical panel first**):
 
 ```
 Tab (root's tab)
-├── pane root     ← root / orchestrator agent (you)
-├── pane right    ← sub-agent reviewer
-└── pane down     ← sub-agent tests
+┌───────────────────────────┐
+│ root (you)                │
+├─────────────┬─────────────┤
+│ reviewer    │ tests       │
+├─────────────┴─────────────┤
+│ docs                      │
+└───────────────────────────┘
 ```
+(Exact tiles depend on aspect ratios; first split prefers `down`.)
 
 You orchestrate with the `herdr` CLI. Prefer agent-status waits over scrollback polling. Relay each agent's answer, not its whole screen.
 
@@ -64,7 +69,7 @@ Six phases, in order: ensure server + resolve root, split sub-agents from root, 
 
 1. **Confirm before destructive actions.** Closing panes/tabs/workspaces or `herdr server stop` can lose agent work — never without explicit user go-ahead. Reading panes is always safe. **Never close the root pane** unless the user explicitly asks to kill the orchestrator.
 2. **Parse IDs from JSON.** Workspace/tab/pane IDs are opaque (`w26`, `w26:t2`, `w26:p4`). Never invent them from sidebar order.
-3. **Split from the root agent — one tab.** Default spawn **splits the root agent's pane** so the human sees **root + all sub-agents in a single tab**. Do **not** create a separate fleet tab and do **not** put the first sub-agent on a new tab's root pane. New tabs only when the user explicitly asks for isolation.
+3. **Grid layout in the root tab.** Default spawn builds a **tiled grid that includes the root agent**. Split the **largest current pane** (not always the same pane), alternating `right`/`down` by geometry so root and workers stay balanced. Do **not** create a separate fleet tab and do **not** put the first sub-agent on a new tab's root pane. New tabs only when the user explicitly asks for isolation.
 4. **Prefer `--no-focus` while spawning** so focus stays on the root agent. Use `herdr agent focus <name>` when the user wants to type into a sub-agent.
 5. **Wait on agent status, don't race.** After send, wait for `working` then `idle`/`done` (Phase 4). Don't send a follow-up while status is `working`.
 6. **`pane run` submits text + Enter.** Prefer it over separate `send-text`/`send-keys` for prompts. `agent send` is literal text only (no Enter) — use when you must type without submitting.
@@ -102,15 +107,19 @@ Optional: `herdr integration install pi|claude|codex|opencode|hermes` for better
 
 **Done when:** you have concrete `root_pane`, `root_tab`, `ws`, and the server is running. Root agent stays alive in `root_pane`.
 
-## Phase 2: Spawn Sub-Agents by Splitting the Root Pane
+## Phase 2: Spawn Sub-Agents into a Grid (Root Included)
 
-Every sub-agent is a **split of the root pane** (same tab). The root agent is **not** moved, renamed into a worker, or replaced.
+Every sub-agent joins the **same tab as the root agent** as part of a **tiled grid**. The root agent is **not** moved, renamed into a worker, or replaced.
 
-### 2a — Split root → launch sub-agent
+### 2a — Split the largest pane → launch sub-agent
+
+Do **not** always split `$root_pane`. Always pick the current largest cell so root and workers stay roughly equal size:
 
 ```bash
 project_dir=/path/to/project   # usually root pane cwd
 root_pane="$HERDR_PANE_ID"     # from Phase 1
+here="$(cd "$(dirname "$0")" 2>/dev/null; pwd)"  # skill scripts/ when known
+# or: here=skills/herdr-agent-comms/scripts
 name=reviewer
 agent_cmd='pi --thinking medium'
 # optional skills for pi:  --skill /path/to/SKILL.md
@@ -118,41 +127,49 @@ agent_cmd='pi --thinking medium'
 # free name if taken
 herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
 
-# Split the ROOT pane (not an anonymous new tab). Always --no-focus.
-dir=right   # first sub-agent: right; later: alternate down / right
-split_json="$(herdr pane split "$root_pane" --direction "$dir" --cwd "$project_dir" --no-focus)"
+# Choose largest pane + direction from live geometry (includes root).
+read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
+split_json="$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)"
 # JSON shape: result.pane.pane_id (verify once with your herdr version if needed)
 sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r.get("root_pane") or r)["pane_id"])')"
 
-herdr pane rename "$sub_pane" "$name"
-herdr agent rename "$sub_pane" "$name"
-herdr pane run "$sub_pane" "$agent_cmd"
+herdr pane rename "$sub_pane" "$name" >/dev/null
+herdr agent rename "$sub_pane" "$name" >/dev/null
+herdr pane run "$sub_pane" "$agent_cmd" >/dev/null
 ```
 
-**Second / third sub-agent** — keep splitting from the **root pane** (or the last sub-pane if root is already too narrow); stay on `root_tab`:
+**Second / third sub-agent** — re-run the chooser each time (geometry changes after every split):
 
 ```bash
 name=tests
 herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-split_json="$(herdr pane split "$root_pane" --direction down --cwd "$project_dir" --no-focus)"
+read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
+split_json="$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)"
 sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
-herdr pane rename "$sub_pane" "$name"
-herdr agent rename "$sub_pane" "$name"
-herdr pane run "$sub_pane" 'pi --thinking low'
+herdr pane rename "$sub_pane" "$name" >/dev/null
+herdr agent rename "$sub_pane" "$name" >/dev/null
+herdr pane run "$sub_pane" 'pi --thinking low' >/dev/null
 ```
 
-**Alternative** (same tab, less precise about which pane is split): `herdr agent start` into the root tab:
+**Manual fallback** when the helper is unavailable: inspect `herdr pane layout --pane "$root_pane"`, split the largest pane by `rect.width * rect.height`, use **`down` if height ≥ width else `right`**. Stay on `root_tab`.
+
+**Alternative** (same tab, less balanced): `herdr agent start` into the root tab:
 
 ```bash
 herdr agent start "$name" --cwd "$project_dir" --workspace "$ws" --tab "$root_tab" \
   --split right --no-focus -- pi --thinking medium
 ```
 
-Prefer **`pane split "$root_pane"`** so the split is anchored on the root agent, not whichever pane last held focus.
+Prefer **`next_grid_split.py` + `pane split`** so the grid includes root and stays balanced. Avoid always splitting the same pane (creates long slivers).
 
-**Split direction rule:** prefer `right` when the source pane is wider than tall; prefer `down` when tall/narrow. If unknown, **alternate** `right`, `down`, `right`, …. Avoid repeating one direction until panes are unusable slivers. Optional geometry: `herdr pane layout --pane "$root_pane"`.
+**Grid rules:**
+1. One tab only: root + every sub-agent.
+2. Before each split, choose the **largest** pane in that tab (tie-break: root).
+3. Direction from that pane's aspect: **`down` when taller or square** (vertical panel first), `right` only when clearly wider.
+4. Always `--no-focus` so the root keeps the keyboard.
+5. Optional check: `herdr pane layout --pane "$root_pane"` should show multiple similar-sized rects, not one huge pane and thin strips.
 
-**Forbidden by default:** `herdr tab create` per sub-agent; hijacking the root pane with the first worker's CLI; `herdr workspace create` just to host workers when a root pane already exists in the project workspace.
+**Forbidden by default:** `herdr tab create` per sub-agent; hijacking the root pane with the first worker's CLI; `herdr workspace create` just to host workers when a root pane already exists; stacking every split from only `$root_pane` after the first cell is already small.
 
 **Optional (user asks for isolation):** tab-per-agent — see `references/herdr-recipes.md`. Not the default.
 
@@ -177,8 +194,8 @@ herdr wait agent-status "$sub_pane" --status idle --timeout 60000
 # if timeout: herdr pane get / herdr agent explain "$sub_pane"
 # if blocked: surface to user (Rule 7)
 
-herdr pane run "$sub_pane" "Review the open PR diff and report only actionable findings."
-herdr wait agent-status "$sub_pane" --status working --timeout 30000 || true
+# Assign through Phase 4 so a pre-send baseline is captured before pane run.
+# Then collect through Phase 5 with that baseline.
 ```
 
 **Fleet spawn:** split every sub-agent first (`--no-focus`), launch every CLI, then wait/read concurrently — don't fully serialize spawn→wait→read per agent when the user wants parallel work. `scripts/broadcast.sh` fans messages after spawn.
@@ -187,7 +204,7 @@ herdr wait agent-status "$sub_pane" --status working --timeout 30000 || true
 
 Detach the Herdr client with `prefix+q` (`ctrl+b` then `q`); agents keep running.
 
-**Done when:** each sub-agent has `sub_pane` + agent `name`, **same `root_tab` as the root pane**, root pane still holds the orchestrator, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
+**Done when:** each sub-agent has `sub_pane` + agent `name`, **same `root_tab` as the root pane**, layout is a **grid that includes the root pane** (not stacked slivers), root pane still holds the orchestrator, status is not stuck on `unknown` after boot wait, and initial tasks (if any) have been submitted.
 
 ## Phase 3: Resolve the Exact Target
 
@@ -204,13 +221,23 @@ If the name is missing, list agents and surface the closest match — don't sile
 
 ## Phase 4: Send a Message
 
+Capture the transcript **before sending**. This lets Phase 5 recognize a fast reply even if the agent finishes before the waiter starts:
+
 ```bash
-# preferred — text + Enter
-herdr pane run "$pane_id" "summarize the changes in src/"
+baseline_file="$(mktemp)"
+herdr pane read "$pane_id" --source recent-unwrapped --lines 80 >"$baseline_file"
+marker_suffix="$(date +%s)_$$_$RANDOM"
+completion_marker="HERDR_DONE_$marker_suffix"
+
+# Keep the full marker out of the prompt so prompt echo cannot satisfy the wait.
+task="summarize the changes in src/
+
+After fully finishing, concatenate and print these two parts without spaces: HERDR_DONE_ and $marker_suffix"
+herdr pane run "$pane_id" "$task"
 
 # by name (literal text only — add Enter yourself if needed)
-herdr agent send reviewer "summarize the changes in src/"
-herdr pane send-keys "$pane_id" enter
+# herdr agent send reviewer "summarize the changes in src/"
+# herdr pane send-keys "$pane_id" enter
 ```
 
 **Escaping:** pass the message as a single argv to `herdr` (quoted for the shell). For multi-line or code-heavy payloads, write a temp file and send a short instruction that reads it — see `references/herdr-recipes.md`.
@@ -218,18 +245,33 @@ herdr pane send-keys "$pane_id" enter
 **Verify delivery:** after send, status should leave `idle` for `working` (or stay `blocked` if a dialog ate the input):
 
 ```bash
-herdr wait agent-status "$pane_id" --status working --timeout 15000 \
-  && echo delivered || echo NOT-DELIVERED
+if herdr wait agent-status "$pane_id" --status working --timeout 15000; then
+  echo delivered
+elif ! cmp -s "$baseline_file" <(herdr pane read "$pane_id" --source recent-unwrapped --lines 80); then
+  echo delivered-transcript-activity
+else
+  echo NOT-DELIVERED
+fi
 ```
 
-`NOT-DELIVERED` → lone Enter via `herdr pane send-keys "$pane_id" enter`, re-check; if still idle with no new output, re-send. Inspect with `herdr pane read "$pane_id" --source recent-unwrapped --lines 40`.
+`NOT-DELIVERED` → lone Enter via `herdr pane send-keys "$pane_id" enter`, re-check; if still idle with no new output, re-send. A transcript change proves delivery activity, but may be only the echoed prompt; do **not** submit an extra Enter. The split completion marker lets Phase 5 distinguish echo from a finished reply.
 
 ## Phase 5: Wait for the Reply, Then Read It
 
-Use Herdr status waits (not fixed `sleep`). Completion may be **`done`** (unseen, usually background) **or `idle`** (seen / focused tab) — wait for either:
+Use Herdr status waits (not fixed `sleep`). Completion may be **`done`** (unseen, usually background) **or `idle`** (seen / focused tab) — wait for either. Prefer the helper with the Phase 4 pre-send baseline; without it, a fast agent can finish before the waiter snapshots the pane and leave the root waiting until timeout:
 
 ```bash
-# After delivery verified (Phase 4). Poll until idle|done|blocked or budget spent.
+python3 scripts/wait_for_idle.py "$pane_id" --timeout 180 --lines 80 \
+  --baseline-file "$baseline_file" --completion-marker "$completion_marker"
+rc=$?
+rm -f "$baseline_file"
+# rc: 0 settled, 2 timeout, 3 blocked
+```
+
+Manual fallback after delivery is verified:
+
+```bash
+# Poll until idle|done|blocked or budget spent.
 deadline=$((SECONDS + 180))
 while (( SECONDS < deadline )); do
   st=$(herdr pane get "$pane_id" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
@@ -315,26 +357,37 @@ root_tab="$HERDR_TAB_ID"
 ws="$HERDR_WORKSPACE_ID"
 project_dir="$(pwd)"
 
+here="skills/herdr-agent-comms/scripts"  # adjust if installed elsewhere
 spawn_sub() {
-  local name="$1" dir="$2" cmd="$3" task="$4"
-  local split_json pane
+  local name="$1" cmd="$2"
+  local split_from dir split_json pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  split_json="$(herdr pane split "$root_pane" --direction "$dir" --cwd "$project_dir" --no-focus)"
+  read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
+  split_json="$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)"
   pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
-  herdr pane rename "$pane" "$name"
-  herdr agent rename "$pane" "$name"
-  herdr pane run "$pane" "$cmd"
-  herdr wait agent-status "$pane" --status idle --timeout 60000
-  herdr pane run "$pane" "$task"
+  herdr pane rename "$pane" "$name" >/dev/null
+  herdr agent rename "$pane" "$name" >/dev/null
+  herdr pane run "$pane" "$cmd" >/dev/null
+  herdr wait agent-status "$pane" --status idle --timeout 60000 >/dev/null
   printf '%s\n' "$pane"
 }
 
-p1="$(spawn_sub reviewer right 'pi --thinking medium' 'Review recent commits for risk; bullet findings only.')"
-p2="$(spawn_sub tests down 'pi --thinking low' 'Outline a minimal test plan for the last change.')"
+p1="$(spawn_sub reviewer 'pi --thinking medium')"
+p2="$(spawn_sub tests 'pi --thinking low')"
+
+# Capture before send so even instant replies are observable.
+b1="$(mktemp)"; b2="$(mktemp)"
+herdr pane read "$p1" --source recent-unwrapped --lines 80 >"$b1"
+herdr pane read "$p2" --source recent-unwrapped --lines 80 >"$b2"
+s1="$(date +%s)_$$_1_$RANDOM"; s2="$(date +%s)_$$_2_$RANDOM"
+herdr pane run "$p1" "Review recent commits for risk; bullet findings only. When finished, concatenate and print: HERDR_DONE_ and $s1"
+herdr pane run "$p2" "Outline a minimal test plan. When finished, concatenate and print: HERDR_DONE_ and $s2"
 
 # Same tab: root_pane + p1 + p2
-python3 scripts/wait_for_idle.py "$p1" --timeout 180
-herdr pane read "$p1" --source recent-unwrapped --lines 80
+python3 scripts/wait_for_idle.py "$p1" --timeout 180 --lines 80 --baseline-file "$b1" --completion-marker "HERDR_DONE_$s1"
+python3 scripts/wait_for_idle.py "$p2" --timeout 180 --lines 80 --baseline-file "$b2" --completion-marker "HERDR_DONE_$s2"
+rm -f "$b1" "$b2"
+# optional: use scripts/broadcast.sh to baseline/send/wait concurrently
 # optional: herdr agent focus reviewer
 ```
 
@@ -347,14 +400,16 @@ herdr pane read "$p1" --source recent-unwrapped --lines 80
 - **Name collision** — `agent rename` / `agent start` names must be unique; suffix with epoch if taken.
 - **Wrong workspace** — never spawn project B agents into project A's workspace; re-resolve Phase 1.
 - **Status `unknown`** — install integration or use `scripts/wait_for_idle.py` + `pane read`.
-- **Too many splits** — more than ~4 panes in one tab gets cramped; still split from root unless the user asks for tab-per-agent.
+- **Too many splits** — more than ~4 panes in one tab gets cramped; keep the grid helper, or switch to tab-per-agent only if the user asks.
+- **Sliver layout** — you kept splitting one pane; re-run `scripts/next_grid_split.py` and split the largest cell instead.
 - **User wants to steer** — `herdr agent focus <name>` for a sub-agent; keep CLI follow-ups only when not fighting their keyboard.
 - **Closing the wrong pane** — only close **sub-agent** panes this skill created; never close root unless asked.
-- **Accidental new fleet tab** — if you created a tab by mistake, move work into root's tab via splits from `root_pane` and close the empty tab only with confirmation.
+- **Accidental new fleet tab** — if you created a tab by mistake, move work into root's tab via grid splits and close the empty tab only with confirmation.
 
 ## Reference
 
-- `references/herdr-recipes.md` — fleet layouts, multi-line sends, focus/steer, scrollback, troubleshooting.
+- `references/herdr-recipes.md` — grid layouts, multi-line sends, focus/steer, scrollback, troubleshooting.
+- `scripts/next_grid_split.py` — choose next largest pane + split direction for a balanced grid.
 - `references/delivery-and-waiting.md` — delivery checks, idle/done/blocked, budgets.
 - Official concepts: https://herdr.dev/docs/concepts/ · CLI: https://herdr.dev/docs/cli-reference/ · cheatsheet: https://luongnv.com/awesome-cheatsheets/cheatsheets/herdr/
 
@@ -378,4 +433,4 @@ After a messaging or lifecycle operation, emit:
   Result:              PASS
 ```
 
-Adapt rows to the operation — a spawn reports `Root kept · N sub-panes split`; a teardown reports `Confirmed` and `Sub-panes closed (root kept)`. Use `⚠` for dropped delivery or escalated stall.
+Adapt rows to the operation — a spawn reports `Root kept · grid N panes · N-1 sub-panes split`; a teardown reports `Confirmed` and `Sub-panes closed (root kept)`. Use `⚠` for dropped delivery or escalated stall.

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.19.0
+  version: 1.20.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -271,10 +271,9 @@ After fully finishing, concatenate and print these two parts without spaces: HER
 python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
   || { echo "Error: $pane_id is not safe to send to (preflight failed) — see stderr" >&2; rm -f "$baseline_file"; exit 1; }
 herdr pane run "$pane_id" "$task" || { echo "Error: send failed for $pane_id" >&2; rm -f "$baseline_file"; exit 1; }
-
-# by name (literal, no Enter): herdr agent send reviewer "…"; then
-# herdr pane send-keys "$pane_id" enter
 ```
+
+To send by agent name without auto-submit, first **resolve the name to its pane id** and drive that one id for every step — see `references/herdr-recipes.md` "Pattern C". Never preflight/Enter one pane id while delivering text to a bare agent name; a stale/mismatched id would mutate one pane and submit into another.
 
 **Escaping:** pass the message as a single argv to `herdr` (quoted for the shell). For multi-line or code-heavy payloads, write a temp file and send a short instruction that reads it — see `references/herdr-recipes.md`.
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.16.0
+  version: 1.17.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.10.0
+  version: 1.11.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -210,15 +210,14 @@ When using `herdr agent start … -- <argv>`, put only the launcher (+ model/thi
 
 ### 2c — Ready, then assign work
 
-```bash
-# boot → idle (or blocked on trust) — per SUB-agent pane
-herdr wait agent-status "$sub_pane" --status idle --timeout 60000
-# if timeout: herdr pane get / herdr agent explain "$sub_pane"
-# if blocked: surface to user (Rule 7)
-
-# Assign through Phase 4 so a pre-send baseline is captured before pane run.
-# Then collect through Phase 5 with that baseline.
-```
+Run a **concurrent readiness pass** after all spawns, and do **not** assign
+work unless every sub-agent is ready. Use `wait_for_idle.py --ready` per pane
+(returns 0 ready, 2 timeout, 3 **blocked**) — a bare `wait agent-status idle`
+would turn a trust/auth dialog into a generic 60s timeout instead of surfacing
+it. Launch all `--ready` waits in the background, then `wait "$pid"` on each and
+**abort if any is non-zero** (full loop in the Example below and in recipes
+"Concurrent readiness pass"). Only after the whole fleet is ready do you assign
+work through Phase 4 (baseline before `pane run`) and collect via Phase 5.
 
 **Fleet spawn:** split every sub-agent first (`--no-focus`), launch every CLI, then wait/read concurrently — don't fully serialize spawn→wait→read per agent when the user wants parallel work. `scripts/broadcast.sh` fans messages after spawn.
 
@@ -316,10 +315,15 @@ rm -f "$baseline_file"
 Manual fallback after delivery is verified:
 
 ```bash
-# Poll until idle|done|blocked or budget spent.
+# Poll until idle|done|blocked or budget spent. FAIL-CLOSED status read: a
+# failed/malformed `herdr pane get` exits with an error instead of falling
+# through to `sleep` as if the pane were merely `unknown`.
 deadline=$((SECONDS + 180))
 while (( SECONDS < deadline )); do
-  st=$(herdr pane get "$pane_id" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
+  out=$(herdr pane get "$pane_id" 2>/dev/null) || { echo "Error: status lookup failed for $pane_id" >&2; exit 1; }
+  st=$(printf '%s' "$out" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin)["result"]["pane"].get("agent_status") or "unknown")
+except Exception: sys.exit(1)') || { echo "Error: could not parse status for $pane_id" >&2; exit 1; }
   case "$st" in
     done|idle) echo "settled:$st"; break ;;
     blocked) echo "blocked"; break ;;
@@ -420,27 +424,34 @@ done
 # references/herdr-recipes.md ("Spawn N sub-agents into an equal-width grid")
 # HERE before the calls below — this example calls it but does not redefine
 # it. That function guards planning, split, pane-id parse, equalize, rename,
-# launch, and readiness, prints the pane id ONLY after a confirmed launch, and
-# returns non-zero on any failure.
+# and launch, and prints the pane id ONLY after a confirmed launch. It does
+# NOT wait on readiness — that is the SEPARATE concurrent pass below (a single
+# idle-wait would hide a `blocked` boot behind a 60s timeout).
 
 # Every caller MUST abort on non-zero — `$(...)` hides spawn_sub's exit status:
 p1="$(spawn_sub reviewer 'pi --thinking medium')" || { echo "reviewer failed to place; aborting" >&2; exit 1; }
 p2="$(spawn_sub tests 'pi --thinking low')" || { echo "tests failed to place; aborting" >&2; exit 1; }
 
-# Capture before send so even instant replies are observable.
-b1="$(mktemp)"; b2="$(mktemp)"
-herdr pane read "$p1" --source recent-unwrapped --lines 80 >"$b1"
-herdr pane read "$p2" --source recent-unwrapped --lines 80 >"$b2"
-s1="$(date +%s)_$$_1_$RANDOM"; s2="$(date +%s)_$$_2_$RANDOM"
-herdr pane run "$p1" "Review recent commits for risk; bullet findings only. When finished, concatenate and print: HERDR_DONE_ and $s1"
-herdr pane run "$p2" "Outline a minimal test plan. When finished, concatenate and print: HERDR_DONE_ and $s2"
+# Readiness gate — do NOT assign work unless every sub-agent is ready
+# (`--ready` returns 3 on blocked, 2 on timeout). See recipes "Concurrent
+# readiness pass" for the full loop; abort the fleet if any pane isn't ready.
+ready_failed=0; rpids=()
+for p in "$p1" "$p2"; do
+  python3 "$here/wait_for_idle.py" "$p" --ready --timeout 60 --no-print &
+  rpids+=("$!:$p")
+done
+for e in "${rpids[@]}"; do jp="${e%%:*}"; pane="${e#*:}"
+  wait "$jp" || { ready_failed=1; echo "$pane: not ready (rc $?)" >&2; }
+done
+[ "$ready_failed" -eq 0 ] || { echo "Fleet not ready; not assigning work." >&2; exit 1; }
 
-# Same tab: root_pane + p1 + p2
-python3 "$here/wait_for_idle.py" "$p1" --timeout 180 --lines 80 --baseline-file "$b1" --completion-marker "HERDR_DONE_$s1"
-python3 "$here/wait_for_idle.py" "$p2" --timeout 180 --lines 80 --baseline-file "$b2" --completion-marker "HERDR_DONE_$s2"
-rm -f "$b1" "$b2"
-# optional: use "$here/broadcast.sh" to baseline/send/wait concurrently
-# optional: herdr agent focus reviewer
+# Assign + collect: prefer the script — it baselines, sends, waits concurrently,
+# and aggregates every send/waiter status into its exit code (see findings this
+# skill has hardened). Check its exit; do not treat a partial fleet as success.
+"$here/broadcast.sh" "Review recent commits for risk; bullet findings only." reviewer \
+  || { echo "broadcast reported failures (blocked/timeout/unverifiable) — see above" >&2; exit 1; }
+# For the manual (non-script) baseline→send→wait pattern with per-waiter status
+# aggregation, see references/delivery-and-waiting.md "Concurrent fleet waits".
 ```
 
 ## Edge Cases

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.8.0
+  version: 1.9.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -143,23 +143,26 @@ herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
 
 # Plan line: "split <rightmost> right --ratio <1/N>". ratio=1/N so the new
 # right pane lands on the 1/N equal target (see "Equal-width columns" below).
-plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
+# Guard EVERY step — a failure anywhere must abort, not launch into a broken
+# or half-built layout. (The planner also rejects 2D/stacked layouts.)
+plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")" || { echo "Error: split planning failed (bad/unsupported layout?)." >&2; exit 1; }
 read -r _ split_from _dir _ratio_flag ratio < <(head -1 <<<"$plan")
-split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
-sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r.get("root_pane") or r)["pane_id"])')"
+[ -n "$split_from" ] && [ -n "$ratio" ] || { echo "Error: empty split plan; refusing to split." >&2; exit 1; }
+split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)" || { echo "Error: 'herdr pane split' failed." >&2; exit 1; }
+sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r.get("root_pane") or r)["pane_id"])')" || { echo "Error: could not parse new pane id." >&2; exit 1; }
+[ -n "$sub_pane" ] || { echo "Error: empty new pane id." >&2; exit 1; }
 
-# Equalize every column to the same width (a split alone leaves pre-existing
-# columns wider than 1/N). HARD GATE: on failure (resize error or
-# non-convergence) do NOT launch into a broken layout — abort and name the
-# orphan split pane. Never swallow this with `|| true`.
+# Equalize every column (a split alone leaves pre-existing columns wider than
+# 1/N). HARD GATE: on failure (resize error or non-convergence) do NOT launch
+# into a broken layout — abort and name the orphan. Never swallow with `|| true`.
 if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane"; then
-  echo "Error: column equalization failed; NOT launching '$name'. Orphan split pane: $sub_pane. Inspect with 'herdr pane layout --pane $root_pane', then 'herdr pane close $sub_pane' to undo, or retry." >&2
+  echo "Error: equalization failed; NOT launching '$name'. Orphan split pane: $sub_pane ('herdr pane close $sub_pane' to undo)." >&2
   exit 1
 fi
 
-herdr pane rename "$sub_pane" "$name" >/dev/null
-herdr agent rename "$sub_pane" "$name" >/dev/null
-herdr pane run "$sub_pane" "$agent_cmd" >/dev/null
+herdr pane rename "$sub_pane" "$name" >/dev/null || { echo "Error: rename failed; orphan $sub_pane." >&2; exit 1; }
+herdr agent rename "$sub_pane" "$name" >/dev/null || { echo "Error: agent rename failed; orphan $sub_pane." >&2; exit 1; }
+herdr pane run "$sub_pane" "$agent_cmd" >/dev/null || { echo "Error: launch failed; orphan $sub_pane." >&2; exit 1; }
 ```
 
 **Second / third sub-agent** — identical: re-run the planner, split, then `--equalize` (the target share shrinks as columns are added, and the equalizer always converges to equal-within-1-cell). Just change `name` and `agent_cmd`.
@@ -404,37 +407,17 @@ for cand in \
   if [ -f "$cand/next_grid_split.py" ]; then here="$cand"; break; fi
 done
 [ -n "$here" ] || { echo "Error: next_grid_split.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
-spawn_sub() {
-  local name="$1" cmd="$2"
-  local plan split_from ratio split_json pane
-  herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  # Plan line: "split <rightmost> right --ratio <1/N>" (new right pane lands on the 1/N target).
-  plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
-  read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
-  split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
-  pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
-  # Equalize all columns — a split alone leaves the pre-existing columns wide.
-  # HARD GATE: on failure, return non-zero WITHOUT launching or printing a
-  # pane id, so the caller aborts instead of spawning into a broken layout.
-  # (No `|| true` — that silently swallowed the failure.)
-  if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >&2; then
-    echo "Error: equalize failed for '$name'; orphan split pane $pane not launched. Inspect 'herdr pane layout --pane $root_pane' or 'herdr pane close $pane'." >&2
-    return 1
-  fi
-  herdr pane rename "$pane" "$name" >/dev/null
-  herdr agent rename "$pane" "$name" >/dev/null
-  herdr pane run "$pane" "$cmd" >/dev/null
-  herdr wait agent-status "$pane" --status idle --timeout 60000 >/dev/null
-  printf '%s\n' "$pane"
-}
 
-# Caller MUST check the exit status — `$(...)` swallows it otherwise:
-#   if ! p_reviewer="$(spawn_sub reviewer 'pi --thinking medium')"; then
-#     echo "aborting fleet spawn: reviewer failed to place" >&2; exit 1
-#   fi
+# PASTE the canonical, fully-guarded `spawn_sub` function definition from
+# references/herdr-recipes.md ("Spawn N sub-agents into an equal-width grid")
+# HERE before the calls below — this example calls it but does not redefine
+# it. That function guards planning, split, pane-id parse, equalize, rename,
+# launch, and readiness, prints the pane id ONLY after a confirmed launch, and
+# returns non-zero on any failure.
 
-p1="$(spawn_sub reviewer 'pi --thinking medium')"
-p2="$(spawn_sub tests 'pi --thinking low')"
+# Every caller MUST abort on non-zero — `$(...)` hides spawn_sub's exit status:
+p1="$(spawn_sub reviewer 'pi --thinking medium')" || { echo "reviewer failed to place; aborting" >&2; exit 1; }
+p2="$(spawn_sub tests 'pi --thinking low')" || { echo "tests failed to place; aborting" >&2; exit 1; }
 
 # Capture before send so even instant replies are observable.
 b1="$(mktemp)"; b2="$(mktemp)"

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -152,10 +152,13 @@ split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" 
 sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r.get("root_pane") or r)["pane_id"])')"
 
 # Resize every pre-existing column (from the plan's remaining lines) to the
-# same share so the new pane doesn't leave the others too wide.
-tail -n +2 <<<"$plan" | while read -r _ pane_id share; do
-  [ "$pane_id" = "$sub_pane" ] && continue   # the new pane is already at `share` from --ratio
-  herdr pane resize --pane "$pane_id" --direction right --amount "$share" >/dev/null || true
+# same share, AND the new pane too — don't rely on --ratio alone to have put
+# the new pane at the right width; a plain resize --amount pass on every
+# column (this one included) converges regardless of what --ratio meant.
+share="$(tail -n +2 <<<"$plan" | head -1 | awk '{print $3}')"
+herdr pane resize --pane "$sub_pane" --direction right --amount "$share" >/dev/null || true
+tail -n +2 <<<"$plan" | while read -r _ pane_id pshare; do
+  herdr pane resize --pane "$pane_id" --direction right --amount "$pshare" >/dev/null || true
 done
 
 herdr pane rename "$sub_pane" "$name" >/dev/null
@@ -172,9 +175,9 @@ plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
 read -r _ split_from _dir _ratio_flag ratio < <(head -1 <<<"$plan")
 split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
 sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
-tail -n +2 <<<"$plan" | while read -r _ pane_id share; do
-  [ "$pane_id" = "$sub_pane" ] && continue
-  herdr pane resize --pane "$pane_id" --direction right --amount "$share" >/dev/null || true
+herdr pane resize --pane "$sub_pane" --direction right --amount "$ratio" >/dev/null || true
+tail -n +2 <<<"$plan" | while read -r _ pane_id pshare; do
+  herdr pane resize --pane "$pane_id" --direction right --amount "$pshare" >/dev/null || true
 done
 herdr pane rename "$sub_pane" "$name" >/dev/null
 herdr agent rename "$sub_pane" "$name" >/dev/null
@@ -427,9 +430,11 @@ spawn_sub() {
   read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
   split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
   pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
-  tail -n +2 <<<"$plan" | while read -r _ pid share; do
-    [ "$pid" = "$pane" ] && continue
-    herdr pane resize --pane "$pid" --direction right --amount "$share" >/dev/null || true
+  # Resize every column, including the new one — don't rely on --ratio alone
+  # to have sized the new pane correctly.
+  herdr pane resize --pane "$pane" --direction right --amount "$ratio" >/dev/null || true
+  tail -n +2 <<<"$plan" | while read -r _ pid pshare; do
+    herdr pane resize --pane "$pid" --direction right --amount "$pshare" >/dev/null || true
   done
   herdr pane rename "$pane" "$name" >/dev/null
   herdr agent rename "$pane" "$name" >/dev/null

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -441,14 +441,14 @@ for p in "$p1" "$p2"; do
   rpids+=("$!:$p")
 done
 for e in "${rpids[@]}"; do jp="${e%%:*}"; pane="${e#*:}"
-  wait "$jp" || { ready_failed=1; echo "$pane: not ready (rc $?)" >&2; }
+  wait "$jp" || { rc=$?; ready_failed=1; echo "$pane: not ready (rc $rc)" >&2; }
 done
 [ "$ready_failed" -eq 0 ] || { echo "Fleet not ready; not assigning work." >&2; exit 1; }
 
 # Assign + collect: prefer the script — it baselines, sends, waits concurrently,
-# and aggregates every send/waiter status into its exit code (see findings this
-# skill has hardened). Check its exit; do not treat a partial fleet as success.
-"$here/broadcast.sh" "Review recent commits for risk; bullet findings only." reviewer \
+# and aggregates every send/waiter status into its exit code. Check its exit;
+# broadcast BOTH placed agents so neither is spawned then left idle.
+"$here/broadcast.sh" "Review recent commits for risk; bullet findings only." reviewer tests \
   || { echo "broadcast reported failures (blocked/timeout/unverifiable) — see above" >&2; exit 1; }
 # For the manual (non-script) baseline→send→wait pattern with per-waiter status
 # aggregation, see references/delivery-and-waiting.md "Concurrent fleet waits".

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.4.0
+  version: 1.5.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -122,16 +122,19 @@ root_pane="$HERDR_PANE_ID"     # from Phase 1
 
 # Resolve scripts/ robustly: $0 is unreliable when an agent runs this inline
 # (it points at the shell, not the skill), so probe known install locations
-# instead of deriving from $0.
+# instead of deriving from $0. Repo-local copies win over global installs so
+# a repo checked out at a pinned commit isn't silently overridden by
+# whatever version happens to be installed globally.
 here=""
 for cand in \
-  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "skills/herdr-agent-comms/scripts" \
+  ".agents/skills/herdr-agent-comms/scripts" \
   ".claude/skills/herdr-agent-comms/scripts" \
-  "$HOME/.agents/skills/herdr-agent-comms/scripts" \
-  "skills/herdr-agent-comms/scripts"; do
+  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
   if [ -f "$cand/next_grid_split.py" ]; then here="$cand"; break; fi
 done
-[ -n "$here" ] || { echo "next_grid_split.py not found — set \$here manually" >&2; }
+[ -n "$here" ] || { echo "Error: next_grid_split.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 name=reviewer
 agent_cmd='pi --thinking medium'
 # optional skills for pi:  --skill /path/to/SKILL.md
@@ -276,15 +279,18 @@ Use Herdr status waits (not fixed `sleep`). Completion may be **`done`** (unseen
 # $here is the scripts/ dir. If Phase 2 already resolved it, reuse it;
 # jumping straight here (e.g. "message an agent that's already running")
 # skips Phase 2, so probe install locations again rather than assume it's set.
+# Repo-local copies win over global installs (see Phase 2a).
 if [ -z "${here:-}" ]; then
   for cand in \
-    "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+    "skills/herdr-agent-comms/scripts" \
+    ".agents/skills/herdr-agent-comms/scripts" \
     ".claude/skills/herdr-agent-comms/scripts" \
-    "$HOME/.agents/skills/herdr-agent-comms/scripts" \
-    "skills/herdr-agent-comms/scripts"; do
+    "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+    "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
     if [ -f "$cand/wait_for_idle.py" ]; then here="$cand"; break; fi
   done
 fi
+[ -n "${here:-}" ] || { echo "Error: wait_for_idle.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 python3 "$here/wait_for_idle.py" "$pane_id" --timeout 180 --lines 80 \
   --baseline-file "$baseline_file" --completion-marker "$completion_marker"
 rc=$?
@@ -383,14 +389,17 @@ project_dir="$(pwd)"
 
 # Resolve scripts/ by probing known install locations (not $0 — unreliable
 # when this snippet runs inline rather than as a saved script file).
+# Repo-local copies win over global installs (see Phase 2a).
 here=""
 for cand in \
-  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "skills/herdr-agent-comms/scripts" \
+  ".agents/skills/herdr-agent-comms/scripts" \
   ".claude/skills/herdr-agent-comms/scripts" \
-  "$HOME/.agents/skills/herdr-agent-comms/scripts" \
-  "skills/herdr-agent-comms/scripts"; do
+  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
   if [ -f "$cand/next_grid_split.py" ]; then here="$cand"; break; fi
 done
+[ -n "$here" ] || { echo "Error: next_grid_split.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 spawn_sub() {
   local name="$1" cmd="$2"
   local split_from dir split_json pane

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.17.0
+  version: 1.18.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -4,7 +4,7 @@ description: "Manage AI agent fleets in Herdr: split root + sub-agents into one 
 license: MIT
 effort: medium
 metadata:
-  version: 1.7.0
+  version: 1.8.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 ---
@@ -32,9 +32,10 @@ Tab (root's tab)
 ```
 (All columns — root and every sub-agent — end up the same width, ±1 terminal
 cell. Adding a column means splitting the current rightmost pane `right`
-(`--ratio (N-1)/N`), then running an iterative equalizer that re-converges
-every column to `1/N`. `next_grid_split.py` does both (`--equalize`); see
-Phase 2a and "Equal-width columns" below for the verified `herdr` semantics.)
+(`--ratio 1/N`, so the new right pane lands on the `1/N` equal target), then
+running an iterative equalizer that re-converges every column to `1/N`.
+`next_grid_split.py` does both (`--equalize`); see Phase 2a and "Equal-width
+columns" below for the verified `herdr` semantics.)
 
 You orchestrate with the `herdr` CLI. Prefer agent-status waits over scrollback polling. Relay each agent's answer, not its whole screen.
 
@@ -140,18 +141,21 @@ agent_cmd='pi --thinking medium'
 # free name if taken
 herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
 
-# Plan line: "split <rightmost_pane> right --ratio <existing_child_ratio>".
-# The ratio = (N-1)/N so the NEW pane is born at the 1/N target share.
+# Plan line: "split <rightmost> right --ratio <1/N>". ratio=1/N so the new
+# right pane lands on the 1/N equal target (see "Equal-width columns" below).
 plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
 read -r _ split_from _dir _ratio_flag ratio < <(head -1 <<<"$plan")
 split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
 sub_pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r.get("root_pane") or r)["pane_id"])')"
 
-# Equalize every column (root + all sub-agents) to the same width. This runs
-# an iterative boundary sweep against the live layout — a split alone leaves
-# the pre-existing columns wider than the new 1/N share.
-python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" || \
-  echo "Warning: columns are best-effort (see herdr pane layout)." >&2
+# Equalize every column to the same width (a split alone leaves pre-existing
+# columns wider than 1/N). HARD GATE: on failure (resize error or
+# non-convergence) do NOT launch into a broken layout — abort and name the
+# orphan split pane. Never swallow this with `|| true`.
+if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane"; then
+  echo "Error: column equalization failed; NOT launching '$name'. Orphan split pane: $sub_pane. Inspect with 'herdr pane layout --pane $root_pane', then 'herdr pane close $sub_pane' to undo, or retry." >&2
+  exit 1
+fi
 
 herdr pane rename "$sub_pane" "$name" >/dev/null
 herdr agent rename "$sub_pane" "$name" >/dev/null
@@ -167,7 +171,9 @@ herdr pane run "$sub_pane" "$agent_cmd" >/dev/null
 ```bash
 herdr agent start "$name" --cwd "$project_dir" --workspace "$ws" --tab "$root_tab" \
   --split right --no-focus -- pi --thinking medium
-python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" || true
+# Same hard gate: abort if the grid can't be equalized rather than leaving it uneven.
+python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" || {
+  echo "Error: equalization failed after agent start; inspect 'herdr pane layout --pane $root_pane'." >&2; exit 1; }
 ```
 
 Prefer **`next_grid_split.py` split + `--equalize`** so the grid includes root and stays equal-width. This alternative skips the equalize step unless you add it.
@@ -180,7 +186,7 @@ Prefer **`next_grid_split.py` split + `--equalize`** so the grid includes root a
 5. Always `--no-focus` so the root keeps the keyboard.
 6. Optional check: `herdr pane layout --pane "$root_pane"` should show N rects of near-equal `rect.width` (equal within ~1 cell), not one wide pane and thin strips.
 
-**Equal-width columns — behavior:** herdr `pane split --ratio` sizes only the split pane, and `pane resize --amount` is a *delta* (cells as a fraction of tab width) whose freed space redistributes proportionally across neighbors — so a single split or a single resize pass cannot equalize 3+ columns. The equalizer sweeps internal boundaries left to right, growing the neighbor-bearing pane toward each target, and iterates until the spread is ≤1 cell. This was verified live against herdr 0.7.4 (2→105/105, 3→70/70/70, 4→53/53/52/52, 5→42×5). Because widths are whole terminal cells, exact equality only holds when the tab width divides evenly; otherwise columns differ by ≤1 cell. Full semantics and the derivation are in `references/herdr-recipes.md`.
+**Equal-width columns — behavior:** herdr `pane split --ratio R` sizes only the split pane (`R` = the existing/left child's fraction; the new right pane gets `1-R`). Splitting the rightmost column with `--ratio 1/N` makes the new pane `(N-1)/N` of that column = `1/N` of the whole tab (the equal target). `pane resize --amount` is a *delta* (cells as a fraction of tab width) whose freed space redistributes proportionally across neighbors — so a single split or a single resize pass cannot equalize 3+ columns. The equalizer sweeps internal boundaries left to right, growing the neighbor-bearing pane toward each target, and iterates until the spread is ≤1 cell. This was verified live against herdr 0.7.4 (2→105/105, 3→70/70/70, 4→53/53/52/52, 5→42×5). Because widths are whole terminal cells, exact equality only holds when the tab width divides evenly; otherwise columns differ by ≤1 cell. A resize failure or non-convergence is a **hard error** — `--equalize` exits non-zero and the spawn recipes abort (they do **not** launch a worker into an uneven layout). Full semantics and the derivation are in `references/herdr-recipes.md`.
 
 **Forbidden by default:** `herdr tab create` per sub-agent; hijacking the root pane with the first worker's CLI; `herdr workspace create` just to host workers when a root pane already exists; splitting a column other than the current rightmost one.
 
@@ -402,19 +408,30 @@ spawn_sub() {
   local name="$1" cmd="$2"
   local plan split_from ratio split_json pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  # Plan line: "split <rightmost> right --ratio <(N-1)/N>" (new pane born at 1/N).
+  # Plan line: "split <rightmost> right --ratio <1/N>" (new right pane lands on the 1/N target).
   plan="$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")"
   read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
   split_json="$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)"
   pane="$(printf '%s' "$split_json" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')"
   # Equalize all columns — a split alone leaves the pre-existing columns wide.
-  python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >/dev/null 2>&1 || true
+  # HARD GATE: on failure, return non-zero WITHOUT launching or printing a
+  # pane id, so the caller aborts instead of spawning into a broken layout.
+  # (No `|| true` — that silently swallowed the failure.)
+  if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >&2; then
+    echo "Error: equalize failed for '$name'; orphan split pane $pane not launched. Inspect 'herdr pane layout --pane $root_pane' or 'herdr pane close $pane'." >&2
+    return 1
+  fi
   herdr pane rename "$pane" "$name" >/dev/null
   herdr agent rename "$pane" "$name" >/dev/null
   herdr pane run "$pane" "$cmd" >/dev/null
   herdr wait agent-status "$pane" --status idle --timeout 60000 >/dev/null
   printf '%s\n' "$pane"
 }
+
+# Caller MUST check the exit status — `$(...)` swallows it otherwise:
+#   if ! p_reviewer="$(spawn_sub reviewer 'pi --thinking medium')"; then
+#     echo "aborting fleet spawn: reviewer failed to place" >&2; exit 1
+#   fi
 
 p1="$(spawn_sub reviewer 'pi --thinking medium')"
 p2="$(spawn_sub tests 'pi --thinking low')"
@@ -453,7 +470,7 @@ rm -f "$b1" "$b2"
 ## Reference
 
 - `references/herdr-recipes.md` — grid layouts, multi-line sends, focus/steer, scrollback, troubleshooting.
-- `scripts/next_grid_split.py` — plan the next split (`--ratio (N-1)/N`) and run the live iterative equalizer (`--equalize`) for an equal-width grid.
+- `scripts/next_grid_split.py` — plan the next split (`--ratio 1/N`) and run the live iterative equalizer (`--equalize`) for an equal-width grid.
 - `references/delivery-and-waiting.md` — delivery checks, idle/done/blocked, budgets.
 - Official concepts: https://herdr.dev/docs/concepts/ · CLI: https://herdr.dev/docs/cli-reference/ · cheatsheet: https://luongnv.com/awesome-cheatsheets/cheatsheets/herdr/
 

--- a/skills/herdr-agent-comms/docs/README.md
+++ b/skills/herdr-agent-comms/docs/README.md
@@ -7,11 +7,11 @@
 
 # Herdr Agent Comms
 
-> Split sub-agents from the **root agent pane** into **one tab** — root stays put, workers appear beside it, messaging via the `herdr` CLI with status-aware waits.
+> Tile **root + sub-agents** into **one grid tab** — root stays put, workers fill balanced cells, messaging via the `herdr` CLI with status-aware waits.
 
 ## Highlights
 
-- **Root + sub-agents, one tab** — every sub-agent is a split of `$HERDR_PANE_ID` (or the resolved root pane).
+- **Root + sub-agents grid** — largest-pane splits keep root and workers in a usable tiled layout.
 - **Root never replaced** — orchestrator pane stays; only close worker panes on teardown.
 - **Fleet spawn** — agent CLI + model + thinking + optional skills, then assign tasks in parallel.
 - **Message & steer** — `pane run` / `agent send`, wait on `working` → `done`/`idle`, read transcripts.
@@ -22,7 +22,7 @@
 
 | Say this... | Skill will... |
 |---|---|
-| "Spin up 2 Herdr agents beside me: reviewer and tests" | Split root pane right/down, launch agents in same tab |
+| "Spin up 2 Herdr agents beside me: reviewer and tests" | Build a grid in the root tab, launch agents in balanced cells |
 | "Ask the reviewer agent what it found" | Resolve target, send, wait on status, relay reply |
 | "Broadcast 'pull main' to all fleet agents" | Fan-out send + concurrent collect |
 | "Focus the tests pane so I can steer" | `herdr agent focus tests` |
@@ -31,7 +31,7 @@
 
 ```mermaid
 graph TD
-    A["Resolve root pane + tab + workspace"] --> B["pane split root --direction right/down"]
+    A["Resolve root pane + tab + workspace"] --> B["next_grid_split · pane split largest"]
     B --> C["Rename sub-pane · launch CLI · wait idle"]
     C --> D["Submit tasks · broadcast"]
     D --> E["Wait agent-status done|idle"]
@@ -46,14 +46,14 @@ graph TD
 /herdr-agent-comms
 ```
 
-Or describe the goal — "split a reviewer agent from my pane", "launch a Herdr fleet beside me".
+Or describe the goal — "tile a reviewer agent with my pane", "launch a Herdr fleet grid beside me".
 
 ## Popular Use Cases
 
-### 1. Sub-agents beside the root (default)
+### 1. Root + sub-agents grid (default)
 
 ```
-/herdr-agent-comms spin up 2 pi agents split from my pane:
+/herdr-agent-comms spin up 2 pi agents in a grid with my pane:
 - reviewer: thinking medium — review the last commit
 - tests: thinking low — propose a minimal test plan
 ```

--- a/skills/herdr-agent-comms/docs/README.md
+++ b/skills/herdr-agent-comms/docs/README.md
@@ -31,7 +31,7 @@
 
 ```mermaid
 graph TD
-    A["Resolve root pane + tab + workspace"] --> B["next_grid_split · split rightmost + resize all to equal width"]
+    A["Resolve root pane + tab + workspace"] --> B["next_grid_split · split rightmost + --equalize to equal width"]
     B --> C["Rename sub-pane · launch CLI · wait idle"]
     C --> D["Submit tasks · broadcast"]
     D --> E["Wait agent-status done|idle"]

--- a/skills/herdr-agent-comms/docs/README.md
+++ b/skills/herdr-agent-comms/docs/README.md
@@ -7,38 +7,37 @@
 
 # Herdr Agent Comms
 
-> Spawn, manage, and talk to AI agents as **split panes in one fleet view** — one project workspace, tiled agents you can see at once, messaging via the `herdr` CLI with status-aware waits.
+> Split sub-agents from the **root agent pane** into **one tab** — root stays put, workers appear beside it, messaging via the `herdr` CLI with status-aware waits.
 
 ## Highlights
 
-- **Project workspace** — all agents for a repo share one Herdr workspace (sidebar rollup).
-- **Split-pane fleet** — one fleet tab; each agent is a visible pane (side-by-side / tiled).
+- **Root + sub-agents, one tab** — every sub-agent is a split of `$HERDR_PANE_ID` (or the resolved root pane).
+- **Root never replaced** — orchestrator pane stays; only close worker panes on teardown.
 - **Fleet spawn** — agent CLI + model + thinking + optional skills, then assign tasks in parallel.
 - **Message & steer** — `pane run` / `agent send`, wait on `working` → `done`/`idle`, read transcripts.
 - **Broadcast** — fan one instruction to many agents; concurrent waits.
-- **Safe teardown** — close panes or the fleet tab only after confirmation; never surprise `server stop`.
+- **Safe teardown** — close sub-panes after confirmation; never surprise `server stop` or kill root.
 
 ## When to Use
 
 | Say this... | Skill will... |
 |---|---|
-| "Spin up 3 Herdr agents for this repo: reviewer, tests, docs" | Create/reuse project workspace, one fleet tab, split panes, launch agents |
+| "Spin up 2 Herdr agents beside me: reviewer and tests" | Split root pane right/down, launch agents in same tab |
 | "Ask the reviewer agent what it found" | Resolve target, send, wait on status, relay reply |
 | "Broadcast 'pull main' to all fleet agents" | Fan-out send + concurrent collect |
-| "Show me all agents / focus the tests pane so I can steer" | `herdr tab focus` fleet · `herdr agent focus tests` |
+| "Focus the tests pane so I can steer" | `herdr agent focus tests` |
 
 ## How It Works
 
 ```mermaid
 graph TD
-    A["Ensure herdr server + project workspace"] --> B["Create one fleet tab"]
-    B --> C["Root pane + split panes per agent"]
-    C --> D["Rename · wait idle · submit tasks"]
-    D --> E["Send / broadcast via pane run"]
-    E --> F["Wait agent-status done|idle"]
-    F --> G["Read recent-unwrapped · focus to steer"]
+    A["Resolve root pane + tab + workspace"] --> B["pane split root --direction right/down"]
+    B --> C["Rename sub-pane · launch CLI · wait idle"]
+    C --> D["Submit tasks · broadcast"]
+    D --> E["Wait agent-status done|idle"]
+    E --> F["Read recent-unwrapped · focus to steer"]
     style A fill:#4CAF50,color:#fff
-    style G fill:#2196F3,color:#fff
+    style F fill:#2196F3,color:#fff
 ```
 
 ## Usage
@@ -47,15 +46,15 @@ graph TD
 /herdr-agent-comms
 ```
 
-Or describe the goal in natural language — "launch a Herdr fleet side by side", "message my Herdr reviewer pane".
+Or describe the goal — "split a reviewer agent from my pane", "launch a Herdr fleet beside me".
 
 ## Popular Use Cases
 
-### 1. Fleet with model/thinking/skill knobs (all visible)
+### 1. Sub-agents beside the root (default)
 
 ```
-/herdr-agent-comms spin up 2 pi agents in this project as split panes:
-- reviewer: model sonnet, thinking medium, skill code-review — review the last commit
+/herdr-agent-comms spin up 2 pi agents split from my pane:
+- reviewer: thinking medium — review the last commit
 - tests: thinking low — propose a minimal test plan
 ```
 
@@ -74,6 +73,7 @@ Or describe the goal in natural language — "launch a Herdr fleet side by side"
 ## Requirements
 
 - Herdr installed (`herdr --version`) and server running (`herdr status`)
+- Prefer running the orchestrator **inside** Herdr (`HERDR_ENV=1`) so `$HERDR_PANE_ID` is the root
 - Agent CLIs on PATH (`pi`, `claude`, `codex`, …) as needed
 - Optional: `herdr integration install <agent>` for better status
 

--- a/skills/herdr-agent-comms/docs/README.md
+++ b/skills/herdr-agent-comms/docs/README.md
@@ -7,11 +7,11 @@
 
 # Herdr Agent Comms
 
-> Tile **root + sub-agents** into **one grid tab** — root stays put, workers fill balanced cells, messaging via the `herdr` CLI with status-aware waits.
+> Tile **root + sub-agents** into **one grid tab** as equal-width columns — root stays put, workers stay the same size as root, messaging via the `herdr` CLI with status-aware waits.
 
 ## Highlights
 
-- **Root + sub-agents grid** — largest-pane splits keep root and workers in a usable tiled layout.
+- **Root + sub-agents grid** — every column, including root, is resized to equal width as sub-agents are added.
 - **Root never replaced** — orchestrator pane stays; only close worker panes on teardown.
 - **Fleet spawn** — agent CLI + model + thinking + optional skills, then assign tasks in parallel.
 - **Message & steer** — `pane run` / `agent send`, wait on `working` → `done`/`idle`, read transcripts.
@@ -22,7 +22,7 @@
 
 | Say this... | Skill will... |
 |---|---|
-| "Spin up 2 Herdr agents beside me: reviewer and tests" | Build a grid in the root tab, launch agents in balanced cells |
+| "Spin up 2 Herdr agents beside me: reviewer and tests" | Build a grid in the root tab, launch agents in equal-width columns |
 | "Ask the reviewer agent what it found" | Resolve target, send, wait on status, relay reply |
 | "Broadcast 'pull main' to all fleet agents" | Fan-out send + concurrent collect |
 | "Focus the tests pane so I can steer" | `herdr agent focus tests` |
@@ -31,7 +31,7 @@
 
 ```mermaid
 graph TD
-    A["Resolve root pane + tab + workspace"] --> B["next_grid_split · pane split largest"]
+    A["Resolve root pane + tab + workspace"] --> B["next_grid_split · split rightmost + resize all to equal width"]
     B --> C["Rename sub-pane · launch CLI · wait idle"]
     C --> D["Submit tasks · broadcast"]
     D --> E["Wait agent-status done|idle"]

--- a/skills/herdr-agent-comms/evals/evals.json
+++ b/skills/herdr-agent-comms/evals/evals.json
@@ -4,13 +4,13 @@
     {
       "id": 1,
       "prompt": "I have a Herdr agent named 'reviewer' already running. Ask it to summarize the open PRs and show me what it says back.",
-      "expected_output": "Resolves the reviewer target via herdr agent get/list, sends with pane run (or agent send + enter), waits on agent-status (working then done/idle) rather than a blind sleep, reads recent-unwrapped, and relays the reply.",
+      "expected_output": "Resolves the reviewer target via herdr agent get/list, captures a pre-send transcript baseline, sends with pane run (or agent send + enter), waits on agent-status (working then done/idle) rather than a blind sleep, uses a split completion marker that cannot be satisfied by prompt echo to recognize a fast reply, reads recent-unwrapped, and relays the reply.",
       "files": []
     },
     {
       "id": 2,
       "prompt": "Spin up two Herdr agents for this project named 'tests' and 'docs'. Use pi with thinking low for both. Split them from my current pane so I can see root + both agents in one tab.",
-      "expected_output": "Checks herdr status, resolves root pane (HERDR_PANE_ID or equivalent), splits root pane twice with --no-focus (not new tabs, not a separate fleet tab), launches pi --thinking low in each sub-pane, renames agents, waits until idle/ready, keeps root agent pane. No server stop.",
+      "expected_output": "Checks herdr status, resolves root pane (HERDR_PANE_ID or equivalent), builds a same-tab grid including root by splitting the largest pane twice with --no-focus (not new tabs, not a separate fleet tab, not repeated slivers from one pane), launches pi --thinking low in each sub-pane, renames agents, waits until idle/ready, keeps root agent pane. No server stop.",
       "files": []
     },
     {
@@ -22,13 +22,13 @@
     {
       "id": 4,
       "prompt": "Launch three Herdr agents (reviewer, tests, docs) for this repo with different tasks in parallel and keep them visible in one view so I can jump into any pane to steer.",
-      "expected_output": "Resolves root pane/tab, splits three sub-agent panes from the root into the same tab (no-focus), submits distinct tasks, explains human can herdr agent focus a pane to steer, does not create per-agent tabs, does not nest tmux.",
+      "expected_output": "Resolves root pane/tab, builds a same-tab grid including root by largest-pane splits for three sub-agents (no-focus), submits distinct tasks, explains human can herdr agent focus a pane to steer, does not create per-agent tabs, does not nest tmux.",
       "files": []
     },
     {
       "id": 5,
       "prompt": "Broadcast 'pull latest main and report status' to all my Herdr fleet agents and collect replies.",
-      "expected_output": "Uses broadcast.sh or equivalent send-all-then-wait-concurrent pattern, reports per-agent idle/timeout/blocked, does not serialize full send-wait-read per agent.",
+      "expected_output": "Uses broadcast.sh or equivalent capture-all-baselines, split-completion-markers, send-all, then wait-concurrent pattern so fast replies and prompt echoes are distinguished; reports per-agent idle/timeout/blocked and does not serialize full send-wait-read per agent.",
       "files": []
     },
     {

--- a/skills/herdr-agent-comms/evals/evals.json
+++ b/skills/herdr-agent-comms/evals/evals.json
@@ -10,7 +10,7 @@
     {
       "id": 2,
       "prompt": "Spin up two Herdr agents for this project named 'tests' and 'docs'. Use pi with thinking low for both. Split them from my current pane so I can see root + both agents in one tab.",
-      "expected_output": "Checks herdr status, resolves root pane (HERDR_PANE_ID or equivalent), builds a same-tab grid including root by splitting the largest pane twice with --no-focus (not new tabs, not a separate fleet tab, not repeated slivers from one pane), launches pi --thinking low in each sub-pane, renames agents, waits until idle/ready, keeps root agent pane. No server stop.",
+      "expected_output": "Checks herdr status, resolves root pane (HERDR_PANE_ID or equivalent), builds a same-tab grid including root by splitting the rightmost column twice with --no-focus and resizing every column to equal width each time (not new tabs, not a separate fleet tab, not unequal-width columns), launches pi --thinking low in each sub-pane, renames agents, waits until idle/ready, keeps root agent pane. No server stop.",
       "files": []
     },
     {
@@ -22,7 +22,7 @@
     {
       "id": 4,
       "prompt": "Launch three Herdr agents (reviewer, tests, docs) for this repo with different tasks in parallel and keep them visible in one view so I can jump into any pane to steer.",
-      "expected_output": "Resolves root pane/tab, builds a same-tab grid including root by largest-pane splits for three sub-agents (no-focus), submits distinct tasks, explains human can herdr agent focus a pane to steer, does not create per-agent tabs, does not nest tmux.",
+      "expected_output": "Resolves root pane/tab, builds a same-tab grid including root by rightmost-column splits + equal-width resize for three sub-agents (no-focus), submits distinct tasks, explains human can herdr agent focus a pane to steer, does not create per-agent tabs, does not nest tmux.",
       "files": []
     },
     {

--- a/skills/herdr-agent-comms/evals/evals.json
+++ b/skills/herdr-agent-comms/evals/evals.json
@@ -9,20 +9,20 @@
     },
     {
       "id": 2,
-      "prompt": "Spin up two Herdr agents for this project named 'tests' and 'docs'. Use pi with thinking low for both. Put them in the same project workspace so I can see both panes at once.",
-      "expected_output": "Checks herdr status, reuses or creates one workspace for the project, creates one fleet tab and split panes (not one tab per agent) with --no-focus, launches pi --thinking low in each, renames agents, waits until idle/ready. No server stop.",
+      "prompt": "Spin up two Herdr agents for this project named 'tests' and 'docs'. Use pi with thinking low for both. Split them from my current pane so I can see root + both agents in one tab.",
+      "expected_output": "Checks herdr status, resolves root pane (HERDR_PANE_ID or equivalent), splits root pane twice with --no-focus (not new tabs, not a separate fleet tab), launches pi --thinking low in each sub-pane, renames agents, waits until idle/ready, keeps root agent pane. No server stop.",
       "files": []
     },
     {
       "id": 3,
       "prompt": "I'm done with all my Herdr fleet agents for this project — shut them down.",
-      "expected_output": "Treats teardown as destructive: confirms first, prefers closing the skill-created tabs/panes (or workspace if user wants) over herdr server stop unless explicitly requested, warns about lost state.",
+      "expected_output": "Treats teardown as destructive: confirms first, prefers closing skill-created sub-agent panes while keeping the root pane, avoids herdr server stop unless explicitly requested, warns about lost state.",
       "files": []
     },
     {
       "id": 4,
       "prompt": "Launch three Herdr agents (reviewer, tests, docs) for this repo with different tasks in parallel and keep them visible in one view so I can jump into any pane to steer.",
-      "expected_output": "One workspace, one fleet tab with three split panes, parallel-friendly spawn (no-focus), submits distinct tasks, explains human can herdr tab focus the fleet or herdr agent focus a pane to steer, does not nest tmux.",
+      "expected_output": "Resolves root pane/tab, splits three sub-agent panes from the root into the same tab (no-focus), submits distinct tasks, explains human can herdr agent focus a pane to steer, does not create per-agent tabs, does not nest tmux.",
       "files": []
     },
     {

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -61,8 +61,12 @@ else
     # dialog, not deliver the task. Never send the Enter blind.
     python3 "$sd/preflight_send.py" "$pane" >/dev/null \
       || { echo "Error: $pane not safe for recovery Enter (blocked/working/unverifiable) — see stderr" >&2; rm -f "$after"; exit 1; }
-    herdr pane send-keys "$pane" enter
-    herdr wait agent-status "$pane" --status working --timeout 10000 || echo NOT-DELIVERED
+    # Guard the keystroke, then PROPAGATE a failed re-wait. `|| echo NOT-DELIVERED`
+    # alone exits 0 — a genuine non-delivery would be reported as success.
+    herdr pane send-keys "$pane" enter \
+      || { echo "Error: recovery Enter failed for $pane" >&2; rm -f "$after"; exit 1; }
+    herdr wait agent-status "$pane" --status working --timeout 10000 \
+      || { echo "Error: $pane NOT-DELIVERED — still idle after recovery Enter; re-send the task." >&2; rm -f "$after"; exit 1; }
   fi
   rm -f "$after"
 fi
@@ -171,7 +175,7 @@ The helper mirrors tmux-agent-comms' wait semantics (exit 0 idle / 2 timeout / 3
 
 Capture every baseline first, then send all, then wait concurrently. This order handles agents that finish before their waiter process starts.
 
-**Precondition:** `$panes` here must already be the deduped, **preflighted** target set — every entry passed the fail-closed working/blocked/unverifiable check (as `scripts/broadcast.sh` Phase 1b and the manual fleet recipe in `references/herdr-recipes.md` build it). Don't `pane run` a raw target list; a working/blocked/off-enum pane would be sent into blind. Prefer `scripts/broadcast.sh`, which does all of this.
+**Precondition:** `$panes` here must already be the deduped, **preflighted** target set — every entry passed the fail-closed working/blocked/unverifiable check (as `scripts/broadcast.sh` Phase 1b and the manual fleet recipe in `references/herdr-recipes.md` build it). Don't `pane run` a raw target list; a working/blocked/off-enum pane would be sent into blind. These illustrative loops send straight after baselining, so a target that turns working/blocked in that window is sent into anyway — prefer `scripts/broadcast.sh`, which **rechecks each target's status immediately before its dispatch** and skips any that became unsafe.
 
 ```bash
 tmpdir="$(mktemp -d)"

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -85,8 +85,11 @@ Both mean "not working anymore." After a task:
 
 Orchestrator pattern — **accept either terminal state**; do not spend the whole budget on `done` alone (focused tabs finish as `idle`):
 
+Pick **exactly one** of the two waiters below — they are mutually exclusive, not sequential. Both consume the pre-send `$baseline` + `$completion_marker`; whichever you run owns the `$baseline` cleanup, so the other must not have deleted it first.
+
+**Preferred — the helper** (post-send semantics; the pre-send baseline closes the fast-completion race):
+
 ```bash
-# Preferred helper. The pre-send baseline closes the fast-completion race.
 # $here = scripts/ dir; probe install locations, don't derive from $0/BASH_SOURCE.
 # Repo-local copies win over global installs; fail fast if none resolve:
 #   for cand in "skills/herdr-agent-comms/scripts" \
@@ -100,32 +103,29 @@ Orchestrator pattern — **accept either terminal state**; do not spend the whol
 python3 "$here/wait_for_idle.py" "$pane" --timeout 180 --lines 80 \
   --baseline-file "$baseline" --completion-marker "$completion_marker"
 rc=$?               # capture BEFORE cleanup — `rm` would clobber $?
-rm -f "$baseline"
+rm -f "$baseline"   # this path is done with the baseline now
 # Act on the waiter's exit and PROPAGATE it — 0 done/idle, 1 error, 2 timeout,
-# 3 blocked. Any non-zero means no delivered reply; exit non-zero, don't fall
-# through to the manual poll as if the wait had succeeded.
+# 3 blocked. Any non-zero means no delivered reply.
 case "$rc" in
-  0) : ;;
+  0) echo "settled" ;;
   3) echo "$pane: BLOCKED — a human must answer a dialog" >&2; exit 3 ;;
   2) echo "$pane: TIMEOUT before completion" >&2; exit 2 ;;
   *) echo "$pane: waiter failed (rc $rc)" >&2; exit "$rc" ;;
 esac
+```
 
-# Helper-free alternative (no wait_for_idle.py). A hand-rolled `pane get` poll
-# must NOT accept the first idle/done it sees: a pane idle BEFORE the task
-# started (send not yet landed, or a prior fast task) would be a FALSE
-# completion for THIS send. Gate acceptance on having first observed `working`
-# (or a fresh completion marker absent from the pre-send baseline). Track the
-# outcome and propagate it: `blocked` exits 3, deadline exhaustion exits 2.
-deadline=$((SECONDS + 180)); settled=""; saw_working=""
+**OR — helper-free** (no `wait_for_idle.py`; run this INSTEAD of the block above, so the baseline still exists). A hand-rolled `pane get` poll must NOT accept the first idle/done it sees: a pane idle BEFORE the task started (send not yet landed, or a prior fast task) would be a FALSE completion for THIS send. Gate acceptance on having first observed `working` (or a fresh completion marker absent from the pre-send baseline); `blocked` exits 3, deadline exhaustion exits 2. A single `rm -f "$baseline"` runs after the loop, on every exit path:
+
+```bash
+deadline=$((SECONDS + 180)); settled=""; saw_working=""; rc=0
 while (( SECONDS < deadline )); do
-  out=$(herdr pane get "$pane" 2>/dev/null) || { echo "status lookup failed for $pane" >&2; exit 1; }
+  out=$(herdr pane get "$pane" 2>/dev/null) || { echo "status lookup failed for $pane" >&2; rc=1; break; }
   st=$(printf '%s' "$out" | python3 -c 'import sys,json
 V={"idle","working","blocked","done","unknown"}
 try: r=json.load(sys.stdin)["result"]["pane"].get("agent_status")
 except Exception: sys.exit(1)
 print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))') \
-    || { echo "status parse failed / off-enum for $pane" >&2; exit 1; }
+    || { echo "status parse failed / off-enum for $pane" >&2; rc=1; break; }
   # A fresh joined marker in the transcript (not in the baseline) also proves
   # completion even if we never caught the `working` window.
   if grep -qF "$completion_marker" <(herdr pane read "$pane" --source recent-unwrapped --lines 80 2>/dev/null) \
@@ -138,11 +138,12 @@ print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exi
                || herdr wait agent-status "$pane" --status idle --timeout 15000 || true ;;
     done|idle) [ -n "$saw_working" ] && { settled="$st"; break; }  # else pre-task idle: keep waiting
                sleep 2 ;;
-    blocked) echo "$pane: BLOCKED — a human must answer a dialog" >&2; rm -f "$baseline"; exit 3 ;;
+    blocked) echo "$pane: BLOCKED — a human must answer a dialog" >&2; rc=3; break ;;
     *) sleep 2 ;;
   esac
 done
-rm -f "$baseline"
+rm -f "$baseline"   # single cleanup, reached on every exit path
+[ "$rc" -eq 0 ] || exit "$rc"
 [ -n "$settled" ] || { echo "$pane: TIMEOUT before completion (never saw working / fresh marker)" >&2; exit 2; }
 echo "settled:$settled"
 ```

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -27,14 +27,7 @@ After `pane run` / send:
 `$sd` below is the skill's `scripts/` dir (resolve it as SKILL.md Phase 4/5 do: probe repo-local then `.agents/`, `.claude/`, `$HOME`).
 
 ```bash
-# $sd = the skill's scripts/ dir. FAIL-CLOSED preflight before EVERY send —
-# the single-target twin of broadcast.sh Phase 1b. Refuse to type a task into a
-# working (rc 2), blocked (rc 3), or unverifiable/off-enum (rc 4) pane; only
-# idle/done/unknown (rc 0) is safe. Skipping this let a task be typed into a
-# blocked trust dialog and still report success.
-python3 "$sd/preflight_send.py" "$pane" >/dev/null \
-  || { echo "Error: $pane not safe to send to (preflight failed) — see stderr" >&2; exit 1; }
-
+# $sd = the skill's scripts/ dir.
 baseline="$(mktemp)"
 herdr pane read "$pane" --source recent-unwrapped --lines 80 >"$baseline" \
   || { echo "Error: baseline read failed for $pane" >&2; exit 1; }
@@ -43,7 +36,15 @@ completion_marker="HERDR_DONE_$suffix"
 task="do the thing
 
 After fully finishing, concatenate and print these parts without spaces: HERDR_DONE_ and $suffix"
-herdr pane run "$pane" "$task" || { echo "Error: send failed for $pane" >&2; exit 1; }
+# FAIL-CLOSED preflight IMMEDIATELY before dispatch — the single-target twin of
+# broadcast.sh's pre-dispatch recheck. Placed here (not before baseline/task
+# prep) so a target that turned working/blocked during that prep can't still be
+# sent into. Refuse to type into a working (rc 2), blocked (rc 3), or
+# unverifiable/off-enum (rc 4) pane; only idle/done/unknown (rc 0) is safe —
+# skipping it let a task land in a blocked trust dialog and report success.
+python3 "$sd/preflight_send.py" "$pane" >/dev/null \
+  || { echo "Error: $pane not safe to send to (preflight failed) — see stderr" >&2; rm -f "$baseline"; exit 1; }
+herdr pane run "$pane" "$task" || { echo "Error: send failed for $pane" >&2; rm -f "$baseline"; exit 1; }
 if herdr wait agent-status "$pane" --status working --timeout 15000; then
   echo delivered
 else
@@ -110,13 +111,13 @@ case "$rc" in
   *) echo "$pane: waiter failed (rc $rc)" >&2; exit "$rc" ;;
 esac
 
-# Manual alternative: poll pane get for idle|done|blocked. FAIL-CLOSED status
-# read — a failed/malformed `herdr pane get` errors out rather than sleeping.
-# Track the OUTCOME and propagate it: `blocked` must exit 3 and deadline
-# exhaustion must exit 2. Breaking out silently (or letting the while condition
-# lapse) would fall through with status 0 — reporting a blocked/timed-out wait
-# as a successful completion.
-deadline=$((SECONDS + 180)); settled=""
+# Helper-free alternative (no wait_for_idle.py). A hand-rolled `pane get` poll
+# must NOT accept the first idle/done it sees: a pane idle BEFORE the task
+# started (send not yet landed, or a prior fast task) would be a FALSE
+# completion for THIS send. Gate acceptance on having first observed `working`
+# (or a fresh completion marker absent from the pre-send baseline). Track the
+# outcome and propagate it: `blocked` exits 3, deadline exhaustion exits 2.
+deadline=$((SECONDS + 180)); settled=""; saw_working=""
 while (( SECONDS < deadline )); do
   out=$(herdr pane get "$pane" 2>/dev/null) || { echo "status lookup failed for $pane" >&2; exit 1; }
   st=$(printf '%s' "$out" | python3 -c 'import sys,json
@@ -125,15 +126,24 @@ try: r=json.load(sys.stdin)["result"]["pane"].get("agent_status")
 except Exception: sys.exit(1)
 print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))') \
     || { echo "status parse failed / off-enum for $pane" >&2; exit 1; }
+  # A fresh joined marker in the transcript (not in the baseline) also proves
+  # completion even if we never caught the `working` window.
+  if grep -qF "$completion_marker" <(herdr pane read "$pane" --source recent-unwrapped --lines 80 2>/dev/null) \
+     && ! grep -qF "$completion_marker" "$baseline"; then
+    settled="marker"; break
+  fi
   case "$st" in
-    done|idle) settled="$st"; break ;;
-    blocked) echo "$pane: BLOCKED — a human must answer a dialog" >&2; exit 3 ;;
-    working) herdr wait agent-status "$pane" --status done --timeout 15000 \
+    working) saw_working=1
+             herdr wait agent-status "$pane" --status done --timeout 15000 \
                || herdr wait agent-status "$pane" --status idle --timeout 15000 || true ;;
+    done|idle) [ -n "$saw_working" ] && { settled="$st"; break; }  # else pre-task idle: keep waiting
+               sleep 2 ;;
+    blocked) echo "$pane: BLOCKED — a human must answer a dialog" >&2; rm -f "$baseline"; exit 3 ;;
     *) sleep 2 ;;
   esac
 done
-[ -n "$settled" ] || { echo "$pane: TIMEOUT before completion" >&2; exit 2; }
+rm -f "$baseline"
+[ -n "$settled" ] || { echo "$pane: TIMEOUT before completion (never saw working / fresh marker)" >&2; exit 2; }
 echo "settled:$settled"
 ```
 
@@ -181,9 +191,19 @@ The helper mirrors tmux-agent-comms' wait semantics (exit 0 idle / 2 timeout / 3
 
 Capture every baseline first, then send all, then wait concurrently. This order handles agents that finish before their waiter process starts.
 
-**Precondition:** `$panes` here must already be the deduped, **preflighted** target set — every entry passed the fail-closed working/blocked/unverifiable check (as `scripts/broadcast.sh` Phase 1b and the manual fleet recipe in `references/herdr-recipes.md` build it). Don't `pane run` a raw target list; a working/blocked/off-enum pane would be sent into blind. These illustrative loops send straight after baselining, so a target that turns working/blocked in that window is sent into anyway — prefer `scripts/broadcast.sh`, which **rechecks each target's status immediately before its dispatch** and skips any that became unsafe.
+**Precondition:** `$panes` here must already be the deduped, **preflighted** target set — every entry passed the fail-closed working/blocked/unverifiable check (as `scripts/broadcast.sh` Phase 1b and the manual fleet recipe in `references/herdr-recipes.md` build it). Don't `pane run` a raw target list; a working/blocked/off-enum pane would be sent into blind. The first loop below **rechecks each target's status immediately before its dispatch** and skips any that became working/blocked/unverifiable in the baseline→send window — matching `scripts/broadcast.sh`. Still prefer `scripts/broadcast.sh` for real use; these loops are illustrative.
 
 ```bash
+# Fail-closed, enum-validated status probe (returns non-zero on lookup/parse
+# failure or an off-enum value) — the same check broadcast.sh runs.
+pane_status() { local out
+  out="$(herdr pane get "$1" 2>/dev/null)" || return 1
+  printf '%s' "$out" | python3 -c 'import sys,json
+V={"idle","working","blocked","done","unknown"}
+try: r=json.load(sys.stdin)["result"]["pane"].get("agent_status")
+except Exception: sys.exit(1)
+print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))'; }
+
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT   # cleanup regardless of how we exit
 markers=()
@@ -198,21 +218,36 @@ for i in "${!panes[@]}"; do
 
 After fully finishing, concatenate and print: HERDR_DONE_ and $suffix"
 done
-# Send to all; a failed send must be recorded, not ignored.
-send_failed=()
+# Send to all. RECHECK status immediately before each dispatch (matching
+# broadcast.sh): the preflight/baseline loop above ran earlier, so a target may
+# have turned working/blocked (or become unverifiable) since — skip it rather
+# than send blind. Record send failures and became-unsafe skips BY INDEX so the
+# wait loop can exclude both (a name-keyed list can't be matched against $i).
+send_failed=(); became_unsafe=()
 for i in "${!panes[@]}"; do
-  herdr pane run "${panes[$i]}" "${tasks[$i]}" || send_failed+=("${panes[$i]}")
+  if ! st="$(pane_status "${panes[$i]}")" \
+     || [ "$st" = "working" ] || [ "$st" = "blocked" ]; then
+    echo "Error: ${panes[$i]} became unsafe (${st:-unverifiable}) before dispatch — skipped." >&2
+    became_unsafe+=("$i"); continue
+  fi
+  herdr pane run "${panes[$i]}" "${tasks[$i]}" || send_failed+=("$i")
 done
-# Wait concurrently, but capture EACH waiter's exit status (a bare `wait`
-# returns 0 for the shell even if a waiter timed out or hit `blocked`).
+# Wait concurrently on dispatched panes only (exclude send_failed AND
+# became_unsafe), capturing EACH waiter's exit status (a bare `wait` returns 0
+# for the shell even if a waiter timed out or hit `blocked`).
 pids=()
 for i in "${!panes[@]}"; do
+  skip=""
+  for f in ${send_failed[@]+"${send_failed[@]}"} ${became_unsafe[@]+"${became_unsafe[@]}"}; do
+    [ "$f" = "$i" ] && { skip=1; break; }
+  done
+  [ -n "$skip" ] && continue
   python3 "$here/wait_for_idle.py" "${panes[$i]}" --timeout 180 --lines 80 \
     --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
   pids+=("$!:${panes[$i]}")
 done
 overall=0
-for e in "${pids[@]}"; do
+for e in "${pids[@]+"${pids[@]}"}"; do
   jp="${e%%:*}"; pane="${e#*:}"
   if wait "$jp"; then
     echo "$pane: reply ready"
@@ -227,34 +262,59 @@ for e in "${pids[@]}"; do
   fi
 done
 if [ "${#send_failed[@]}" -gt 0 ]; then
-  echo "Send failed for: ${send_failed[*]}" >&2
+  for i in "${send_failed[@]}"; do echo "Send failed for: ${panes[$i]}" >&2; done
   overall=1
 fi
-exit "$overall"   # non-zero if any send failed or any waiter didn't complete
+[ "${#became_unsafe[@]}" -eq 0 ] || overall=1
+exit "$overall"   # non-zero if any send/preflight failed or any waiter didn't complete
 ```
 
 Or with raw waits — **do not** wait only on `done` (focused fleet tabs usually finish as `idle`):
 
 ```bash
-send_failed=()
-for p in "${panes[@]}"; do herdr pane run "$p" "$msg" || send_failed+=("$p"); done
-pids=()
+_status() { local out; out="$(herdr pane get "$1" 2>/dev/null)" || return 1
+  printf '%s' "$out" | python3 -c 'import sys,json
+V={"idle","working","blocked","done","unknown"}
+try: r=json.load(sys.stdin)["result"]["pane"].get("agent_status")
+except Exception: sys.exit(1)
+print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))'; }
+send_failed=(); unsafe=()
 for p in "${panes[@]}"; do
+  # Recheck immediately before dispatch (matching broadcast.sh); skip if it
+  # turned working/blocked/unverifiable since the preflight.
+  if ! st="$(_status "$p")" || [ "$st" = working ] || [ "$st" = blocked ]; then
+    echo "Error: $p became unsafe (${st:-unverifiable}) before dispatch — skipped." >&2
+    unsafe+=("$p"); continue
+  fi
+  herdr pane run "$p" "$msg" || send_failed+=("$p")
+done
+# Build the wait set: dispatched panes only (exclude send_failed and unsafe).
+wait_panes=()
+for p in "${panes[@]}"; do
+  drop=""
+  for b in ${send_failed[@]+"${send_failed[@]}"} ${unsafe[@]+"${unsafe[@]}"}; do
+    [ "$b" = "$p" ] && { drop=1; break; }
+  done
+  [ -n "$drop" ] || wait_panes+=("$p")
+done
+pids=()
+for p in ${wait_panes[@]+"${wait_panes[@]}"}; do
   (
-    deadline=$((SECONDS + 180))
+    deadline=$((SECONDS + 180)); saw_working=""
     while (( SECONDS < deadline )); do
-      # Guard the status read — a failed `herdr pane get` must not be treated
-      # as an empty status that falls through to `sleep`; exit as an error.
-      out=$(herdr pane get "$p" 2>/dev/null) || exit 4
+      out=$(herdr pane get "$p" 2>/dev/null) || exit 4   # fail-closed status read
       st=$(printf '%s' "$out" | python3 -c 'import sys,json
 V={"idle","working","blocked","done","unknown"}
 try: r=json.load(sys.stdin)["result"]["pane"].get("agent_status")
 except Exception: sys.exit(1)
 print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))') || exit 4
       case "$st" in
-        done|idle) exit 0 ;;
+        # Accept idle/done ONLY after a `working` transition — a pane idle before
+        # the task landed would otherwise be a false completion for THIS send.
+        done|idle) [ -n "$saw_working" ] && exit 0; sleep 2 ;;
         blocked) exit 3 ;;
-        working) herdr wait agent-status "$p" --status done --timeout 15000 \
+        working) saw_working=1
+                 herdr wait agent-status "$p" --status done --timeout 15000 \
                    || herdr wait agent-status "$p" --status idle --timeout 15000 || true ;;
         *) sleep 2 ;;
       esac
@@ -264,14 +324,16 @@ print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exi
   pids+=("$!:$p")
 done
 overall=0
-for e in "${pids[@]}"; do
+for e in ${pids[@]+"${pids[@]}"}; do
   jp="${e%%:*}"; pane="${e#*:}"
   wait "$jp" || { rc=$?; overall=1
     case "$rc" in 3) echo "$pane: BLOCKED (human needed)" >&2 ;;
                   4) echo "$pane: status lookup failed" >&2 ;;
+                  2) echo "$pane: TIMEOUT (never saw working)" >&2 ;;
                   *) echo "$pane: not ready (rc $rc)" >&2 ;; esac; }
 done
 [ "${#send_failed[@]}" -eq 0 ] || { echo "Send failed: ${send_failed[*]}" >&2; overall=1; }
+[ "${#unsafe[@]}" -eq 0 ] || overall=1
 exit "$overall"
 ```
 

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -56,8 +56,15 @@ Both mean "not working anymore." After a task:
 Orchestrator pattern — **accept either terminal state**; do not spend the whole budget on `done` alone (focused tabs finish as `idle`):
 
 ```bash
-# Preferred helper. The pre-send baseline closes the fast-completion race:
-python3 scripts/wait_for_idle.py "$pane" --timeout 180 --lines 80 \
+# Preferred helper. The pre-send baseline closes the fast-completion race.
+# $here = scripts/ dir; probe install locations, don't derive from $0/BASH_SOURCE:
+#   for cand in "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+#               ".claude/skills/herdr-agent-comms/scripts" \
+#               "$HOME/.agents/skills/herdr-agent-comms/scripts" \
+#               "skills/herdr-agent-comms/scripts"; do
+#     [ -f "$cand/wait_for_idle.py" ] && here="$cand" && break
+#   done
+python3 "$here/wait_for_idle.py" "$pane" --timeout 180 --lines 80 \
   --baseline-file "$baseline" --completion-marker "$completion_marker"
 rc=$?
 rm -f "$baseline"
@@ -111,7 +118,7 @@ On timeout:
 Integrations missing or exotic CLI:
 
 1. `herdr integration install <agent>` when supported
-2. Fall back to content stability: `python3 scripts/wait_for_idle.py <pane_id>`
+2. Fall back to content stability: `python3 "$here/wait_for_idle.py" <pane_id>` (`$here` = resolved scripts/ dir — probe install locations, not `$0`)
 3. Still use capped `pane read` for the reply
 
 The helper mirrors tmux-agent-comms' wait semantics (exit 0 idle / 2 timeout / 3 blocked markers) but reads via `herdr pane read` instead of `tmux capture-pane`.
@@ -134,7 +141,7 @@ After fully finishing, concatenate and print: HERDR_DONE_ and $suffix"
 done
 for i in "${!panes[@]}"; do herdr pane run "${panes[$i]}" "${tasks[$i]}"; done
 for i in "${!panes[@]}"; do
-  python3 scripts/wait_for_idle.py "${panes[$i]}" --timeout 180 --lines 80 \
+  python3 "$here/wait_for_idle.py" "${panes[$i]}" --timeout 180 --lines 80 \
     --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
 done
 wait

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -57,13 +57,16 @@ Orchestrator pattern — **accept either terminal state**; do not spend the whol
 
 ```bash
 # Preferred helper. The pre-send baseline closes the fast-completion race.
-# $here = scripts/ dir; probe install locations, don't derive from $0/BASH_SOURCE:
-#   for cand in "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+# $here = scripts/ dir; probe install locations, don't derive from $0/BASH_SOURCE.
+# Repo-local copies win over global installs; fail fast if none resolve:
+#   for cand in "skills/herdr-agent-comms/scripts" \
+#               ".agents/skills/herdr-agent-comms/scripts" \
 #               ".claude/skills/herdr-agent-comms/scripts" \
-#               "$HOME/.agents/skills/herdr-agent-comms/scripts" \
-#               "skills/herdr-agent-comms/scripts"; do
+#               "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+#               "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
 #     [ -f "$cand/wait_for_idle.py" ] && here="$cand" && break
 #   done
+#   [ -n "$here" ] || { echo "Error: wait_for_idle.py not found" >&2; exit 1; }
 python3 "$here/wait_for_idle.py" "$pane" --timeout 180 --lines 80 \
   --baseline-file "$baseline" --completion-marker "$completion_marker"
 rc=$?

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -25,16 +25,25 @@ After `pane run` / send:
 3. If `blocked` → dialog ate focus; do not treat as delivered task.
 
 ```bash
-herdr pane run "$pane" "do the thing"
+baseline="$(mktemp)"
+herdr pane read "$pane" --source recent-unwrapped --lines 80 >"$baseline"
+suffix="$(date +%s)_$$_$RANDOM"
+completion_marker="HERDR_DONE_$suffix"
+task="do the thing
+
+After fully finishing, concatenate and print these parts without spaces: HERDR_DONE_ and $suffix"
+herdr pane run "$pane" "$task"
 if herdr wait agent-status "$pane" --status working --timeout 15000; then
   echo delivered
+elif ! cmp -s "$baseline" <(herdr pane read "$pane" --source recent-unwrapped --lines 80); then
+  echo delivered-transcript-activity
 else
   herdr pane send-keys "$pane" enter
   herdr wait agent-status "$pane" --status working --timeout 10000 || echo NOT-DELIVERED
 fi
 ```
 
-On-screen text alone does not prove submission (typed but not Enter'd looks the same). Status `working` (or new output while leaving idle) is the reliable signal.
+On-screen text alone does not prove submission. Status `working` or output different from the **pre-send baseline** proves delivery activity. The difference may only be prompt echo. Split the completion marker into two prompt fragments; only the finished reply contains the joined marker. Keep `baseline` and `completion_marker` for the wait.
 
 ## Completion: idle vs done
 
@@ -47,8 +56,11 @@ Both mean "not working anymore." After a task:
 Orchestrator pattern — **accept either terminal state**; do not spend the whole budget on `done` alone (focused tabs finish as `idle`):
 
 ```bash
-# Preferred helper (requires saw working / transcript change before success):
-python3 scripts/wait_for_idle.py "$pane" --timeout 180
+# Preferred helper. The pre-send baseline closes the fast-completion race:
+python3 scripts/wait_for_idle.py "$pane" --timeout 180 --lines 80 \
+  --baseline-file "$baseline" --completion-marker "$completion_marker"
+rc=$?
+rm -f "$baseline"
 
 # Manual: poll pane get for idle|done|blocked while re-waiting in short slices
 deadline=$((SECONDS + 180))
@@ -64,7 +76,7 @@ while (( SECONDS < deadline )); do
 done
 ```
 
-`scripts/wait_for_idle.py` defaults to **post-send** semantics: already-idle panes are not success until `working` (or a transcript change) is observed. Use `--ready` only for boot waits.
+`scripts/wait_for_idle.py` defaults to **post-send** semantics. Capture `--baseline-file` before send and arrange `--completion-marker`; this closes both races: a fast reply cannot become the baseline, and stable prompt echo cannot look complete. Without a marker, content stability remains a legacy heuristic fallback. Use `--ready` only for boot waits.
 
 ## Blocked
 
@@ -106,14 +118,27 @@ The helper mirrors tmux-agent-comms' wait semantics (exit 0 idle / 2 timeout / 3
 
 ## Concurrent fleet waits
 
-Send all first, wait all second. Prefer the helper (handles `idle` **or** `done`, and post-send semantics):
+Capture every baseline first, then send all, then wait concurrently. This order handles agents that finish before their waiter process starts:
 
 ```bash
-for p in "${panes[@]}"; do herdr pane run "$p" "$msg"; done
-for p in "${panes[@]}"; do
-  python3 scripts/wait_for_idle.py "$p" --timeout 180 &
+tmpdir="$(mktemp -d)"
+markers=()
+tasks=()
+for i in "${!panes[@]}"; do
+  herdr pane read "${panes[$i]}" --source recent-unwrapped --lines 80 >"$tmpdir/$i.baseline"
+  suffix="$(date +%s)_$$_${i}_$RANDOM"
+  markers+=("HERDR_DONE_$suffix")
+  tasks[$i]="$msg
+
+After fully finishing, concatenate and print: HERDR_DONE_ and $suffix"
+done
+for i in "${!panes[@]}"; do herdr pane run "${panes[$i]}" "${tasks[$i]}"; done
+for i in "${!panes[@]}"; do
+  python3 scripts/wait_for_idle.py "${panes[$i]}" --timeout 180 --lines 80 \
+    --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
 done
 wait
+rm -rf "$tmpdir"
 ```
 
 Or with raw waits — **do not** wait only on `done` (focused fleet tabs usually finish as `idle`):

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -112,7 +112,11 @@ esac
 
 # Manual alternative: poll pane get for idle|done|blocked. FAIL-CLOSED status
 # read — a failed/malformed `herdr pane get` errors out rather than sleeping.
-deadline=$((SECONDS + 180))
+# Track the OUTCOME and propagate it: `blocked` must exit 3 and deadline
+# exhaustion must exit 2. Breaking out silently (or letting the while condition
+# lapse) would fall through with status 0 — reporting a blocked/timed-out wait
+# as a successful completion.
+deadline=$((SECONDS + 180)); settled=""
 while (( SECONDS < deadline )); do
   out=$(herdr pane get "$pane" 2>/dev/null) || { echo "status lookup failed for $pane" >&2; exit 1; }
   st=$(printf '%s' "$out" | python3 -c 'import sys,json
@@ -122,13 +126,15 @@ except Exception: sys.exit(1)
 print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))') \
     || { echo "status parse failed / off-enum for $pane" >&2; exit 1; }
   case "$st" in
-    done|idle) break ;;
-    blocked) echo blocked; break ;;
+    done|idle) settled="$st"; break ;;
+    blocked) echo "$pane: BLOCKED — a human must answer a dialog" >&2; exit 3 ;;
     working) herdr wait agent-status "$pane" --status done --timeout 15000 \
                || herdr wait agent-status "$pane" --status idle --timeout 15000 || true ;;
     *) sleep 2 ;;
   esac
 done
+[ -n "$settled" ] || { echo "$pane: TIMEOUT before completion" >&2; exit 2; }
+echo "settled:$settled"
 ```
 
 `scripts/wait_for_idle.py` defaults to **post-send** semantics. Capture `--baseline-file` before send and arrange `--completion-marker`; this closes both races: a fast reply cannot become the baseline, and stable prompt echo cannot look complete. Without a marker, content stability remains a legacy heuristic fallback. Use `--ready` only for boot waits.

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -24,10 +24,16 @@ After `pane run` / send:
 2. If still `idle`/`done` with no new transcript lines → likely not submitted → lone `enter`, then re-check.
 3. If `blocked` → dialog ate focus; do not treat as delivered task.
 
-`$sd` below is the skill's `scripts/` dir (resolve it as SKILL.md Phase 4/5 do: probe repo-local then `.agents/`, `.claude/`, `$HOME`).
+`$here` below is the skill's `scripts/` dir, resolved executably (repo-local first, then `.agents/`, `.claude/`, `$HOME`; fail fast if none resolve — matching SKILL.md Phase 4/5).
 
 ```bash
-# $sd = the skill's scripts/ dir.
+here=""
+for cand in "skills/herdr-agent-comms/scripts" ".agents/skills/herdr-agent-comms/scripts" \
+  ".claude/skills/herdr-agent-comms/scripts" "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
+  [ -f "$cand/preflight_send.py" ] && { here="$cand"; break; }
+done
+[ -n "$here" ] || { echo "Error: preflight_send.py not found in any known install location" >&2; exit 1; }
 baseline="$(mktemp)"
 herdr pane read "$pane" --source recent-unwrapped --lines 80 >"$baseline" \
   || { echo "Error: baseline read failed for $pane" >&2; exit 1; }
@@ -42,7 +48,7 @@ After fully finishing, concatenate and print these parts without spaces: HERDR_D
 # sent into. Refuse to type into a working (rc 2), blocked (rc 3), or
 # unverifiable/off-enum (rc 4) pane; only idle/done/unknown (rc 0) is safe —
 # skipping it let a task land in a blocked trust dialog and report success.
-python3 "$sd/preflight_send.py" "$pane" >/dev/null \
+python3 "$here/preflight_send.py" "$pane" >/dev/null \
   || { echo "Error: $pane not safe to send to (preflight failed) — see stderr" >&2; rm -f "$baseline"; exit 1; }
 herdr pane run "$pane" "$task" || { echo "Error: send failed for $pane" >&2; rm -f "$baseline"; exit 1; }
 if herdr wait agent-status "$pane" --status working --timeout 15000; then
@@ -60,7 +66,7 @@ else
     # Re-run the preflight before the recovery Enter: the send may have flipped
     # the pane into a `blocked` dialog, and a bare Enter would answer THAT
     # dialog, not deliver the task. Never send the Enter blind.
-    python3 "$sd/preflight_send.py" "$pane" >/dev/null \
+    python3 "$here/preflight_send.py" "$pane" >/dev/null \
       || { echo "Error: $pane not safe for recovery Enter (blocked/working/unverifiable) — see stderr" >&2; rm -f "$after"; exit 1; }
     # Guard the keystroke, then PROPAGATE a failed re-wait. `|| echo NOT-DELIVERED`
     # alone exits 0 — a genuine non-delivery would be reported as success.
@@ -90,16 +96,15 @@ Pick **exactly one** of the two waiters below — they are mutually exclusive, n
 **Preferred — the helper** (post-send semantics; the pre-send baseline closes the fast-completion race):
 
 ```bash
-# $here = scripts/ dir; probe install locations, don't derive from $0/BASH_SOURCE.
+# Resolve $here = scripts/ dir executably (don't derive from $0/BASH_SOURCE).
 # Repo-local copies win over global installs; fail fast if none resolve:
-#   for cand in "skills/herdr-agent-comms/scripts" \
-#               ".agents/skills/herdr-agent-comms/scripts" \
-#               ".claude/skills/herdr-agent-comms/scripts" \
-#               "$HOME/.claude/skills/herdr-agent-comms/scripts" \
-#               "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
-#     [ -f "$cand/wait_for_idle.py" ] && here="$cand" && break
-#   done
-#   [ -n "$here" ] || { echo "Error: wait_for_idle.py not found" >&2; exit 1; }
+here=""
+for cand in "skills/herdr-agent-comms/scripts" ".agents/skills/herdr-agent-comms/scripts" \
+  ".claude/skills/herdr-agent-comms/scripts" "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
+  [ -f "$cand/wait_for_idle.py" ] && { here="$cand"; break; }
+done
+[ -n "$here" ] || { echo "Error: wait_for_idle.py not found in any known install location" >&2; exit 1; }
 python3 "$here/wait_for_idle.py" "$pane" --timeout 180 --lines 80 \
   --baseline-file "$baseline" --completion-marker "$completion_marker"
 rc=$?               # capture BEFORE cleanup — `rm` would clobber $?
@@ -195,6 +200,14 @@ Capture every baseline first, then send all, then wait concurrently. This order 
 **Precondition:** `$panes` here must already be the deduped, **preflighted** target set — every entry passed the fail-closed working/blocked/unverifiable check (as `scripts/broadcast.sh` Phase 1b and the manual fleet recipe in `references/herdr-recipes.md` build it). Don't `pane run` a raw target list; a working/blocked/off-enum pane would be sent into blind. The first loop below **rechecks each target's status immediately before its dispatch** and skips any that became working/blocked/unverifiable in the baseline→send window — matching `scripts/broadcast.sh`. Still prefer `scripts/broadcast.sh` for real use; these loops are illustrative.
 
 ```bash
+# Resolve $here = scripts/ dir executably (repo-local first; fail fast).
+here=""
+for cand in "skills/herdr-agent-comms/scripts" ".agents/skills/herdr-agent-comms/scripts" \
+  ".claude/skills/herdr-agent-comms/scripts" "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
+  [ -f "$cand/wait_for_idle.py" ] && { here="$cand"; break; }
+done
+[ -n "$here" ] || { echo "Error: wait_for_idle.py not found in any known install location" >&2; exit 1; }
 # Fail-closed, enum-validated status probe (returns non-zero on lookup/parse
 # failure or an off-enum value) — the same check broadcast.sh runs.
 pane_status() { local out

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -37,16 +37,19 @@ herdr pane run "$pane" "$task" || { echo "Error: send failed for $pane" >&2; exi
 if herdr wait agent-status "$pane" --status working --timeout 15000; then
   echo delivered
 else
-  # Capture the read EXPLICITLY and check it — a failed `herdr pane read`
-  # inside `<(...)` would differ from baseline and be misread as activity.
-  after="$(herdr pane read "$pane" --source recent-unwrapped --lines 80)" \
-    || { echo "Error: post-send read failed for $pane" >&2; exit 1; }
-  if ! printf '%s' "$after" | cmp -s "$baseline" -; then
+  # Read post-send into a SECOND FILE and compare file-to-file. `$(...)` capture
+  # strips trailing newlines the baseline file keeps, so identical transcripts
+  # would falsely compare as "activity". A failed read is an error, not delivery.
+  after="$(mktemp)"
+  herdr pane read "$pane" --source recent-unwrapped --lines 80 >"$after" \
+    || { echo "Error: post-send read failed for $pane" >&2; rm -f "$after"; exit 1; }
+  if ! cmp -s "$baseline" "$after"; then
     echo delivered-transcript-activity
   else
     herdr pane send-keys "$pane" enter
     herdr wait agent-status "$pane" --status working --timeout 10000 || echo NOT-DELIVERED
   fi
+  rm -f "$after"
 fi
 ```
 
@@ -76,14 +79,16 @@ Orchestrator pattern — **accept either terminal state**; do not spend the whol
 #   [ -n "$here" ] || { echo "Error: wait_for_idle.py not found" >&2; exit 1; }
 python3 "$here/wait_for_idle.py" "$pane" --timeout 180 --lines 80 \
   --baseline-file "$baseline" --completion-marker "$completion_marker"
-rc=$?
+rc=$?               # capture BEFORE cleanup — `rm` would clobber $?
 rm -f "$baseline"
-# Act on the waiter's exit — 0 done/idle, 2 timeout, 3 blocked (needs human).
+# Act on the waiter's exit and PROPAGATE it — 0 done/idle, 1 error, 2 timeout,
+# 3 blocked. Any non-zero means no delivered reply; exit non-zero, don't fall
+# through to the manual poll as if the wait had succeeded.
 case "$rc" in
   0) : ;;
-  3) echo "$pane: BLOCKED — a human must answer a dialog" >&2 ;;
-  2) echo "$pane: TIMEOUT before completion" >&2 ;;
-  *) echo "$pane: waiter failed (rc $rc)" >&2 ;;
+  3) echo "$pane: BLOCKED — a human must answer a dialog" >&2; exit 3 ;;
+  2) echo "$pane: TIMEOUT before completion" >&2; exit 2 ;;
+  *) echo "$pane: waiter failed (rc $rc)" >&2; exit "$rc" ;;
 esac
 
 # Manual alternative: poll pane get for idle|done|blocked. FAIL-CLOSED status

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -26,20 +26,27 @@ After `pane run` / send:
 
 ```bash
 baseline="$(mktemp)"
-herdr pane read "$pane" --source recent-unwrapped --lines 80 >"$baseline"
+herdr pane read "$pane" --source recent-unwrapped --lines 80 >"$baseline" \
+  || { echo "Error: baseline read failed for $pane" >&2; exit 1; }
 suffix="$(date +%s)_$$_$RANDOM"
 completion_marker="HERDR_DONE_$suffix"
 task="do the thing
 
 After fully finishing, concatenate and print these parts without spaces: HERDR_DONE_ and $suffix"
-herdr pane run "$pane" "$task"
+herdr pane run "$pane" "$task" || { echo "Error: send failed for $pane" >&2; exit 1; }
 if herdr wait agent-status "$pane" --status working --timeout 15000; then
   echo delivered
-elif ! cmp -s "$baseline" <(herdr pane read "$pane" --source recent-unwrapped --lines 80); then
-  echo delivered-transcript-activity
 else
-  herdr pane send-keys "$pane" enter
-  herdr wait agent-status "$pane" --status working --timeout 10000 || echo NOT-DELIVERED
+  # Capture the read EXPLICITLY and check it — a failed `herdr pane read`
+  # inside `<(...)` would differ from baseline and be misread as activity.
+  after="$(herdr pane read "$pane" --source recent-unwrapped --lines 80)" \
+    || { echo "Error: post-send read failed for $pane" >&2; exit 1; }
+  if ! printf '%s' "$after" | cmp -s "$baseline" -; then
+    echo delivered-transcript-activity
+  else
+    herdr pane send-keys "$pane" enter
+    herdr wait agent-status "$pane" --status working --timeout 10000 || echo NOT-DELIVERED
+  fi
 fi
 ```
 
@@ -132,34 +139,70 @@ Capture every baseline first, then send all, then wait concurrently. This order 
 
 ```bash
 tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT   # cleanup regardless of how we exit
 markers=()
 tasks=()
 for i in "${!panes[@]}"; do
-  herdr pane read "${panes[$i]}" --source recent-unwrapped --lines 80 >"$tmpdir/$i.baseline"
+  # Guard each baseline read — a silent failure here would poison the wait.
+  herdr pane read "${panes[$i]}" --source recent-unwrapped --lines 80 >"$tmpdir/$i.baseline" \
+    || { echo "Error: baseline read failed for ${panes[$i]}" >&2; exit 1; }
   suffix="$(date +%s)_$$_${i}_$RANDOM"
   markers+=("HERDR_DONE_$suffix")
   tasks[$i]="$msg
 
 After fully finishing, concatenate and print: HERDR_DONE_ and $suffix"
 done
-for i in "${!panes[@]}"; do herdr pane run "${panes[$i]}" "${tasks[$i]}"; done
+# Send to all; a failed send must be recorded, not ignored.
+send_failed=()
+for i in "${!panes[@]}"; do
+  herdr pane run "${panes[$i]}" "${tasks[$i]}" || send_failed+=("${panes[$i]}")
+done
+# Wait concurrently, but capture EACH waiter's exit status (a bare `wait`
+# returns 0 for the shell even if a waiter timed out or hit `blocked`).
+pids=()
 for i in "${!panes[@]}"; do
   python3 "$here/wait_for_idle.py" "${panes[$i]}" --timeout 180 --lines 80 \
     --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
+  pids+=("$!:${panes[$i]}")
 done
-wait
-rm -rf "$tmpdir"
+overall=0
+for e in "${pids[@]}"; do
+  jp="${e%%:*}"; pane="${e#*:}"
+  if wait "$jp"; then
+    echo "$pane: reply ready"
+  else
+    rc=$?
+    case "$rc" in
+      3) echo "$pane: BLOCKED — a human must answer a dialog" >&2 ;;
+      2) echo "$pane: TIMEOUT before completion" >&2 ;;
+      *) echo "$pane: waiter failed (rc $rc)" >&2 ;;
+    esac
+    overall=1
+  fi
+done
+if [ "${#send_failed[@]}" -gt 0 ]; then
+  echo "Send failed for: ${send_failed[*]}" >&2
+  overall=1
+fi
+exit "$overall"   # non-zero if any send failed or any waiter didn't complete
 ```
 
 Or with raw waits — **do not** wait only on `done` (focused fleet tabs usually finish as `idle`):
 
 ```bash
-for p in "${panes[@]}"; do herdr pane run "$p" "$msg"; done
+send_failed=()
+for p in "${panes[@]}"; do herdr pane run "$p" "$msg" || send_failed+=("$p"); done
+pids=()
 for p in "${panes[@]}"; do
   (
     deadline=$((SECONDS + 180))
     while (( SECONDS < deadline )); do
-      st=$(herdr pane get "$p" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
+      # Guard the status read — a failed `herdr pane get` must not be treated
+      # as an empty status that falls through to `sleep`; exit as an error.
+      out=$(herdr pane get "$p" 2>/dev/null) || exit 4
+      st=$(printf '%s' "$out" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin)["result"]["pane"].get("agent_status") or "unknown")
+except Exception: sys.exit(1)') || exit 4
       case "$st" in
         done|idle) exit 0 ;;
         blocked) exit 3 ;;
@@ -170,8 +213,18 @@ for p in "${panes[@]}"; do
     done
     exit 2
   ) &
+  pids+=("$!:$p")
 done
-wait
+overall=0
+for e in "${pids[@]}"; do
+  jp="${e%%:*}"; pane="${e#*:}"
+  wait "$jp" || { rc=$?; overall=1
+    case "$rc" in 3) echo "$pane: BLOCKED (human needed)" >&2 ;;
+                  4) echo "$pane: status lookup failed" >&2 ;;
+                  *) echo "$pane: not ready (rc $rc)" >&2 ;; esac; }
+done
+[ "${#send_failed[@]}" -eq 0 ] || { echo "Send failed: ${send_failed[*]}" >&2; overall=1; }
+exit "$overall"
 ```
 
 Or simply: `scripts/broadcast.sh "$msg" reviewer tests docs`.

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -24,7 +24,17 @@ After `pane run` / send:
 2. If still `idle`/`done` with no new transcript lines → likely not submitted → lone `enter`, then re-check.
 3. If `blocked` → dialog ate focus; do not treat as delivered task.
 
+`$sd` below is the skill's `scripts/` dir (resolve it as SKILL.md Phase 4/5 do: probe repo-local then `.agents/`, `.claude/`, `$HOME`).
+
 ```bash
+# $sd = the skill's scripts/ dir. FAIL-CLOSED preflight before EVERY send —
+# the single-target twin of broadcast.sh Phase 1b. Refuse to type a task into a
+# working (rc 2), blocked (rc 3), or unverifiable/off-enum (rc 4) pane; only
+# idle/done/unknown (rc 0) is safe. Skipping this let a task be typed into a
+# blocked trust dialog and still report success.
+python3 "$sd/preflight_send.py" "$pane" >/dev/null \
+  || { echo "Error: $pane not safe to send to (preflight failed) — see stderr" >&2; exit 1; }
+
 baseline="$(mktemp)"
 herdr pane read "$pane" --source recent-unwrapped --lines 80 >"$baseline" \
   || { echo "Error: baseline read failed for $pane" >&2; exit 1; }
@@ -46,6 +56,11 @@ else
   if ! cmp -s "$baseline" "$after"; then
     echo delivered-transcript-activity
   else
+    # Re-run the preflight before the recovery Enter: the send may have flipped
+    # the pane into a `blocked` dialog, and a bare Enter would answer THAT
+    # dialog, not deliver the task. Never send the Enter blind.
+    python3 "$sd/preflight_send.py" "$pane" >/dev/null \
+      || { echo "Error: $pane not safe for recovery Enter (blocked/working/unverifiable) — see stderr" >&2; rm -f "$after"; exit 1; }
     herdr pane send-keys "$pane" enter
     herdr wait agent-status "$pane" --status working --timeout 10000 || echo NOT-DELIVERED
   fi
@@ -97,8 +112,11 @@ deadline=$((SECONDS + 180))
 while (( SECONDS < deadline )); do
   out=$(herdr pane get "$pane" 2>/dev/null) || { echo "status lookup failed for $pane" >&2; exit 1; }
   st=$(printf '%s' "$out" | python3 -c 'import sys,json
-try: print(json.load(sys.stdin)["result"]["pane"].get("agent_status") or "unknown")
-except Exception: sys.exit(1)') || { echo "status parse failed for $pane" >&2; exit 1; }
+V={"idle","working","blocked","done","unknown"}
+try: r=json.load(sys.stdin)["result"]["pane"].get("agent_status")
+except Exception: sys.exit(1)
+print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))') \
+    || { echo "status parse failed / off-enum for $pane" >&2; exit 1; }
   case "$st" in
     done|idle) break ;;
     blocked) echo blocked; break ;;
@@ -151,7 +169,9 @@ The helper mirrors tmux-agent-comms' wait semantics (exit 0 idle / 2 timeout / 3
 
 ## Concurrent fleet waits
 
-Capture every baseline first, then send all, then wait concurrently. This order handles agents that finish before their waiter process starts:
+Capture every baseline first, then send all, then wait concurrently. This order handles agents that finish before their waiter process starts.
+
+**Precondition:** `$panes` here must already be the deduped, **preflighted** target set — every entry passed the fail-closed working/blocked/unverifiable check (as `scripts/broadcast.sh` Phase 1b and the manual fleet recipe in `references/herdr-recipes.md` build it). Don't `pane run` a raw target list; a working/blocked/off-enum pane would be sent into blind. Prefer `scripts/broadcast.sh`, which does all of this.
 
 ```bash
 tmpdir="$(mktemp -d)"
@@ -217,8 +237,10 @@ for p in "${panes[@]}"; do
       # as an empty status that falls through to `sleep`; exit as an error.
       out=$(herdr pane get "$p" 2>/dev/null) || exit 4
       st=$(printf '%s' "$out" | python3 -c 'import sys,json
-try: print(json.load(sys.stdin)["result"]["pane"].get("agent_status") or "unknown")
-except Exception: sys.exit(1)') || exit 4
+V={"idle","working","blocked","done","unknown"}
+try: r=json.load(sys.stdin)["result"]["pane"].get("agent_status")
+except Exception: sys.exit(1)
+print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))') || exit 4
       case "$st" in
         done|idle) exit 0 ;;
         blocked) exit 3 ;;

--- a/skills/herdr-agent-comms/references/delivery-and-waiting.md
+++ b/skills/herdr-agent-comms/references/delivery-and-waiting.md
@@ -78,11 +78,22 @@ python3 "$here/wait_for_idle.py" "$pane" --timeout 180 --lines 80 \
   --baseline-file "$baseline" --completion-marker "$completion_marker"
 rc=$?
 rm -f "$baseline"
+# Act on the waiter's exit — 0 done/idle, 2 timeout, 3 blocked (needs human).
+case "$rc" in
+  0) : ;;
+  3) echo "$pane: BLOCKED — a human must answer a dialog" >&2 ;;
+  2) echo "$pane: TIMEOUT before completion" >&2 ;;
+  *) echo "$pane: waiter failed (rc $rc)" >&2 ;;
+esac
 
-# Manual: poll pane get for idle|done|blocked while re-waiting in short slices
+# Manual alternative: poll pane get for idle|done|blocked. FAIL-CLOSED status
+# read — a failed/malformed `herdr pane get` errors out rather than sleeping.
 deadline=$((SECONDS + 180))
 while (( SECONDS < deadline )); do
-  st=$(herdr pane get "$pane" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
+  out=$(herdr pane get "$pane" 2>/dev/null) || { echo "status lookup failed for $pane" >&2; exit 1; }
+  st=$(printf '%s' "$out" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin)["result"]["pane"].get("agent_status") or "unknown")
+except Exception: sys.exit(1)') || { echo "status parse failed for $pane" >&2; exit 1; }
   case "$st" in
     done|idle) break ;;
     blocked) echo blocked; break ;;

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -242,7 +242,7 @@ herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'" || { echo "Error: launc
 
 ## Sending multi-line or code-heavy messages
 
-`herdr pane run <pane> <command>` takes one shell-quoted string. Nested quotes and newlines break easily.
+`herdr pane run <pane> <command>` takes one shell-quoted string. Nested quotes and newlines break easily. These patterns cover **escaping only** — run the fail-closed preflight (`scripts/preflight_send.py`, see "Delivery verification" in `references/delivery-and-waiting.md`) before any of them, so a task never lands in a working/blocked/unverifiable pane.
 
 **Pattern A — short instruction that reads a file:**
 
@@ -354,9 +354,11 @@ pane_status() {  # prints status, returns non-zero on lookup/parse failure
   out="$(herdr pane get "$1" 2>/dev/null)" || return 1
   printf '%s' "$out" | python3 -c '
 import sys, json
-try: pane = json.load(sys.stdin)["result"]["pane"]
+V={"idle","working","blocked","done","unknown"}
+try: r = json.load(sys.stdin)["result"]["pane"].get("agent_status")
 except Exception: sys.exit(1)
-print(pane.get("agent_status") or "unknown")'
+# Off-enum values (numeric, garbage, empty) are unverifiable, NOT "unknown".
+print("unknown" if r is None else r if isinstance(r,str) and r in V else sys.exit(1))'
 }
 ready_panes=(); ready_labels=(); skipped_any=0
 for i in "${!panes[@]}"; do

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -257,7 +257,8 @@ Return only:
 1. bugs
 2. missing tests
 EOF
-herdr pane run "$pane_id" "Read $task_file and follow its instructions. Delete the file when done."
+herdr pane run "$pane_id" "Read $task_file and follow its instructions. Delete the file when done." \
+  || { echo "send failed for $pane_id" >&2; exit 1; }
 ```
 
 **Pattern B — `send-text` then Enter** (when you must avoid shell expansion inside `pane run`):

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -4,66 +4,74 @@ Read this when you need layout variants, multi-line sends, human steer/focus, sc
 
 ## Default fleet layout (this skill)
 
-**Root agent pane + sub-agents split from root — one tab:**
+**Root + sub-agents as a tiled grid in one tab (vertical panel first):**
 
 ```
 Session (default)
 └── Workspace: <project>
-    └── Tab: <root's tab>                 ← single view
-        ├── pane root   agent "orchestrator" / caller  ($HERDR_PANE_ID)
-        ├── pane right  agent "reviewer"               (split from root)
-        └── pane down   agent "tests"                  (split from root)
+    └── Tab: <root's tab>                 ← single grid view
+        ┌───────────────────────────┐
+        │ root (you)                │
+        ├─────────────┬─────────────┤
+        │ reviewer    │ tests       │
+        └─────────────┴─────────────┘
 ```
 
-Why this default: the human sees the **root agent and every sub-agent together**; the orchestrator is never displaced into a side tab; sidebar still rolls status per workspace.
+Why this default: the human sees the **root agent and every sub-agent together at usable sizes**; the orchestrator is never displaced into a side tab; sidebar still rolls status per workspace.
 
-### Spawn N sub-agents from the root pane
+### Spawn N sub-agents into a balanced grid
+
+Use `scripts/next_grid_split.py` before every split: it picks the **largest pane** (tie-break root) and a direction from that pane's aspect ratio.
 
 ```bash
 root_pane="${HERDR_PANE_ID:?}"
 root_tab="${HERDR_TAB_ID:?}"
 ws="${HERDR_WORKSPACE_ID:?}"
 project_dir=$(pwd)
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"  # when run from scripts/
+# or: here=skills/herdr-agent-comms/scripts
 
 spawn_sub() {
-  local name=$1 dir=$2 cmd=$3
-  local j pane
+  local name=$1 cmd=$2
+  local split_from dir j pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  j=$(herdr pane split "$root_pane" --direction "$dir" --cwd "$project_dir" --no-focus)
+  read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
+  j=$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)
   pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
-  herdr pane rename "$pane" "$name"
-  herdr agent rename "$pane" "$name"
-  herdr pane run "$pane" "$cmd"
+  herdr pane rename "$pane" "$name" >/dev/null
+  herdr agent rename "$pane" "$name" >/dev/null
+  herdr pane run "$pane" "$cmd" >/dev/null
   printf '%s\n' "$pane"
 }
 
-p_reviewer=$(spawn_sub reviewer right "pi --thinking medium")
-p_tests=$(spawn_sub tests down "pi --thinking low")
-# optional third: spawn_sub docs right "pi --thinking low"
+p_reviewer=$(spawn_sub reviewer "pi --thinking medium")
+p_tests=$(spawn_sub tests "pi --thinking low")
+# optional third: spawn_sub docs "pi --thinking low"
 ```
 
-### Split direction heuristics
+### Grid heuristics
 
-| Situation | Direction |
+| Step | Rule |
 |---|---|
-| First sub-agent | `right` |
-| Second sub-agent | `down` |
-| Wide source pane | prefer `right` |
-| Tall/narrow source pane | prefer `down` |
-| Unknown geometry | alternate `right`, `down`, `right`, … |
+| Target pane | largest area in the tab (`width * height`) |
+| Tie-break | prefer root pane |
+| Direction | **`down` if target height ≥ width** (vertical first), else `right` |
+| After each spawn | re-run the chooser — never hardcode a fixed dir sequence |
+| Focus | always `--no-focus` |
 
 ```bash
-herdr pane layout --pane "$root_pane"
+python3 scripts/next_grid_split.py --root-pane "$root_pane"
+herdr pane layout --pane "$root_pane"   # verify balanced rects
 ```
 
-Always pass **`--no-focus`** so the root agent keeps the keyboard while the fleet builds.
+Manual fallback without the helper: read `herdr pane layout`, pick the largest `rect`, split that pane with the aspect rule above.
 
-### Prefer `pane split` over `agent start` for anchoring
+### Prefer grid split over `agent start`
 
 | Command | When |
 |---|---|
-| `herdr pane split "$root_pane" --direction … --no-focus` | **Default** — split is guaranteed off the root pane |
-| `herdr agent start name --tab "$root_tab" --split right --no-focus -- …` | OK if you only care about same tab; may split relative to last focused pane |
+| `next_grid_split.py` + `herdr pane split … --no-focus` | **Default** — balanced grid including root |
+| `herdr agent start name --tab "$root_tab" --split right --no-focus -- …` | OK if you only care about same tab; may create slivers |
 
 ### When to use tab-per-agent instead
 
@@ -81,10 +89,11 @@ for name in reviewer tests docs; do
 done
 ```
 
-### Adding a log / shell pane beside the root
+### Adding a log / shell pane into the grid
 
 ```bash
-j=$(herdr pane split "$root_pane" --direction down --cwd "$project_dir" --no-focus)
+read -r split_from dir < <(python3 scripts/next_grid_split.py --root-pane "$root_pane")
+j=$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)
 pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
 herdr pane rename "$pane" logs
 herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'"
@@ -166,14 +175,26 @@ for t in "${targets[@]}"; do
   panes+=("$p")
 done
 
-for pane in "${panes[@]}"; do
-  herdr pane run "$pane" "$msg"
+tmpdir="$(mktemp -d)"
+markers=(); tasks=()
+for i in "${!panes[@]}"; do
+  herdr pane read "${panes[$i]}" --source recent-unwrapped --lines 80 >"$tmpdir/$i.baseline"
+  suffix="$(date +%s)_$$_${i}_$RANDOM"
+  markers+=("HERDR_DONE_$suffix")
+  tasks[$i]="$msg
+
+After fully finishing, concatenate and print: HERDR_DONE_ and $suffix"
+done
+for i in "${!panes[@]}"; do
+  herdr pane run "${panes[$i]}" "${tasks[$i]}"
 done
 
-for pane in "${panes[@]}"; do
-  python3 scripts/wait_for_idle.py "$pane" --timeout 180 &
+for i in "${!panes[@]}"; do
+  python3 scripts/wait_for_idle.py "${panes[$i]}" --timeout 180 --lines 80 \
+    --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
 done
 wait
+rm -rf "$tmpdir"
 ```
 
 Do **not** `agent send` and then `pane run` the same message (double submit). Do **not** wait only on `done` for the full budget when the tab is focused — agents often settle as `idle` (use `wait_for_idle.py` or idle|done polling).
@@ -183,14 +204,15 @@ Do **not** `agent send` and then `pane run` the same message (double submit). Do
 | Symptom | Check |
 |---|---|
 | CLI errors "server not running" | `herdr status`; user starts `herdr` once in a real TTY |
-| Sub-agent on a new tab | You used `tab create` — use `pane split "$root_pane"` instead |
+| Sub-agent on a new tab | You used `tab create` — use grid split in the root tab instead |
 | Root pane taken by worker | Never `pane run` the worker CLI on `$HERDR_PANE_ID` |
+| Thin sliver panes | Always split the largest pane via `next_grid_split.py` |
 | Agent always `unknown` | `herdr integration install <agent>`; `herdr agent explain <target>` |
 | Nested tmux breaks detection | Don't run tmux inside Herdr panes |
 | `pane run` typed but agent idle | `herdr pane send-keys $pane enter`; re-wait `working` |
 | Status stuck `working` | `pane read`; overall wait budget; escalate stall |
 | `blocked` | Human must answer dialog; `agent focus` to show it |
-| Panes too narrow | Fewer agents; alternate split directions; tab-per-agent only if user asks |
+| Panes too narrow | Fewer agents; rebalance by largest-pane splits; tab-per-agent only if user asks |
 | Wrong project files | Confirm `--cwd` before spawn |
 | Name not found | `herdr agent list`; names are unique session-wide |
 | Accidentally focused spawn | Pass `--no-focus` on `pane split` / `agent start` |
@@ -217,11 +239,11 @@ HERDR_LOG=herdr=debug herdr   # human client only
 
 | tmux | Herdr |
 |---|---|
-| `tmux split-window` from current | `herdr pane split "$root_pane" --direction right\|down --no-focus` |
+| `tmux split-window` from current | `next_grid_split.py` + `herdr pane split <largest> --direction right\|down --no-focus` |
 | session name | agent `name` + `pane_id` |
 | `tmux send-keys … Enter` | `herdr pane run` |
 | `tmux capture-pane -p -S -40` | `herdr pane read … --source recent-unwrapped --lines 40` |
 | `tmux has-session` | `herdr agent get` / `herdr pane get` |
 | `tmux kill-pane` (worker) | `herdr pane close` (sub-agent only) |
 | `tmux kill-server` | `herdr server stop` (confirm!) |
-| multiple app terminal tabs | **one** tab: root + split sub-agents |
+| multiple app terminal tabs | **one** tab grid: root + tiled sub-agents |

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -76,12 +76,12 @@ spawn_sub() {
   printf '%s\n' "$pane"
 }
 
-# Caller MUST check the status — `$(...)` hides it:
-#   p_reviewer="$(spawn_sub reviewer 'pi --thinking medium')" || { echo aborting >&2; exit 1; }
-
-p_reviewer=$(spawn_sub reviewer "pi --thinking medium")
-p_tests=$(spawn_sub tests "pi --thinking low")
-# optional third: spawn_sub docs "pi --thinking low"
+# Caller MUST check the status — `$(...)` hides spawn_sub's non-zero exit, so
+# a failed equalize would otherwise be ignored and the next spawn would build
+# on a broken layout. Abort the whole fleet spawn if any placement fails.
+p_reviewer=$(spawn_sub reviewer "pi --thinking medium") || { echo "reviewer failed to place; aborting" >&2; exit 1; }
+p_tests=$(spawn_sub tests "pi --thinking low") || { echo "tests failed to place; aborting" >&2; exit 1; }
+# optional third: p_docs=$(spawn_sub docs "pi --thinking low") || { echo "docs failed; aborting" >&2; exit 1; }
 ```
 
 ### Grid heuristics

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -109,15 +109,21 @@ for p in "${fleet[@]}"; do
   python3 "$here/wait_for_idle.py" "$p" --ready --timeout 60 --no-print &
   rpids+=("$!:$p")
 done
+ready_failed=0
 for e in "${rpids[@]}"; do
   jp="${e%%:*}"; pane="${e#*:}"
   if wait "$jp"; then echo "$pane: ready"
   else rc=$?
+    ready_failed=1   # any non-ready sub-agent fails the whole fleet spawn
     case "$rc" in 3) echo "$pane: BLOCKED — a human must answer a dialog" >&2 ;;
                   2) echo "$pane: not ready within 60s (timeout)" >&2 ;;
                   *) echo "$pane: readiness check failed (rc $rc)" >&2 ;; esac
   fi
 done
+# Do NOT assign work if any agent isn't ready — abort so a blocked/timed-out
+# pane never receives a task (a bare readiness loop that only echoes would let
+# the caller proceed as if the fleet were up).
+[ "$ready_failed" -eq 0 ] || { echo "Fleet not fully ready; aborting before task assignment." >&2; exit 1; }
 ```
 
 ### Grid heuristics
@@ -335,15 +341,31 @@ for t in "${targets[@]}"; do
   panes+=("$p"); labels+=("$t")
 done
 
-# Preflight: reject panes that are `working` (busy with unrelated prior work)
-# or `blocked` (trust/auth dialog — typing into it submits garbage, not a
-# task). Matches scripts/broadcast.sh Phase 1b.
-ready_panes=(); ready_labels=()
+# Preflight: reject panes that are `working`, `blocked`, or whose status we
+# can't verify (a failed/malformed `herdr pane get`). Matches
+# scripts/broadcast.sh Phase 1b — the status read is FAIL-CLOSED: a lookup or
+# parse failure returns non-zero (NOT an empty "safe" status), so an
+# unverifiable pane is skipped, never sent to. `skipped_any` folds every
+# skipped target into the final exit status so a mixed bad+good broadcast
+# does not report success.
+pane_status() {  # prints status, returns non-zero on lookup/parse failure
+  local out
+  out="$(herdr pane get "$1" 2>/dev/null)" || return 1
+  printf '%s' "$out" | python3 -c '
+import sys, json
+try: pane = json.load(sys.stdin)["result"]["pane"]
+except Exception: sys.exit(1)
+print(pane.get("agent_status") or "unknown")'
+}
+ready_panes=(); ready_labels=(); skipped_any=0
 for i in "${!panes[@]}"; do
-  st=$(herdr pane get "${panes[$i]}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
+  if ! st="$(pane_status "${panes[$i]}")"; then
+    echo "Error: '${labels[$i]}' (${panes[$i]}) status could not be verified — skipped." >&2
+    skipped_any=1; continue
+  fi
   case "$st" in
-    working) echo "Error: '${labels[$i]}' (${panes[$i]}) is already working — skipped." >&2; continue ;;
-    blocked) echo "Error: '${labels[$i]}' (${panes[$i]}) is blocked (trust/auth dialog) — skipped." >&2; continue ;;
+    working) echo "Error: '${labels[$i]}' (${panes[$i]}) is already working — skipped." >&2; skipped_any=1; continue ;;
+    blocked) echo "Error: '${labels[$i]}' (${panes[$i]}) is blocked (trust/auth dialog) — skipped." >&2; skipped_any=1; continue ;;
   esac
   ready_panes+=("${panes[$i]}"); ready_labels+=("${labels[$i]}")
 done
@@ -374,7 +396,9 @@ for i in "${!panes[@]}"; do
     --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
   pids+=("$!:${panes[$i]}")
 done
-overall=0
+# Seed the result with the preflight outcome: any busy/blocked/unverifiable
+# target that was skipped above must fail the whole broadcast, not vanish.
+overall="$skipped_any"
 for e in "${pids[@]}"; do
   jp="${e%%:*}"; pane="${e#*:}"
   if wait "$jp"; then echo "$pane: reply ready"

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -61,9 +61,11 @@ spawn_sub() {
   read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
   j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
   pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
-  tail -n +2 <<<"$plan" | while read -r _ pid share; do
-    [ "$pid" = "$pane" ] && continue
-    herdr pane resize --pane "$pid" --direction right --amount "$share" >/dev/null || true
+  # Resize every column, including the new one — don't rely on --ratio alone
+  # to have sized the new pane correctly.
+  herdr pane resize --pane "$pane" --direction right --amount "$ratio" >/dev/null || true
+  tail -n +2 <<<"$plan" | while read -r _ pid pshare; do
+    herdr pane resize --pane "$pid" --direction right --amount "$pshare" >/dev/null || true
   done
   herdr pane rename "$pane" "$name" >/dev/null
   herdr agent rename "$pane" "$name" >/dev/null
@@ -127,9 +129,11 @@ plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
 read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
 j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
 pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
-tail -n +2 <<<"$plan" | while read -r _ pid share; do
-  [ "$pid" = "$pane" ] && continue
-  herdr pane resize --pane "$pid" --direction right --amount "$share" >/dev/null || true
+# Resize every column, including the new one — don't rely on --ratio alone
+# to have sized the new pane correctly.
+herdr pane resize --pane "$pane" --direction right --amount "$ratio" >/dev/null || true
+tail -n +2 <<<"$plan" | while read -r _ pid pshare; do
+  herdr pane resize --pane "$pid" --direction right --amount "$pshare" >/dev/null || true
 done
 herdr pane rename "$pane" logs
 herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'"

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -55,25 +55,42 @@ for cand in \
 done
 [ -n "$here" ] || { echo "Error: next_grid_split.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 
+# Canonical guarded spawn: every critical step is checked, the pane id is
+# printed ONLY after a successful launch + readiness, and any failure returns
+# non-zero (naming the orphan split pane) so the caller can abort. Note the
+# `local` declarations are separate from the assignments — `local pane=$(...)`
+# would mask the substitution's exit status.
 spawn_sub() {
   local name=$1 cmd=$2
   local plan split_from ratio j pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
   # plan line: "split <rightmost> right --ratio <1/N>" (new right pane -> 1/N target)
-  plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
+  plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane") || {
+    echo "Error: planning split failed for '$name' (bad/unsupported layout?)." >&2; return 1; }
   read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
-  j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
-  pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
+  [ -n "$split_from" ] && [ -n "$ratio" ] || {
+    echo "Error: empty plan for '$name'; refusing to split." >&2; return 1; }
+  j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus) || {
+    echo "Error: 'herdr pane split $split_from' failed for '$name'." >&2; return 1; }
+  pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])') || {
+    echo "Error: could not parse pane id from split output for '$name'." >&2; return 1; }
+  [ -n "$pane" ] || { echo "Error: empty pane id for '$name'." >&2; return 1; }
   # Equalize all columns — HARD GATE: on failure return non-zero WITHOUT
   # launching or printing a pane id, so the caller aborts (no `|| true`).
   if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >&2; then
-    echo "Error: equalize failed for '$name'; orphan split pane $pane not launched. Inspect 'herdr pane layout --pane $root_pane'." >&2
+    echo "Error: equalize failed for '$name'; orphan split pane $pane not launched. 'herdr pane close $pane' to undo." >&2
     return 1
   fi
-  herdr pane rename "$pane" "$name" >/dev/null
-  herdr agent rename "$pane" "$name" >/dev/null
-  herdr pane run "$pane" "$cmd" >/dev/null
-  printf '%s\n' "$pane"
+  herdr pane rename "$pane" "$name" >/dev/null || { echo "Error: rename failed; orphan $pane." >&2; return 1; }
+  herdr agent rename "$pane" "$name" >/dev/null || { echo "Error: agent rename failed; orphan $pane." >&2; return 1; }
+  herdr pane run "$pane" "$cmd" >/dev/null || { echo "Error: launch failed; orphan $pane." >&2; return 1; }
+  # Readiness: treat a boot timeout as failure so the caller doesn't message a
+  # dead pane. (Agents without status integration will time out here — the
+  # orphan is named so it's recoverable; drop this line if you rely on the
+  # content-stability fallback instead.)
+  herdr wait agent-status "$pane" --status idle --timeout 60000 >/dev/null || {
+    echo "Error: '$name' ($pane) not ready within 60s; orphan not confirmed launched." >&2; return 1; }
+  printf '%s\n' "$pane"   # ONLY after everything above succeeded
 }
 
 # Caller MUST check the status — `$(...)` hides spawn_sub's non-zero exit, so
@@ -181,10 +198,12 @@ done
 
 ```bash
 # $here from the resolver above (or re-probe if starting fresh in this shell)
-plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
+plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane") || { echo "Error: split planning failed." >&2; exit 1; }
 read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
-j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
-pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
+[ -n "$split_from" ] && [ -n "$ratio" ] || { echo "Error: empty split plan." >&2; exit 1; }
+j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus) || { echo "Error: pane split failed." >&2; exit 1; }
+pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])') || { echo "Error: could not parse pane id." >&2; exit 1; }
+[ -n "$pane" ] || { echo "Error: empty pane id." >&2; exit 1; }
 # Equalize all columns — HARD GATE: abort (and close the orphan pane) rather
 # than run the log tail into an uneven layout.
 if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane"; then
@@ -192,8 +211,8 @@ if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane"; the
   herdr pane close "$pane" >/dev/null 2>&1 || true
   exit 1
 fi
-herdr pane rename "$pane" logs
-herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'"
+herdr pane rename "$pane" logs || { echo "Error: rename failed; orphan $pane." >&2; exit 1; }
+herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'" || { echo "Error: launch failed; orphan $pane." >&2; exit 1; }
 ```
 
 ## Sending multi-line or code-heavy messages

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -36,15 +36,19 @@ ws="${HERDR_WORKSPACE_ID:?}"
 project_dir=$(pwd)
 # Resolve scripts/ by probing known install locations. Don't derive from
 # $0/BASH_SOURCE here — unreliable when an agent runs this inline rather
-# than as a saved script file.
+# than as a saved script file. Repo-local copies win over global installs
+# so a pinned repo checkout isn't silently overridden by whatever version
+# happens to be installed globally.
 here=""
 for cand in \
-  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "skills/herdr-agent-comms/scripts" \
+  ".agents/skills/herdr-agent-comms/scripts" \
   ".claude/skills/herdr-agent-comms/scripts" \
-  "$HOME/.agents/skills/herdr-agent-comms/scripts" \
-  "skills/herdr-agent-comms/scripts"; do
+  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
   if [ -f "$cand/next_grid_split.py" ]; then here="$cand"; break; fi
 done
+[ -n "$here" ] || { echo "Error: next_grid_split.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 
 spawn_sub() {
   local name=$1 cmd=$2
@@ -180,27 +184,58 @@ Prefer `recent-unwrapped` for agent transcripts. Widen `--lines` stepwise if tru
 
 ## Broadcast pattern (manual)
 
-Prefer `scripts/broadcast.sh`. Manual equivalent:
+Prefer `scripts/broadcast.sh` — it already resolves paths, dedupes, and rejects
+busy/blocked panes. The manual equivalent below exists for when the script is
+unavailable and must **replicate the same safeguards**, not skip them:
 
 ```bash
+# Repo-local copies win over global installs (see Phase 2a). Fail fast if
+# unresolved — do not silently continue with an empty $here.
 here=""
 for cand in \
-  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "skills/herdr-agent-comms/scripts" \
+  ".agents/skills/herdr-agent-comms/scripts" \
   ".claude/skills/herdr-agent-comms/scripts" \
-  "$HOME/.agents/skills/herdr-agent-comms/scripts" \
-  "skills/herdr-agent-comms/scripts"; do
+  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
   if [ -f "$cand/wait_for_idle.py" ]; then here="$cand"; break; fi
 done
+[ -n "$here" ] || { echo "Error: wait_for_idle.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 
 targets=(reviewer tests docs)
 msg="Pull latest main and report branch + dirty state."
 
-# Resolve names → pane ids once, then single pane run each
-panes=()
+# Resolve names → pane ids, deduping so a name and its own pane-id alias
+# (e.g. "reviewer" and "w26:p4") don't double-send.
+panes=(); labels=()
 for t in "${targets[@]}"; do
   p=$(herdr agent get "$t" | python3 -c 'import sys,json; d=json.load(sys.stdin); a=d.get("result",{}).get("agent") or d.get("result",{}); print(a["pane_id"])')
-  panes+=("$p")
+  [ -n "$p" ] || { echo "Error: target '$t' does not resolve — herdr agent list" >&2; exit 1; }
+  dup=""
+  for existing in "${panes[@]+"${panes[@]}"}"; do
+    [ "$existing" = "$p" ] && { dup=1; break; }
+  done
+  if [ -n "$dup" ]; then
+    echo "Note: '$t' resolves to an already-targeted pane $p — skipping duplicate." >&2
+    continue
+  fi
+  panes+=("$p"); labels+=("$t")
 done
+
+# Preflight: reject panes that are `working` (busy with unrelated prior work)
+# or `blocked` (trust/auth dialog — typing into it submits garbage, not a
+# task). Matches scripts/broadcast.sh Phase 1b.
+ready_panes=(); ready_labels=()
+for i in "${!panes[@]}"; do
+  st=$(herdr pane get "${panes[$i]}" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["pane"].get("agent_status",""))')
+  case "$st" in
+    working) echo "Error: '${labels[$i]}' (${panes[$i]}) is already working — skipped." >&2; continue ;;
+    blocked) echo "Error: '${labels[$i]}' (${panes[$i]}) is blocked (trust/auth dialog) — skipped." >&2; continue ;;
+  esac
+  ready_panes+=("${panes[$i]}"); ready_labels+=("${labels[$i]}")
+done
+panes=("${ready_panes[@]+"${ready_panes[@]}"}"); labels=("${ready_labels[@]+"${ready_labels[@]}"}")
+[ "${#panes[@]}" -gt 0 ] || { echo "Error: no targets left to send to." >&2; exit 1; }
 
 tmpdir="$(mktemp -d)"
 markers=(); tasks=()
@@ -224,7 +259,7 @@ wait
 rm -rf "$tmpdir"
 ```
 
-Do **not** `agent send` and then `pane run` the same message (double submit). Do **not** wait only on `done` for the full budget when the tab is focused — agents often settle as `idle` (use `wait_for_idle.py` or idle|done polling).
+Do **not** `agent send` and then `pane run` the same message (double submit). Do **not** wait only on `done` for the full budget when the tab is focused — agents often settle as `idle` (use `wait_for_idle.py` or idle|done polling). Do **not** drop the dedupe or busy/blocked preflight from this manual path — that would reintroduce double-sends and dialog-clobbering that `scripts/broadcast.sh` exists to prevent.
 
 ## Troubleshooting
 

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -398,16 +398,22 @@ for i in "${!panes[@]}"; do
     echo "Error: ${panes[$i]} became unsafe (${st:-unverifiable}) before dispatch — skipped." >&2
     became_unsafe+=("$i"); continue
   fi
-  herdr pane run "${panes[$i]}" "${tasks[$i]}" || send_failed+=("${panes[$i]}")
+  # Record a failed send BY INDEX (not pane id) so the wait loop below, which
+  # iterates indices, can actually exclude it — a name-keyed entry would never
+  # match `$i` and the failed target would get a pointless completion waiter.
+  herdr pane run "${panes[$i]}" "${tasks[$i]}" || send_failed+=("$i")
 done
 
 # Retain each waiter's exit status — a bare `wait` masks timeouts (rc 2) and
 # blocked (rc 3), so the whole broadcast would "succeed" with agents stuck.
-# Wait only on panes actually dispatched (skip became_unsafe / send_failed).
+# Wait only on panes actually dispatched (skip BOTH send_failed and
+# became_unsafe — both are index lists).
 pids=()
 for i in "${!panes[@]}"; do
   skip=""
-  for f in ${became_unsafe[@]+"${became_unsafe[@]}"}; do [ "$f" = "$i" ] && { skip=1; break; }; done
+  for f in ${send_failed[@]+"${send_failed[@]}"} ${became_unsafe[@]+"${became_unsafe[@]}"}; do
+    [ "$f" = "$i" ] && { skip=1; break; }
+  done
   [ -n "$skip" ] && continue
   python3 "$here/wait_for_idle.py" "${panes[$i]}" --timeout 180 --lines 80 \
     --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
@@ -418,7 +424,7 @@ done
 # whole broadcast, not vanish.
 overall="$skipped_any"
 [ "${#became_unsafe[@]}" -eq 0 ] || overall=1
-for e in "${pids[@]}"; do
+for e in ${pids[@]+"${pids[@]}"}; do
   jp="${e%%:*}"; pane="${e#*:}"
   if wait "$jp"; then echo "$pane: reply ready"
   else rc=$?
@@ -428,7 +434,11 @@ for e in "${pids[@]}"; do
     overall=1
   fi
 done
-[ "${#send_failed[@]}" -eq 0 ] || { echo "Send failed for: ${send_failed[*]}" >&2; overall=1; }
+# send_failed holds INDICES — map back to pane ids for the report.
+if [ "${#send_failed[@]}" -gt 0 ]; then
+  for i in "${send_failed[@]}"; do echo "Send failed for: ${panes[$i]}" >&2; done
+  overall=1
+fi
 exit "$overall"
 ```
 

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -4,30 +4,32 @@ Read this when you need layout variants, multi-line sends, human steer/focus, sc
 
 ## Default fleet layout (this skill)
 
-**Root + sub-agents as a tiled grid in one tab (vertical panel first):**
+**Root + sub-agents as equal-width columns in one tab:**
 
 ```
 Session (default)
 └── Workspace: <project>
-    └── Tab: <root's tab>                 ← single grid view
-        ┌─────────────┬─────────────┐
-        │ root (you)  │ tests       │
-        ├─────────────┴─────────────┤
-        │ reviewer                  │
-        └────────────────────────────┘
+    └── Tab: <root's tab>                          ← single row of columns
+        ┌───────────┬───────────┬───────────┐
+        │ root (you)│ reviewer  │ tests      │
+        └───────────┴───────────┴───────────┘
 ```
 
-(`next_grid_split.py` always retargets the largest pane, so which sub-agent
-lands where depends on split order and live geometry — root can end up
-top-left rather than a full-width top strip. Either way root starts on top
-after the first, always-`down` split, and stays in the grid at a comparable
-size to its workers.)
+(`next_grid_split.py` always targets the current rightmost column and plans
+a resize for every column, so root and every sub-agent stay the same width
+no matter how many are spawned — never a wide root next to narrow workers,
+or vice versa.)
 
-Why this default: the human sees the **root agent and every sub-agent together at usable sizes**; the orchestrator is never displaced into a side tab; sidebar still rolls status per workspace.
+Why this default: the human sees the **root agent and every sub-agent at the
+same size**; the orchestrator is never displaced into a side tab or left
+oddly wide/narrow; sidebar still rolls status per workspace.
 
-### Spawn N sub-agents into a balanced grid
+### Spawn N sub-agents into an equal-width grid
 
-Use `scripts/next_grid_split.py` before every split: it picks the **largest pane** (tie-break root) and a direction from that pane's aspect ratio.
+Use `scripts/next_grid_split.py` before every split: it always targets the
+**current rightmost column** and emits a full plan — the split ratio for the
+new pane, plus a resize line for every existing column so all of them
+(including root) converge to the same `1/N` share.
 
 ```bash
 root_pane="${HERDR_PANE_ID:?}"
@@ -52,11 +54,17 @@ done
 
 spawn_sub() {
   local name=$1 cmd=$2
-  local split_from dir j pane
+  local plan split_from ratio j pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
-  j=$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)
+  # plan: line 1 "split <rightmost> right --ratio <share>", rest "resize <pane> <share>"
+  plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
+  read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
+  j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
   pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
+  tail -n +2 <<<"$plan" | while read -r _ pid share; do
+    [ "$pid" = "$pane" ] && continue
+    herdr pane resize --pane "$pid" --direction right --amount "$share" >/dev/null || true
+  done
   herdr pane rename "$pane" "$name" >/dev/null
   herdr agent rename "$pane" "$name" >/dev/null
   herdr pane run "$pane" "$cmd" >/dev/null
@@ -72,27 +80,28 @@ p_tests=$(spawn_sub tests "pi --thinking low")
 
 | Step | Rule |
 |---|---|
-| Target pane | largest area in the tab (`width * height`) |
-| Tie-break | prefer root pane |
-| Direction (first split) | always `down` — vertical panel first, independent of aspect |
-| Direction (later splits) | `down` if target height ≥ width, else `right` |
-| After each spawn | re-run the chooser — never hardcode a fixed dir sequence |
+| Target pane | current rightmost column (`rect.x` order) |
+| Direction | always `right` — one row of columns, never `down` |
+| After each spawn | resize **every** column (including root) to `1/N`, N = new column count |
+| Re-run per spawn | never hardcode a fixed ratio/amount — it shrinks every time |
 | Focus | always `--no-focus` |
 
 ```bash
 # $here from the resolver above (or re-probe if starting fresh in this shell)
 python3 "$here/next_grid_split.py" --root-pane "$root_pane"
-herdr pane layout --pane "$root_pane"   # verify balanced rects
+herdr pane layout --pane "$root_pane"   # verify equal-width rects
 ```
 
-Manual fallback without the helper: read `herdr pane layout`, pick the largest `rect`, split that pane with the aspect rule above.
+Manual fallback without the helper: read `herdr pane layout`, order panes by `rect.x`, split the rightmost one `right`, then resize every column (new + pre-existing) to `1 / (existing_count + 1)`.
+
+**Verification caveat:** `herdr pane split --ratio` / `herdr pane resize --amount` semantics (fraction of remaining space vs. absolute tab fraction) are not confirmed against a live `herdr` server by this skill's tests. Check `herdr pane layout` after a spawn to confirm the rects actually came out equal width.
 
 ### Prefer grid split over `agent start`
 
 | Command | When |
 |---|---|
-| `next_grid_split.py` + `herdr pane split … --no-focus` | **Default** — balanced grid including root |
-| `herdr agent start name --tab "$root_tab" --split right --no-focus -- …` | OK if you only care about same tab; may create slivers |
+| `next_grid_split.py` + `herdr pane split` + `herdr pane resize` … `--no-focus` | **Default** — equal-width grid including root |
+| `herdr agent start name --tab "$root_tab" --split right --no-focus -- …` | OK if you only care about same tab; leaves unequal widths unless you resize manually afterward |
 
 ### When to use tab-per-agent instead
 
@@ -114,9 +123,14 @@ done
 
 ```bash
 # $here from the resolver above (or re-probe if starting fresh in this shell)
-read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
-j=$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)
+plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
+read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
+j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
 pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
+tail -n +2 <<<"$plan" | while read -r _ pid share; do
+  [ "$pid" = "$pane" ] && continue
+  herdr pane resize --pane "$pid" --direction right --amount "$share" >/dev/null || true
+done
 herdr pane rename "$pane" logs
 herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'"
 ```
@@ -268,13 +282,13 @@ Do **not** `agent send` and then `pane run` the same message (double submit). Do
 | CLI errors "server not running" | `herdr status`; user starts `herdr` once in a real TTY |
 | Sub-agent on a new tab | You used `tab create` — use grid split in the root tab instead |
 | Root pane taken by worker | Never `pane run` the worker CLI on `$HERDR_PANE_ID` |
-| Thin sliver panes | Always split the largest pane via `next_grid_split.py` |
+| Unequal-width columns | Always split the current rightmost column and apply the full resize plan from `next_grid_split.py` |
 | Agent always `unknown` | `herdr integration install <agent>`; `herdr agent explain <target>` |
 | Nested tmux breaks detection | Don't run tmux inside Herdr panes |
 | `pane run` typed but agent idle | `herdr pane send-keys $pane enter`; re-wait `working` |
 | Status stuck `working` | `pane read`; overall wait budget; escalate stall |
 | `blocked` | Human must answer dialog; `agent focus` to show it |
-| Panes too narrow | Fewer agents; rebalance by largest-pane splits; tab-per-agent only if user asks |
+| Panes too narrow | Fewer agents (equal-width columns shrink every time); tab-per-agent only if user asks |
 | Wrong project files | Confirm `--cwd` before spawn |
 | Name not found | `herdr agent list`; names are unique session-wide |
 | Accidentally focused spawn | Pass `--no-focus` on `pane split` / `agent start` |
@@ -301,7 +315,7 @@ HERDR_LOG=herdr=debug herdr   # human client only
 
 | tmux | Herdr |
 |---|---|
-| `tmux split-window` from current | `next_grid_split.py` + `herdr pane split <largest> --direction right\|down --no-focus` |
+| `tmux split-window` from current | `next_grid_split.py` + `herdr pane split <rightmost> --direction right --no-focus` + `herdr pane resize` on every column |
 | session name | agent `name` + `pane_id` |
 | `tmux send-keys … Enter` | `herdr pane run` |
 | `tmux capture-pane -p -S -40` | `herdr pane read … --source recent-unwrapped --lines 40` |

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -386,22 +386,38 @@ for i in "${!panes[@]}"; do
 
 After fully finishing, concatenate and print: HERDR_DONE_ and $suffix"
 done
-send_failed=()
+send_failed=(); became_unsafe=()
 for i in "${!panes[@]}"; do
+  # Recheck status IMMEDIATELY before dispatch — same enum-validated pane_status
+  # broadcast.sh re-runs here. The preflight above ran before baseline capture
+  # and task prep, so a target could have turned working/blocked (or become
+  # unverifiable) in that window; sending now would clobber a dialog or race a
+  # prior task. Skip it and fold it into the failure count.
+  if ! st="$(pane_status "${panes[$i]}")" \
+     || [ "$st" = "working" ] || [ "$st" = "blocked" ]; then
+    echo "Error: ${panes[$i]} became unsafe (${st:-unverifiable}) before dispatch — skipped." >&2
+    became_unsafe+=("$i"); continue
+  fi
   herdr pane run "${panes[$i]}" "${tasks[$i]}" || send_failed+=("${panes[$i]}")
 done
 
 # Retain each waiter's exit status — a bare `wait` masks timeouts (rc 2) and
 # blocked (rc 3), so the whole broadcast would "succeed" with agents stuck.
+# Wait only on panes actually dispatched (skip became_unsafe / send_failed).
 pids=()
 for i in "${!panes[@]}"; do
+  skip=""
+  for f in ${became_unsafe[@]+"${became_unsafe[@]}"}; do [ "$f" = "$i" ] && { skip=1; break; }; done
+  [ -n "$skip" ] && continue
   python3 "$here/wait_for_idle.py" "${panes[$i]}" --timeout 180 --lines 80 \
     --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
   pids+=("$!:${panes[$i]}")
 done
 # Seed the result with the preflight outcome: any busy/blocked/unverifiable
-# target that was skipped above must fail the whole broadcast, not vanish.
+# target skipped above (at preflight OR the pre-dispatch recheck) must fail the
+# whole broadcast, not vanish.
 overall="$skipped_any"
+[ "${#became_unsafe[@]}" -eq 0 ] || overall=1
 for e in "${pids[@]}"; do
   jp="${e%%:*}"; pane="${e#*:}"
   if wait "$jp"; then echo "$pane: reply ready"

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -4,62 +4,66 @@ Read this when you need layout variants, multi-line sends, human steer/focus, sc
 
 ## Default fleet layout (this skill)
 
-**One fleet tab, split pane per agent** — all agents visible in a single view:
+**Root agent pane + sub-agents split from root — one tab:**
 
 ```
 Session (default)
-└── Workspace: <project>                 ← one per repo
-    └── Tab: fleet
-        ├── pane wN:pA  agent "reviewer"
-        ├── pane wN:pB  agent "tests"     (split right)
-        └── pane wN:pC  agent "docs"      (split down)
+└── Workspace: <project>
+    └── Tab: <root's tab>                 ← single view
+        ├── pane root   agent "orchestrator" / caller  ($HERDR_PANE_ID)
+        ├── pane right  agent "reviewer"               (split from root)
+        └── pane down   agent "tests"                  (split from root)
 ```
 
-Why splits by default: the human sees the whole fleet without switching tabs; sidebar still rolls status up per workspace. Use tab-per-agent only when the user wants a full viewport per agent.
+Why this default: the human sees the **root agent and every sub-agent together**; the orchestrator is never displaced into a side tab; sidebar still rolls status per workspace.
 
-### Create workspace + three-agent fleet (splits)
+### Spawn N sub-agents from the root pane
 
 ```bash
-project_dir=/path/to/project
-label=$(basename "$project_dir")
-ws=$(herdr workspace create --cwd "$project_dir" --label "$label" --no-focus \
-  | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["workspace"]["workspace_id"])')
+root_pane="${HERDR_PANE_ID:?}"
+root_tab="${HERDR_TAB_ID:?}"
+ws="${HERDR_WORKSPACE_ID:?}"
+project_dir=$(pwd)
 
-tab_json=$(herdr tab create --workspace "$ws" --cwd "$project_dir" --label fleet --no-focus)
-fleet_tab=$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["tab"]["tab_id"])')
-root=$(printf '%s' "$tab_json" | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["root_pane"]["pane_id"])')
+spawn_sub() {
+  local name=$1 dir=$2 cmd=$3
+  local j pane
+  herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
+  j=$(herdr pane split "$root_pane" --direction "$dir" --cwd "$project_dir" --no-focus)
+  pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
+  herdr pane rename "$pane" "$name"
+  herdr agent rename "$pane" "$name"
+  herdr pane run "$pane" "$cmd"
+  printf '%s\n' "$pane"
+}
 
-# Agent 1 on root pane
-herdr pane rename "$root" reviewer
-herdr agent rename "$root" reviewer
-herdr pane run "$root" "pi --thinking medium"
-
-# Agent 2 / 3 via agent start + split (same tab)
-herdr agent start tests --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
-  --split right --no-focus -- pi --thinking low
-herdr agent start docs --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
-  --split down --no-focus -- pi --thinking low
-
-herdr tab focus "$fleet_tab"   # show the whole board
+p_reviewer=$(spawn_sub reviewer right "pi --thinking medium")
+p_tests=$(spawn_sub tests down "pi --thinking low")
+# optional third: spawn_sub docs right "pi --thinking low"
 ```
 
 ### Split direction heuristics
 
 | Situation | Direction |
 |---|---|
-| 2 agents | first extra: `right` |
-| 3 agents | `right` then `down` |
-| Wide pane | prefer `right` |
-| Tall/narrow pane | prefer `down` |
+| First sub-agent | `right` |
+| Second sub-agent | `down` |
+| Wide source pane | prefer `right` |
+| Tall/narrow source pane | prefer `down` |
 | Unknown geometry | alternate `right`, `down`, `right`, … |
 
-Inspect geometry when available:
-
 ```bash
-herdr pane layout --pane "$pane_id"
+herdr pane layout --pane "$root_pane"
 ```
 
-Avoid repeating the same direction for every split (creates unusable slivers).
+Always pass **`--no-focus`** so the root agent keeps the keyboard while the fleet builds.
+
+### Prefer `pane split` over `agent start` for anchoring
+
+| Command | When |
+|---|---|
+| `herdr pane split "$root_pane" --direction … --no-focus` | **Default** — split is guaranteed off the root pane |
+| `herdr agent start name --tab "$root_tab" --split right --no-focus -- …` | OK if you only care about same tab; may split relative to last focused pane |
 
 ### When to use tab-per-agent instead
 
@@ -77,11 +81,13 @@ for name in reviewer tests docs; do
 done
 ```
 
-### Adding a log / shell pane beside the fleet
+### Adding a log / shell pane beside the root
 
 ```bash
-herdr agent start logs --cwd "$project_dir" --workspace "$ws" --tab "$fleet_tab" \
-  --split down --no-focus -- bash -lc 'tail -f /tmp/app.log'
+j=$(herdr pane split "$root_pane" --direction down --cwd "$project_dir" --no-focus)
+pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
+herdr pane rename "$pane" logs
+herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'"
 ```
 
 ## Sending multi-line or code-heavy messages
@@ -108,7 +114,6 @@ herdr pane run "$pane_id" "Read $task_file and follow its instructions. Delete t
 
 ```bash
 herdr pane send-text "$pane_id" "line one"
-# For multi-line, prefer Pattern A. send-text is literal; then:
 herdr pane send-keys "$pane_id" enter
 ```
 
@@ -125,13 +130,13 @@ Remember: `agent send` does **not** append Enter; `pane run` does.
 
 | Goal | Command |
 |---|---|
-| Show whole fleet board | `herdr tab focus "$fleet_tab"` |
-| Jump UI to one agent pane | `herdr agent focus reviewer` |
-| Jump to workspace | `herdr workspace focus w26` |
+| Stay on whole board | already one tab (root + subs) |
+| Jump UI to one sub-agent | `herdr agent focus reviewer` |
+| Jump back toward root | click root pane / focus root pane id |
 | Attach/takeover terminal | `herdr agent attach reviewer` (optional `--takeover`) |
 | Read without stealing focus | `herdr agent read reviewer --source recent-unwrapped --lines 80` |
 
-Orchestrator rule: use `--no-focus` on create/split/start so fleet spawn doesn't yank the human away mid-layout. After spawn, **focus the fleet tab once** so all panes are visible. Focus a single agent only when they ask to type into it or to dismiss a `blocked` dialog.
+Orchestrator rule: use `--no-focus` on every split/start so fleet spawn doesn't yank focus off the root agent. Focus a sub-agent only when the human wants to type or dismiss a `blocked` dialog.
 
 Detach Herdr client (leave agents running): `prefix+q` (`ctrl+b` then `q`). Reattach: `herdr` in a terminal.
 
@@ -139,58 +144,50 @@ Detach Herdr client (leave agents running): `prefix+q` (`ctrl+b` then `q`). Reat
 
 ```bash
 herdr pane read "$pane_id" --source recent-unwrapped --lines 80
-herdr pane read "$pane_id" --source recent-unwrapped --lines 200   # widen if truncated
-herdr pane read "$pane_id" --source visible --lines 50             # viewport only
-herdr pane read "$pane_id" --source detection                      # detector bottom buffer
+herdr pane read "$pane_id" --source recent-unwrapped --lines 200
+herdr pane read "$pane_id" --source visible --lines 50
+herdr pane read "$pane_id" --source detection
 ```
 
-Prefer `recent-unwrapped` for agent transcripts (soft wraps joined). Use `--format ansi` only when colors are evidence.
-
-If the answer clearly started above the window, increase `--lines` stepwise (80 → 160 → 300). There is no unbounded dump flag — widen deliberately.
+Prefer `recent-unwrapped` for agent transcripts. Widen `--lines` stepwise if truncated.
 
 ## Broadcast pattern (manual)
 
-Same idea as `scripts/broadcast.sh` (preferred one-liner: `scripts/broadcast.sh "$msg" reviewer tests docs`):
+Prefer `scripts/broadcast.sh`. Manual equivalent:
 
 ```bash
 targets=(reviewer tests docs)
 msg="Pull latest main and report branch + dirty state."
 
-# Resolve names → pane ids once (agent send is text-only; pane run submits Enter)
-panes=()
-for t in "${targets[@]}"; do
-  p=$(herdr agent get "$t" | python3 -c 'import sys,json; d=json.load(sys.stdin); a=d.get("result",{}).get("agent") or d.get("result",{}); print(a["pane_id"])')
-  panes+=("$p")
-done
-
-# Send once per pane (do NOT also agent-send the same message)
+# Resolve names → pane ids once, then single pane run each
 for pane in "${panes[@]}"; do
   herdr pane run "$pane" "$msg"
 done
 
-# Concurrent completion: idle OR done (focused fleet tabs finish as idle)
 for pane in "${panes[@]}"; do
   python3 scripts/wait_for_idle.py "$pane" --timeout 180 &
 done
 wait
 ```
 
-Never wait only on `done` for the full budget after `herdr tab focus` — the fleet view is focused, so agents settle as `idle`.
+Do **not** `agent send` and then `pane run` the same message (double submit). Do **not** wait only on `done` for the full budget when the tab is focused — agents often settle as `idle` (use `wait_for_idle.py` or idle|done polling).
 
 ## Troubleshooting
 
 | Symptom | Check |
 |---|---|
 | CLI errors "server not running" | `herdr status`; user starts `herdr` once in a real TTY |
+| Sub-agent on a new tab | You used `tab create` — use `pane split "$root_pane"` instead |
+| Root pane taken by worker | Never `pane run` the worker CLI on `$HERDR_PANE_ID` |
 | Agent always `unknown` | `herdr integration install <agent>`; `herdr agent explain <target>` |
 | Nested tmux breaks detection | Don't run tmux inside Herdr panes |
-| `pane run` typed but agent idle | Send `herdr pane send-keys $pane enter`; re-wait `working` |
+| `pane run` typed but agent idle | `herdr pane send-keys $pane enter`; re-wait `working` |
 | Status stuck `working` | `pane read`; overall wait budget; escalate stall |
 | `blocked` | Human must answer dialog; `agent focus` to show it |
-| Panes too narrow | Fewer agents per tab, or tab-per-agent layout; alternate split directions |
-| Wrong project files | Confirm `--cwd` and workspace label before spawn |
+| Panes too narrow | Fewer agents; alternate split directions; tab-per-agent only if user asks |
+| Wrong project files | Confirm `--cwd` before spawn |
 | Name not found | `herdr agent list`; names are unique session-wide |
-| Accidentally focused spawn | Pass `--no-focus` on `tab create` / `agent start` / `pane split` |
+| Accidentally focused spawn | Pass `--no-focus` on `pane split` / `agent start` |
 
 ### Debug one pane
 
@@ -214,11 +211,11 @@ HERDR_LOG=herdr=debug herdr   # human client only
 
 | tmux | Herdr |
 |---|---|
-| `tmux new-session -s name` | `herdr agent start … --split …` (or root pane of fleet tab) |
+| `tmux split-window` from current | `herdr pane split "$root_pane" --direction right\|down --no-focus` |
 | session name | agent `name` + `pane_id` |
 | `tmux send-keys … Enter` | `herdr pane run` |
 | `tmux capture-pane -p -S -40` | `herdr pane read … --source recent-unwrapped --lines 40` |
 | `tmux has-session` | `herdr agent get` / `herdr pane get` |
-| `tmux kill-session` | `herdr pane close` / `herdr tab close` (fleet tab) |
+| `tmux kill-pane` (worker) | `herdr pane close` (sub-agent only) |
 | `tmux kill-server` | `herdr server stop` (confirm!) |
-| multiple app terminal tabs | one fleet tab with tiled panes (default) |
+| multiple app terminal tabs | **one** tab: root + split sub-agents |

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -15,10 +15,10 @@ Session (default)
         └───────────┴───────────┴───────────┘
 ```
 
-(`next_grid_split.py` always targets the current rightmost column and plans
-a resize for every column, so root and every sub-agent stay the same width
-no matter how many are spawned — never a wide root next to narrow workers,
-or vice versa.)
+(`next_grid_split.py` always targets the current rightmost column for the
+split, then its `--equalize` pass re-converges every column to the same
+width no matter how many are spawned — never a wide root next to narrow
+workers, or vice versa. Columns end equal within ~1 terminal cell.)
 
 Why this default: the human sees the **root agent and every sub-agent at the
 same size**; the orchestrator is never displaced into a side tab or left
@@ -26,10 +26,11 @@ oddly wide/narrow; sidebar still rolls status per workspace.
 
 ### Spawn N sub-agents into an equal-width grid
 
-Use `scripts/next_grid_split.py` before every split: it always targets the
-**current rightmost column** and emits a full plan — the split ratio for the
-new pane, plus a resize line for every existing column so all of them
-(including root) converge to the same `1/N` share.
+Use `scripts/next_grid_split.py` for every spawn: the default run emits the
+split line targeting the **current rightmost column** (`--ratio (N-1)/N`, so
+the new pane is born at the `1/N` target share), and `--equalize` runs the
+live iterative equalizer that re-converges every column (including root) to
+the same width.
 
 ```bash
 root_pane="${HERDR_PANE_ID:?}"
@@ -56,17 +57,13 @@ spawn_sub() {
   local name=$1 cmd=$2
   local plan split_from ratio j pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  # plan: line 1 "split <rightmost> right --ratio <share>", rest "resize <pane> <share>"
+  # plan line: "split <rightmost> right --ratio <(N-1)/N>" (new pane born at 1/N)
   plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
   read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
   j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
   pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
-  # Resize every column, including the new one — don't rely on --ratio alone
-  # to have sized the new pane correctly.
-  herdr pane resize --pane "$pane" --direction right --amount "$ratio" >/dev/null || true
-  tail -n +2 <<<"$plan" | while read -r _ pid pshare; do
-    herdr pane resize --pane "$pid" --direction right --amount "$pshare" >/dev/null || true
-  done
+  # Equalize all columns — a split alone leaves the pre-existing columns wide.
+  python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >/dev/null 2>&1 || true
   herdr pane rename "$pane" "$name" >/dev/null
   herdr agent rename "$pane" "$name" >/dev/null
   herdr pane run "$pane" "$cmd" >/dev/null
@@ -84,26 +81,65 @@ p_tests=$(spawn_sub tests "pi --thinking low")
 |---|---|
 | Target pane | current rightmost column (`rect.x` order) |
 | Direction | always `right` — one row of columns, never `down` |
-| After each spawn | resize **every** column (including root) to `1/N`, N = new column count |
-| Re-run per spawn | never hardcode a fixed ratio/amount — it shrinks every time |
+| Split ratio | `(N-1)/N` (the planner emits it) so the new pane is born at `1/N` |
+| After each spawn | run `--equalize` — a split alone can't shrink the pre-existing columns |
+| Re-run per spawn | never hardcode a fixed ratio — it shrinks every time |
 | Focus | always `--no-focus` |
 
 ```bash
 # $here from the resolver above (or re-probe if starting fresh in this shell)
-python3 "$here/next_grid_split.py" --root-pane "$root_pane"
-herdr pane layout --pane "$root_pane"   # verify equal-width rects
+python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane"
+herdr pane layout --pane "$root_pane"   # verify near-equal-width rects
 ```
 
-Manual fallback without the helper: read `herdr pane layout`, order panes by `rect.x`, split the rightmost one `right`, then resize every column (new + pre-existing) to `1 / (existing_count + 1)`.
-
-**Verification caveat:** `herdr pane split --ratio` / `herdr pane resize --amount` semantics (fraction of remaining space vs. absolute tab fraction) are not confirmed against a live `herdr` server by this skill's tests. Check `herdr pane layout` after a spawn to confirm the rects actually came out equal width.
+Manual fallback without the helper: read `herdr pane layout`, order panes by `rect.x`, split the rightmost one `right`, then hand-run the equalizer — see "Equal-width columns — verified semantics" below.
 
 ### Prefer grid split over `agent start`
 
 | Command | When |
 |---|---|
-| `next_grid_split.py` + `herdr pane split` + `herdr pane resize` … `--no-focus` | **Default** — equal-width grid including root |
-| `herdr agent start name --tab "$root_tab" --split right --no-focus -- …` | OK if you only care about same tab; leaves unequal widths unless you resize manually afterward |
+| `next_grid_split.py` split + `--equalize` … `--no-focus` | **Default** — equal-width grid including root |
+| `herdr agent start name --tab "$root_tab" --split right --no-focus -- …` | OK if you only care about same tab; leaves unequal widths unless you run `--equalize` afterward |
+
+### Equal-width columns — verified semantics
+
+These were confirmed **live against herdr 0.7.4**; the CLI has no `--help`, so
+run experiments in a throwaway `herdr tab create` and read `herdr pane layout`
+before/after (close the probe tab when done — never probe the session's own
+tab). Results:
+
+- **`pane split <p> --direction right --ratio R`** — `R` is the fraction the
+  **existing (left) child** keeps of the pane `p`; the new pane gets `1 - R`.
+  It resizes only `p`; the other columns are untouched. So a single split can
+  never equalize `N >= 3` columns. (`--ratio 0.5` on a 210-cell tab → 105/105.)
+- **`pane resize --pane P --direction D --amount A`** — `A` is a **delta**, a
+  fraction of the whole tab area width (`A * area_width` cells), *not* an
+  absolute target width. `--direction D` moves the edge on side `D`: a pane
+  with a neighbor on side `D` **grows** toward it; against a wall it shrinks.
+  The freed/absorbed cells redistribute **proportionally** among the panes on
+  the far side of the moved boundary. (Verified: a leftmost pane resized
+  `left 0.1` on a 210 tab shrank by exactly 21 cells, distributed to its
+  right neighbors by their prior widths.)
+- **Consequence:** one left-to-right resize sweep does not land equal (each
+  resize perturbs downstream columns), but the sweep is a *contraction* —
+  iterating it converges. Observed 4-column decay: spread 25 → 13 → 5 → 3 → 1.
+
+**Equalizer algorithm** (`next_grid_split.py --equalize`): compute equal
+integer targets summing to `area_width` (remainder onto the leftmost
+columns); each pass, sweep internal boundaries left to right and move each
+toward its target cumulative position by **growing the neighbor-bearing pane**
+(boundary must move right → `resize left_col right`; must move left →
+`resize right_col left`), re-reading the layout after every resize; repeat
+until the width spread is ≤1 cell (cap 12 passes). Verified end-to-end via the
+script: 2 cols → 105/105, 3 → 70/70/70, 4 → 53/53/52/52, 5 → 42×5.
+
+**Manual equalize** (helper unavailable): for a tab of width `W` with `N`
+columns, target each column ≈ `W/N`. Repeat this sweep until widths stop
+changing: for each internal boundary `i` (left to right), if the cumulative
+width left of it is below `(i+1)*W/N`, `herdr pane resize --pane <col i>
+--direction right --amount <deficit/W>`; if above, `herdr pane resize --pane
+<col i+1> --direction left --amount <excess/W>`. Because widths are whole
+cells, columns end equal within ±1 cell (exact only when `W` divides by `N`).
 
 ### When to use tab-per-agent instead
 
@@ -129,12 +165,8 @@ plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
 read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
 j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
 pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
-# Resize every column, including the new one — don't rely on --ratio alone
-# to have sized the new pane correctly.
-herdr pane resize --pane "$pane" --direction right --amount "$ratio" >/dev/null || true
-tail -n +2 <<<"$plan" | while read -r _ pid pshare; do
-  herdr pane resize --pane "$pid" --direction right --amount "$pshare" >/dev/null || true
-done
+# Equalize all columns — a split alone leaves the pre-existing columns wide.
+python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >/dev/null 2>&1 || true
 herdr pane rename "$pane" logs
 herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'"
 ```

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -242,7 +242,17 @@ herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'" || { echo "Error: launc
 
 ## Sending multi-line or code-heavy messages
 
-`herdr pane run <pane> <command>` takes one shell-quoted string. Nested quotes and newlines break easily. `$sd` below is the skill's `scripts/` dir. Each pattern is **self-contained**: it runs the fail-closed preflight (`scripts/preflight_send.py`) immediately before its guarded submission, and **guards every text-delivery step** so a failed `send-text`/`agent send` can never fall through to a bare Enter (which would deliver an empty line into whatever is on screen).
+`herdr pane run <pane> <command>` takes one shell-quoted string. Nested quotes and newlines break easily. Each pattern is **self-contained**: it resolves `$here` (the skill's `scripts/` dir) executably, **preflights before the first pane mutation** (so a working/blocked pane is never touched), guards every text-delivery step, then **preflights AGAIN immediately before the guarded Enter** (the pane could have flipped `blocked` in between). Resolve `$here` once first:
+
+```bash
+here=""
+for cand in "skills/herdr-agent-comms/scripts" ".agents/skills/herdr-agent-comms/scripts" \
+  ".claude/skills/herdr-agent-comms/scripts" "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts"; do
+  [ -f "$cand/preflight_send.py" ] && { here="$cand"; break; }
+done
+[ -n "$here" ] || { echo "Error: preflight_send.py not found in any known install location" >&2; exit 1; }
+```
 
 **Pattern A — short instruction that reads a file:**
 
@@ -257,8 +267,8 @@ Return only:
 1. bugs
 2. missing tests
 EOF
-# Preflight immediately before the send.
-python3 "$sd/preflight_send.py" "$pane_id" >/dev/null \
+# One atomic mutation (`pane run` submits + Enter): a single preflight before it.
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
   || { echo "Error: $pane_id not safe to send to (preflight failed) — see stderr" >&2; rm -f "$task_file"; exit 1; }
 herdr pane run "$pane_id" "Read $task_file and follow its instructions. Delete the file when done." \
   || { echo "send failed for $pane_id" >&2; rm -f "$task_file"; exit 1; }
@@ -267,11 +277,16 @@ herdr pane run "$pane_id" "Read $task_file and follow its instructions. Delete t
 **Pattern B — `send-text` then Enter** (when you must avoid shell expansion inside `pane run`):
 
 ```bash
-# Guard send-text: if the text never landed, DO NOT submit a bare Enter.
+# Preflight BEFORE the first mutation — send-text alters the pane, so a
+# working/blocked pane must be rejected before any text is injected.
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id not safe to send to (preflight failed) — see stderr" >&2; exit 1; }
+# Guard send-text: if the text never landed, DO NOT fall through to the Enter.
 herdr pane send-text "$pane_id" "line one" \
   || { echo "send-text failed for $pane_id — not submitting Enter" >&2; exit 1; }
-# Preflight immediately before the Enter that submits it.
-python3 "$sd/preflight_send.py" "$pane_id" >/dev/null \
+# Preflight AGAIN immediately before the Enter (the pane may have flipped
+# `blocked` since the text landed — a bare Enter would answer that dialog).
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
   || { echo "Error: $pane_id not safe to submit (preflight failed) — see stderr" >&2; exit 1; }
 herdr pane send-keys "$pane_id" enter \
   || { echo "Enter failed for $pane_id" >&2; exit 1; }
@@ -280,11 +295,14 @@ herdr pane send-keys "$pane_id" enter \
 **Pattern C — agent name:**
 
 ```bash
+# Preflight BEFORE the first mutation — `agent send` injects text into the pane.
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id not safe to send to (preflight failed) — see stderr" >&2; exit 1; }
 # Guard agent send: a failed send must not fall through to a bare Enter.
 herdr agent send reviewer "summarize src/" \
   || { echo "agent send failed for reviewer — not submitting Enter" >&2; exit 1; }
-# Preflight immediately before the submitting Enter.
-python3 "$sd/preflight_send.py" "$pane_id" >/dev/null \
+# Preflight AGAIN immediately before the submitting Enter.
+python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
   || { echo "Error: $pane_id not safe to submit (preflight failed) — see stderr" >&2; exit 1; }
 herdr pane send-keys "$pane_id" enter \
   || { echo "Enter failed for $pane_id" >&2; exit 1; }

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -160,6 +160,12 @@ targets=(reviewer tests docs)
 msg="Pull latest main and report branch + dirty state."
 
 # Resolve names → pane ids once, then single pane run each
+panes=()
+for t in "${targets[@]}"; do
+  p=$(herdr agent get "$t" | python3 -c 'import sys,json; d=json.load(sys.stdin); a=d.get("result",{}).get("agent") or d.get("result",{}); print(a["pane_id"])')
+  panes+=("$p")
+done
+
 for pane in "${panes[@]}"; do
   herdr pane run "$pane" "$msg"
 done

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -428,7 +428,7 @@ Do **not** `agent send` and then `pane run` the same message (double submit). Do
 | Unequal-width columns | Always split the current rightmost column and apply the full resize plan from `next_grid_split.py` |
 | Agent always `unknown` | `herdr integration install <agent>`; `herdr agent explain <target>` |
 | Nested tmux breaks detection | Don't run tmux inside Herdr panes |
-| `pane run` typed but agent idle | `herdr pane send-keys $pane enter`; re-wait `working` |
+| `pane run` typed but agent idle | Preflight (`preflight_send.py`), then guarded `send-keys $pane enter`; re-wait `working` and **propagate** its failure (a swallowed re-wait reports non-delivery as success) |
 | Status stuck `working` | `pane read`; overall wait budget; escalate stall |
 | `blocked` | Human must answer dialog; `agent focus` to show it |
 | Panes too narrow | Fewer agents (equal-width columns shrink every time); tab-per-agent only if user asks |

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -27,10 +27,12 @@ oddly wide/narrow; sidebar still rolls status per workspace.
 ### Spawn N sub-agents into an equal-width grid
 
 Use `scripts/next_grid_split.py` for every spawn: the default run emits the
-split line targeting the **current rightmost column** (`--ratio (N-1)/N`, so
-the new pane is born at the `1/N` target share), and `--equalize` runs the
-live iterative equalizer that re-converges every column (including root) to
-the same width.
+split line targeting the **current rightmost column** (`--ratio 1/N`, so the
+new right pane lands on the `1/N` equal target — see "Split ratio" below),
+and `--equalize` runs the live iterative equalizer that re-converges every
+column (including root) to the same width. `--equalize` is a **hard gate**:
+it exits non-zero on a resize failure or non-convergence, and the spawn
+helper below aborts rather than launch a worker into an uneven layout.
 
 ```bash
 root_pane="${HERDR_PANE_ID:?}"
@@ -57,18 +59,25 @@ spawn_sub() {
   local name=$1 cmd=$2
   local plan split_from ratio j pane
   herdr agent list | grep -q "\"name\":\"$name\"" && name="${name}-$(date +%s)"
-  # plan line: "split <rightmost> right --ratio <(N-1)/N>" (new pane born at 1/N)
+  # plan line: "split <rightmost> right --ratio <1/N>" (new right pane -> 1/N target)
   plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
   read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
   j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
   pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
-  # Equalize all columns — a split alone leaves the pre-existing columns wide.
-  python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >/dev/null 2>&1 || true
+  # Equalize all columns — HARD GATE: on failure return non-zero WITHOUT
+  # launching or printing a pane id, so the caller aborts (no `|| true`).
+  if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >&2; then
+    echo "Error: equalize failed for '$name'; orphan split pane $pane not launched. Inspect 'herdr pane layout --pane $root_pane'." >&2
+    return 1
+  fi
   herdr pane rename "$pane" "$name" >/dev/null
   herdr agent rename "$pane" "$name" >/dev/null
   herdr pane run "$pane" "$cmd" >/dev/null
   printf '%s\n' "$pane"
 }
+
+# Caller MUST check the status — `$(...)` hides it:
+#   p_reviewer="$(spawn_sub reviewer 'pi --thinking medium')" || { echo aborting >&2; exit 1; }
 
 p_reviewer=$(spawn_sub reviewer "pi --thinking medium")
 p_tests=$(spawn_sub tests "pi --thinking low")
@@ -81,7 +90,7 @@ p_tests=$(spawn_sub tests "pi --thinking low")
 |---|---|
 | Target pane | current rightmost column (`rect.x` order) |
 | Direction | always `right` — one row of columns, never `down` |
-| Split ratio | `(N-1)/N` (the planner emits it) so the new pane is born at `1/N` |
+| Split ratio | `1/N` (the planner emits it) — `--ratio R` is the existing/left child's share, so the new right pane gets `1-R = (N-1)/N` of the split column = the `1/N` equal target of the tab |
 | After each spawn | run `--equalize` — a split alone can't shrink the pre-existing columns |
 | Re-run per spawn | never hardcode a fixed ratio — it shrinks every time |
 | Focus | always `--no-focus` |
@@ -109,9 +118,16 @@ before/after (close the probe tab when done — never probe the session's own
 tab). Results:
 
 - **`pane split <p> --direction right --ratio R`** — `R` is the fraction the
-  **existing (left) child** keeps of the pane `p`; the new pane gets `1 - R`.
-  It resizes only `p`; the other columns are untouched. So a single split can
-  never equalize `N >= 3` columns. (`--ratio 0.5` on a 210-cell tab → 105/105.)
+  **existing (left) child** keeps of the pane `p`; the new (right) pane gets
+  `1 - R`. It resizes only `p`; the other columns are untouched. So a single
+  split can never equalize `N >= 3` columns. (`--ratio 0.5` on a 210-cell tab
+  → 105/105.) To add column N we split the rightmost column at **`R = 1/N`**:
+  when the N-1 existing columns are equal, the rightmost is `1/(N-1)` of the
+  tab, so the new pane's `(1-R) = (N-1)/N` share of it equals `1/N` of the
+  whole tab — the equal target. Verified live: from 105/105, splitting the
+  rightmost at `--ratio 0.333` (=1/3) gives a new pane of 70 (= 210/3), i.e.
+  the equal target — NOT 35, which is what the earlier inverted `(N-1)/N`
+  value produced. The equalizer then fixes the disturbed inner columns.
 - **`pane resize --pane P --direction D --amount A`** — `A` is a **delta**, a
   fraction of the whole tab area width (`A * area_width` cells), *not* an
   absolute target width. `--direction D` moves the edge on side `D`: a pane
@@ -131,7 +147,11 @@ toward its target cumulative position by **growing the neighbor-bearing pane**
 (boundary must move right → `resize left_col right`; must move left →
 `resize right_col left`), re-reading the layout after every resize; repeat
 until the width spread is ≤1 cell (cap 12 passes). Verified end-to-end via the
-script: 2 cols → 105/105, 3 → 70/70/70, 4 → 53/53/52/52, 5 → 42×5.
+script: 2 cols → 105/105, 3 → 70/70/70, 4 → 53/53/52/52, 5 → 42×5. A failed
+`herdr pane resize` (nonzero exit) or non-convergence within the pass cap is a
+**hard error**: `--equalize` exits non-zero with an actionable message naming
+the pane/direction/amount (or the final widths), and the spawn recipes abort
+instead of launching a worker into an uneven layout.
 
 **Manual equalize** (helper unavailable): for a tab of width `W` with `N`
 columns, target each column ≈ `W/N`. Repeat this sweep until widths stop
@@ -165,8 +185,13 @@ plan=$(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
 read -r _ split_from _ _ ratio < <(head -1 <<<"$plan")
 j=$(herdr pane split "$split_from" --direction right --ratio "$ratio" --cwd "$project_dir" --no-focus)
 pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
-# Equalize all columns — a split alone leaves the pre-existing columns wide.
-python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane" >/dev/null 2>&1 || true
+# Equalize all columns — HARD GATE: abort (and close the orphan pane) rather
+# than run the log tail into an uneven layout.
+if ! python3 "$here/next_grid_split.py" --equalize --root-pane "$root_pane"; then
+  echo "Error: equalize failed; not launching log pane. Orphan: $pane (herdr pane close $pane to undo)." >&2
+  herdr pane close "$pane" >/dev/null 2>&1 || true
+  exit 1
+fi
 herdr pane rename "$pane" logs
 herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'"
 ```

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -56,10 +56,15 @@ done
 [ -n "$here" ] || { echo "Error: next_grid_split.py not found in any known install location (repo, .agents/, .claude/, \$HOME). Fix the install or set \$here manually before retrying." >&2; exit 1; }
 
 # Canonical guarded spawn: every critical step is checked, the pane id is
-# printed ONLY after a successful launch + readiness, and any failure returns
+# printed ONLY after the launch (`pane run`) succeeds, and any failure returns
 # non-zero (naming the orphan split pane) so the caller can abort. Note the
 # `local` declarations are separate from the assignments — `local pane=$(...)`
 # would mask the substitution's exit status.
+#
+# Readiness is NOT waited on here: a single `wait agent-status idle` would
+# turn a `blocked` boot (trust/auth dialog) into a generic 60s timeout and
+# serialize the fleet. Placement and readiness are separated — see the
+# concurrent readiness pass after all spawns below.
 spawn_sub() {
   local name=$1 cmd=$2
   local plan split_from ratio j pane
@@ -84,13 +89,7 @@ spawn_sub() {
   herdr pane rename "$pane" "$name" >/dev/null || { echo "Error: rename failed; orphan $pane." >&2; return 1; }
   herdr agent rename "$pane" "$name" >/dev/null || { echo "Error: agent rename failed; orphan $pane." >&2; return 1; }
   herdr pane run "$pane" "$cmd" >/dev/null || { echo "Error: launch failed; orphan $pane." >&2; return 1; }
-  # Readiness: treat a boot timeout as failure so the caller doesn't message a
-  # dead pane. (Agents without status integration will time out here — the
-  # orphan is named so it's recoverable; drop this line if you rely on the
-  # content-stability fallback instead.)
-  herdr wait agent-status "$pane" --status idle --timeout 60000 >/dev/null || {
-    echo "Error: '$name' ($pane) not ready within 60s; orphan not confirmed launched." >&2; return 1; }
-  printf '%s\n' "$pane"   # ONLY after everything above succeeded
+  printf '%s\n' "$pane"   # ONLY after the launch above succeeded
 }
 
 # Caller MUST check the status — `$(...)` hides spawn_sub's non-zero exit, so
@@ -99,6 +98,26 @@ spawn_sub() {
 p_reviewer=$(spawn_sub reviewer "pi --thinking medium") || { echo "reviewer failed to place; aborting" >&2; exit 1; }
 p_tests=$(spawn_sub tests "pi --thinking low") || { echo "tests failed to place; aborting" >&2; exit 1; }
 # optional third: p_docs=$(spawn_sub docs "pi --thinking low") || { echo "docs failed; aborting" >&2; exit 1; }
+
+# Concurrent readiness pass — run AFTER all spawns so boot waits overlap.
+# `wait_for_idle.py --ready` returns 0 ready, 2 timeout, 3 BLOCKED — so a
+# trust/auth dialog is surfaced immediately instead of hiding behind a 60s
+# idle timeout (the reason a bare `wait agent-status idle` was wrong here).
+fleet=("$p_reviewer" "$p_tests")   # add "$p_docs" if spawned
+rpids=()
+for p in "${fleet[@]}"; do
+  python3 "$here/wait_for_idle.py" "$p" --ready --timeout 60 --no-print &
+  rpids+=("$!:$p")
+done
+for e in "${rpids[@]}"; do
+  jp="${e%%:*}"; pane="${e#*:}"
+  if wait "$jp"; then echo "$pane: ready"
+  else rc=$?
+    case "$rc" in 3) echo "$pane: BLOCKED — a human must answer a dialog" >&2 ;;
+                  2) echo "$pane: not ready within 60s (timeout)" >&2 ;;
+                  *) echo "$pane: readiness check failed (rc $rc)" >&2 ;; esac
+  fi
+done
 ```
 
 ### Grid heuristics
@@ -331,26 +350,43 @@ done
 panes=("${ready_panes[@]+"${ready_panes[@]}"}"); labels=("${ready_labels[@]+"${ready_labels[@]}"}")
 [ "${#panes[@]}" -gt 0 ] || { echo "Error: no targets left to send to." >&2; exit 1; }
 
-tmpdir="$(mktemp -d)"
+tmpdir="$(mktemp -d)"; trap 'rm -rf "$tmpdir"' EXIT
 markers=(); tasks=()
 for i in "${!panes[@]}"; do
-  herdr pane read "${panes[$i]}" --source recent-unwrapped --lines 80 >"$tmpdir/$i.baseline"
+  herdr pane read "${panes[$i]}" --source recent-unwrapped --lines 80 >"$tmpdir/$i.baseline" \
+    || { echo "Error: baseline read failed for ${panes[$i]}" >&2; exit 1; }
   suffix="$(date +%s)_$$_${i}_$RANDOM"
   markers+=("HERDR_DONE_$suffix")
   tasks[$i]="$msg
 
 After fully finishing, concatenate and print: HERDR_DONE_ and $suffix"
 done
+send_failed=()
 for i in "${!panes[@]}"; do
-  herdr pane run "${panes[$i]}" "${tasks[$i]}"
+  herdr pane run "${panes[$i]}" "${tasks[$i]}" || send_failed+=("${panes[$i]}")
 done
 
+# Retain each waiter's exit status — a bare `wait` masks timeouts (rc 2) and
+# blocked (rc 3), so the whole broadcast would "succeed" with agents stuck.
+pids=()
 for i in "${!panes[@]}"; do
   python3 "$here/wait_for_idle.py" "${panes[$i]}" --timeout 180 --lines 80 \
     --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
+  pids+=("$!:${panes[$i]}")
 done
-wait
-rm -rf "$tmpdir"
+overall=0
+for e in "${pids[@]}"; do
+  jp="${e%%:*}"; pane="${e#*:}"
+  if wait "$jp"; then echo "$pane: reply ready"
+  else rc=$?
+    case "$rc" in 3) echo "$pane: BLOCKED (human needed)" >&2 ;;
+                  2) echo "$pane: TIMEOUT" >&2 ;;
+                  *) echo "$pane: waiter failed (rc $rc)" >&2 ;; esac
+    overall=1
+  fi
+done
+[ "${#send_failed[@]}" -eq 0 ] || { echo "Send failed for: ${send_failed[*]}" >&2; overall=1; }
+exit "$overall"
 ```
 
 Do **not** `agent send` and then `pane run` the same message (double submit). Do **not** wait only on `done` for the full budget when the tab is focused — agents often settle as `idle` (use `wait_for_idle.py` or idle|done polling). Do **not** drop the dedupe or busy/blocked preflight from this manual path — that would reintroduce double-sends and dialog-clobbering that `scripts/broadcast.sh` exists to prevent.

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -292,16 +292,27 @@ herdr pane send-keys "$pane_id" enter \
   || { echo "Enter failed for $pane_id" >&2; exit 1; }
 ```
 
-**Pattern C — agent name:**
+**Pattern C — agent name:** resolve the name to **one** pane id first, then drive that **exact** id for the preflight, the text delivery, and the Enter. Never preflight/Enter a `$pane_id` while delivering text to a bare name — a stale/mismatched id would mutate one pane and submit into another.
 
 ```bash
-# Preflight BEFORE the first mutation — `agent send` injects text into the pane.
+# Resolve the agent NAME to a single pane id, then pin every step to it.
+pane_id="$(herdr agent get reviewer 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    a = d.get("result", {}).get("agent") or d.get("result", {})
+    pid = a.get("pane_id")
+except Exception:
+    pid = None
+print(pid or "", end="")')"
+[ -n "$pane_id" ] || { echo "Error: could not resolve agent 'reviewer' to a pane id" >&2; exit 1; }
+# Preflight BEFORE the first mutation — send-text injects into THIS pane.
 python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
   || { echo "Error: $pane_id not safe to send to (preflight failed) — see stderr" >&2; exit 1; }
-# Guard agent send: a failed send must not fall through to a bare Enter.
-herdr agent send reviewer "summarize src/" \
-  || { echo "agent send failed for reviewer — not submitting Enter" >&2; exit 1; }
-# Preflight AGAIN immediately before the submitting Enter.
+# Deliver text to the resolved pane id (not the bare name), guarded.
+herdr pane send-text "$pane_id" "summarize src/" \
+  || { echo "send-text failed for $pane_id — not submitting Enter" >&2; exit 1; }
+# Preflight AGAIN immediately before the submitting Enter (same pane id).
 python3 "$here/preflight_send.py" "$pane_id" >/dev/null \
   || { echo "Error: $pane_id not safe to submit (preflight failed) — see stderr" >&2; exit 1; }
 herdr pane send-keys "$pane_id" enter \

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -242,7 +242,7 @@ herdr pane run "$pane" "bash -lc 'tail -f /tmp/app.log'" || { echo "Error: launc
 
 ## Sending multi-line or code-heavy messages
 
-`herdr pane run <pane> <command>` takes one shell-quoted string. Nested quotes and newlines break easily. These patterns cover **escaping only** — run the fail-closed preflight (`scripts/preflight_send.py`, see "Delivery verification" in `references/delivery-and-waiting.md`) before any of them, so a task never lands in a working/blocked/unverifiable pane.
+`herdr pane run <pane> <command>` takes one shell-quoted string. Nested quotes and newlines break easily. `$sd` below is the skill's `scripts/` dir. Each pattern is **self-contained**: it runs the fail-closed preflight (`scripts/preflight_send.py`) immediately before its guarded submission, and **guards every text-delivery step** so a failed `send-text`/`agent send` can never fall through to a bare Enter (which would deliver an empty line into whatever is on screen).
 
 **Pattern A — short instruction that reads a file:**
 
@@ -257,22 +257,37 @@ Return only:
 1. bugs
 2. missing tests
 EOF
+# Preflight immediately before the send.
+python3 "$sd/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id not safe to send to (preflight failed) — see stderr" >&2; rm -f "$task_file"; exit 1; }
 herdr pane run "$pane_id" "Read $task_file and follow its instructions. Delete the file when done." \
-  || { echo "send failed for $pane_id" >&2; exit 1; }
+  || { echo "send failed for $pane_id" >&2; rm -f "$task_file"; exit 1; }
 ```
 
 **Pattern B — `send-text` then Enter** (when you must avoid shell expansion inside `pane run`):
 
 ```bash
-herdr pane send-text "$pane_id" "line one"
-herdr pane send-keys "$pane_id" enter
+# Guard send-text: if the text never landed, DO NOT submit a bare Enter.
+herdr pane send-text "$pane_id" "line one" \
+  || { echo "send-text failed for $pane_id — not submitting Enter" >&2; exit 1; }
+# Preflight immediately before the Enter that submits it.
+python3 "$sd/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id not safe to submit (preflight failed) — see stderr" >&2; exit 1; }
+herdr pane send-keys "$pane_id" enter \
+  || { echo "Enter failed for $pane_id" >&2; exit 1; }
 ```
 
 **Pattern C — agent name:**
 
 ```bash
-herdr agent send reviewer "summarize src/"
-herdr pane send-keys "$pane_id" enter
+# Guard agent send: a failed send must not fall through to a bare Enter.
+herdr agent send reviewer "summarize src/" \
+  || { echo "agent send failed for reviewer — not submitting Enter" >&2; exit 1; }
+# Preflight immediately before the submitting Enter.
+python3 "$sd/preflight_send.py" "$pane_id" >/dev/null \
+  || { echo "Error: $pane_id not safe to submit (preflight failed) — see stderr" >&2; exit 1; }
+herdr pane send-keys "$pane_id" enter \
+  || { echo "Enter failed for $pane_id" >&2; exit 1; }
 ```
 
 Remember: `agent send` does **not** append Enter; `pane run` does.

--- a/skills/herdr-agent-comms/references/herdr-recipes.md
+++ b/skills/herdr-agent-comms/references/herdr-recipes.md
@@ -10,12 +10,18 @@ Read this when you need layout variants, multi-line sends, human steer/focus, sc
 Session (default)
 └── Workspace: <project>
     └── Tab: <root's tab>                 ← single grid view
-        ┌───────────────────────────┐
-        │ root (you)                │
-        ├─────────────┬─────────────┤
-        │ reviewer    │ tests       │
-        └─────────────┴─────────────┘
+        ┌─────────────┬─────────────┐
+        │ root (you)  │ tests       │
+        ├─────────────┴─────────────┤
+        │ reviewer                  │
+        └────────────────────────────┘
 ```
+
+(`next_grid_split.py` always retargets the largest pane, so which sub-agent
+lands where depends on split order and live geometry — root can end up
+top-left rather than a full-width top strip. Either way root starts on top
+after the first, always-`down` split, and stays in the grid at a comparable
+size to its workers.)
 
 Why this default: the human sees the **root agent and every sub-agent together at usable sizes**; the orchestrator is never displaced into a side tab; sidebar still rolls status per workspace.
 
@@ -28,8 +34,17 @@ root_pane="${HERDR_PANE_ID:?}"
 root_tab="${HERDR_TAB_ID:?}"
 ws="${HERDR_WORKSPACE_ID:?}"
 project_dir=$(pwd)
-here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"  # when run from scripts/
-# or: here=skills/herdr-agent-comms/scripts
+# Resolve scripts/ by probing known install locations. Don't derive from
+# $0/BASH_SOURCE here — unreliable when an agent runs this inline rather
+# than as a saved script file.
+here=""
+for cand in \
+  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  ".claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts" \
+  "skills/herdr-agent-comms/scripts"; do
+  if [ -f "$cand/next_grid_split.py" ]; then here="$cand"; break; fi
+done
 
 spawn_sub() {
   local name=$1 cmd=$2
@@ -55,12 +70,14 @@ p_tests=$(spawn_sub tests "pi --thinking low")
 |---|---|
 | Target pane | largest area in the tab (`width * height`) |
 | Tie-break | prefer root pane |
-| Direction | **`down` if target height ≥ width** (vertical first), else `right` |
+| Direction (first split) | always `down` — vertical panel first, independent of aspect |
+| Direction (later splits) | `down` if target height ≥ width, else `right` |
 | After each spawn | re-run the chooser — never hardcode a fixed dir sequence |
 | Focus | always `--no-focus` |
 
 ```bash
-python3 scripts/next_grid_split.py --root-pane "$root_pane"
+# $here from the resolver above (or re-probe if starting fresh in this shell)
+python3 "$here/next_grid_split.py" --root-pane "$root_pane"
 herdr pane layout --pane "$root_pane"   # verify balanced rects
 ```
 
@@ -92,7 +109,8 @@ done
 ### Adding a log / shell pane into the grid
 
 ```bash
-read -r split_from dir < <(python3 scripts/next_grid_split.py --root-pane "$root_pane")
+# $here from the resolver above (or re-probe if starting fresh in this shell)
+read -r split_from dir < <(python3 "$here/next_grid_split.py" --root-pane "$root_pane")
 j=$(herdr pane split "$split_from" --direction "$dir" --cwd "$project_dir" --no-focus)
 pane=$(printf '%s' "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); r=d["result"]; print((r.get("pane") or r)["pane_id"])')
 herdr pane rename "$pane" logs
@@ -165,6 +183,15 @@ Prefer `recent-unwrapped` for agent transcripts. Widen `--lines` stepwise if tru
 Prefer `scripts/broadcast.sh`. Manual equivalent:
 
 ```bash
+here=""
+for cand in \
+  "$HOME/.claude/skills/herdr-agent-comms/scripts" \
+  ".claude/skills/herdr-agent-comms/scripts" \
+  "$HOME/.agents/skills/herdr-agent-comms/scripts" \
+  "skills/herdr-agent-comms/scripts"; do
+  if [ -f "$cand/wait_for_idle.py" ]; then here="$cand"; break; fi
+done
+
 targets=(reviewer tests docs)
 msg="Pull latest main and report branch + dirty state."
 
@@ -190,7 +217,7 @@ for i in "${!panes[@]}"; do
 done
 
 for i in "${!panes[@]}"; do
-  python3 scripts/wait_for_idle.py "${panes[$i]}" --timeout 180 --lines 80 \
+  python3 "$here/wait_for_idle.py" "${panes[$i]}" --timeout 180 --lines 80 \
     --baseline-file "$tmpdir/$i.baseline" --completion-marker "${markers[$i]}" &
 done
 wait

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -100,12 +100,16 @@ if [ "${#missing[@]}" -gt 0 ]; then
   exit 1
 fi
 
-# Phase 1b: reject panes already busy with other work before we send — a pane
-# that is already `working` did not start working because of THIS broadcast,
-# so waiting on it afterward cannot reliably distinguish this send's
-# completion from the prior task's. Skip busy panes rather than risk a false
-# "settled" report.
+# Phase 1b: reject panes that aren't safely sendable before we send.
+# - `working`: did not start working because of THIS broadcast, so waiting on
+#   it afterward cannot reliably distinguish this send's completion from the
+#   prior task's.
+# - `blocked`: a trust/auth/permission dialog is on screen. Typing the task
+#   into that dialog would submit garbage to the prompt, not the agent — skip
+#   it and surface the dialog instead (Critical Rule 7 in SKILL.md).
+# Skip both rather than risk a false "settled" report or a swallowed dialog.
 busy=()
+blocked=()
 ready_panes=()
 ready_labels=()
 for i in "${!panes[@]}"; do
@@ -114,12 +118,20 @@ for i in "${!panes[@]}"; do
     busy+=("${labels[$i]} (${panes[$i]})")
     continue
   fi
+  if [ "$st" = "blocked" ]; then
+    blocked+=("${labels[$i]} (${panes[$i]})")
+    continue
+  fi
   ready_panes+=("${panes[$i]}")
   ready_labels+=("${labels[$i]}")
 done
 if [ "${#busy[@]}" -gt 0 ]; then
   echo "Error: these targets are already working and were skipped: ${busy[*]}" >&2
   echo "Wait for them to go idle/done first, or target only the idle agents." >&2
+fi
+if [ "${#blocked[@]}" -gt 0 ]; then
+  echo "Error: these targets are blocked (trust/auth dialog) and were skipped: ${blocked[*]}" >&2
+  echo "A human must answer the dialog first — see: herdr agent focus <name>." >&2
 fi
 panes=("${ready_panes[@]+"${ready_panes[@]}"}")
 labels=("${ready_labels[@]+"${ready_labels[@]}"}")
@@ -142,24 +154,38 @@ done
 
 # Phase 3: fan out. The full marker is deliberately absent from the prompt:
 # prompt echo contains its two halves; only the completed reply joins them.
+#
+# A failed `pane run` here must NOT abort the whole broadcast: panes sent
+# to earlier in this loop are already mid-task, and abandoning them without
+# a wait/report would silently drop results the caller has no way to
+# recover. Record the failure and keep going; only successfully-dispatched
+# panes proceed to Phase 4.
 markers=()
+send_failed=()
 for i in "${!panes[@]}"; do
   p="${panes[$i]}"
   suffix="$(date +%s)_$$_${i}_${RANDOM}"
-  markers+=("HERDR_DONE_$suffix")
+  markers[$i]="HERDR_DONE_$suffix"
   task="$msg
 
 After fully finishing the task, concatenate and print these two parts without spaces: HERDR_DONE_ and $suffix"
-  herdr pane run "$p" "$task" >/dev/null || {
-    echo "Error: pane run failed for $p" >&2
-    exit 1
-  }
+  if ! herdr pane run "$p" "$task" >/dev/null; then
+    echo "Error: pane run failed for ${labels[$i]} ($p) — dispatch stopped for this target, already-sent panes still awaited." >&2
+    send_failed+=("$i")
+  fi
 done
 
-# Phase 4: wait concurrently
+# Phase 4: wait concurrently, but only on panes the send actually reached.
 pids=()
+wait_indices=()
 for i in "${!panes[@]}"; do
+  skip=""
+  for f in "${send_failed[@]+"${send_failed[@]}"}"; do
+    [ "$f" = "$i" ] && { skip=1; break; }
+  done
+  [ -n "$skip" ] && continue
   p="${panes[$i]}"
+  wait_indices+=("$i")
   # shellcheck disable=SC2086
   (
     python3 "$waiter" "$p" --timeout "$timeout" ${HAC_WAIT_ARGS:-} \
@@ -170,14 +196,15 @@ for i in "${!panes[@]}"; do
   ) &
   pids+=("$!")
 done
-for pid in "${pids[@]}"; do wait "$pid"; done
+for pid in "${pids[@]+"${pids[@]}"}"; do wait "$pid"; done
 
-# Phase 5: emit labeled blocks
+# Phase 5: emit labeled blocks — dispatched panes first (settled/timeout/
+# blocked/error), then a distinct block per pane that never got a send.
 overall=0
-if [ "${#busy[@]}" -gt 0 ]; then
+if [ "${#busy[@]}" -gt 0 ] || [ "${#blocked[@]}" -gt 0 ] || [ "${#send_failed[@]}" -gt 0 ]; then
   overall=1
 fi
-for i in "${!panes[@]}"; do
+for i in "${wait_indices[@]+"${wait_indices[@]}"}"; do
   label="${labels[$i]}"
   p="${panes[$i]}"
   code="$(cat "$tmpdir/$i.code" 2>/dev/null || echo "?")"
@@ -194,5 +221,12 @@ for i in "${!panes[@]}"; do
   fi
   echo
 done
+for i in "${send_failed[@]+"${send_failed[@]}"}"; do
+  echo "===== ${labels[$i]} (${panes[$i]}) [SEND-FAILED, not waited] =====" >&2
+done
+
+if [ "${#send_failed[@]}" -gt 0 ]; then
+  echo "Partial results: ${#send_failed[@]} of ${#panes[@]} target(s) never received the message (see SEND-FAILED above). Results above are only for targets successfully dispatched." >&2
+fi
 
 exit "$overall"

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -221,7 +221,11 @@ for pid in "${pids[@]+"${pids[@]}"}"; do wait "$pid"; done
 # Phase 5: emit labeled blocks — dispatched panes first (settled/timeout/
 # blocked/error), then a distinct block per pane that never got a send.
 overall=0
-if [ "${#busy[@]}" -gt 0 ] || [ "${#blocked[@]}" -gt 0 ] || [ "${#send_failed[@]}" -gt 0 ]; then
+# Any pane we could NOT safely deliver to fails the broadcast — including
+# `unverifiable` targets (status lookup/parse failed). Omitting them here made
+# a mixed bad+good broadcast exit 0 even though some targets were skipped.
+if [ "${#busy[@]}" -gt 0 ] || [ "${#blocked[@]}" -gt 0 ] \
+   || [ "${#unverifiable[@]}" -gt 0 ] || [ "${#send_failed[@]}" -gt 0 ]; then
   overall=1
 fi
 for i in "${wait_indices[@]+"${wait_indices[@]}"}"; do

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -67,12 +67,19 @@ pane_status() {
   out="$(herdr pane get "$1" 2>/dev/null)" || return 1
   printf '%s' "$out" | python3 -c '
 import sys, json
+VALID = {"idle", "working", "blocked", "done", "unknown"}
 try:
     d = json.load(sys.stdin)
     pane = d["result"]["pane"]
 except Exception:
     sys.exit(1)   # lookup/parse failure — NOT a safe empty status
-print(pane.get("agent_status") or "unknown")
+raw = pane.get("agent_status")
+if raw is None:
+    print("unknown")                 # validly absent (non-integrated CLI)
+elif isinstance(raw, str) and raw in VALID:
+    print(raw)
+else:
+    sys.exit(1)                       # off-enum/garbage (e.g. numeric 123) — unverifiable
 '
 }
 

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -57,12 +57,37 @@ except Exception:
 '
 }
 
-# Phase 1: resolve all targets first
+pane_status() {
+  herdr pane get "$1" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d["result"]["pane"].get("agent_status", ""))
+except Exception:
+    print("")
+'
+}
+
+# Phase 1: resolve all targets first, deduping by pane id so a name and its
+# pane-id alias (e.g. "reviewer" and "w26:p4") don't double-send.
+# (Plain arrays + linear scan, not associative arrays: this needs to run on
+# bash 3.2 too, e.g. macOS's default /bin/bash.)
 panes=()
 labels=()
 missing=()
 for t in "${targets[@]}"; do
   if p="$(resolve_pane "$t")"; then
+    dup=""
+    for existing in "${panes[@]+"${panes[@]}"}"; do
+      if [ "$existing" = "$p" ]; then
+        dup=1
+        break
+      fi
+    done
+    if [ -n "$dup" ]; then
+      echo "Note: '$t' resolves to an already-targeted pane $p — skipping duplicate." >&2
+      continue
+    fi
     panes+=("$p")
     labels+=("$t")
   else
@@ -72,6 +97,34 @@ done
 if [ "${#missing[@]}" -gt 0 ]; then
   echo "Error: these targets don't resolve: ${missing[*]}" >&2
   echo "List them with: herdr agent list" >&2
+  exit 1
+fi
+
+# Phase 1b: reject panes already busy with other work before we send — a pane
+# that is already `working` did not start working because of THIS broadcast,
+# so waiting on it afterward cannot reliably distinguish this send's
+# completion from the prior task's. Skip busy panes rather than risk a false
+# "settled" report.
+busy=()
+ready_panes=()
+ready_labels=()
+for i in "${!panes[@]}"; do
+  st="$(pane_status "${panes[$i]}")"
+  if [ "$st" = "working" ]; then
+    busy+=("${labels[$i]} (${panes[$i]})")
+    continue
+  fi
+  ready_panes+=("${panes[$i]}")
+  ready_labels+=("${labels[$i]}")
+done
+if [ "${#busy[@]}" -gt 0 ]; then
+  echo "Error: these targets are already working and were skipped: ${busy[*]}" >&2
+  echo "Wait for them to go idle/done first, or target only the idle agents." >&2
+fi
+panes=("${ready_panes[@]+"${ready_panes[@]}"}")
+labels=("${ready_labels[@]+"${ready_labels[@]}"}")
+if [ "${#panes[@]}" -eq 0 ]; then
+  echo "Error: no targets left to send to." >&2
   exit 1
 fi
 
@@ -121,6 +174,9 @@ for pid in "${pids[@]}"; do wait "$pid"; done
 
 # Phase 5: emit labeled blocks
 overall=0
+if [ "${#busy[@]}" -gt 0 ]; then
+  overall=1
+fi
 for i in "${!panes[@]}"; do
   label="${labels[$i]}"
   p="${panes[$i]}"

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -189,8 +189,25 @@ done
 # panes proceed to Phase 4.
 markers=()
 send_failed=()
+became_unsafe=()
 for i in "${!panes[@]}"; do
   p="${panes[$i]}"
+  # Re-check status immediately before dispatch. The Phase 1b preflight and the
+  # Phase 2 baseline loop both run BEFORE this send, so a target that was idle
+  # then could have gone `working`/`blocked` (or become unverifiable) in the
+  # interval. Sending now would type into a dialog or race a prior task's
+  # completion. Skip it and fold it into the failure aggregation — same
+  # fail-closed, enum-validated check as Phase 1b.
+  if ! st="$(pane_status "$p")"; then
+    echo "Error: ${labels[$i]} ($p) status became unverifiable before dispatch — skipped (not sent)." >&2
+    became_unsafe+=("$i")
+    continue
+  fi
+  if [ "$st" = "working" ] || [ "$st" = "blocked" ]; then
+    echo "Error: ${labels[$i]} ($p) turned $st before dispatch — skipped (not sent)." >&2
+    became_unsafe+=("$i")
+    continue
+  fi
   suffix="$(date +%s)_$$_${i}_${RANDOM}"
   markers[$i]="HERDR_DONE_$suffix"
   task="$msg
@@ -203,11 +220,13 @@ After fully finishing the task, concatenate and print these two parts without sp
 done
 
 # Phase 4: wait concurrently, but only on panes the send actually reached.
+# Exclude both `send_failed` (pane run errored) and `became_unsafe` (skipped at
+# the pre-dispatch recheck) — neither was sent, so neither has a task to await.
 pids=()
 wait_indices=()
 for i in "${!panes[@]}"; do
   skip=""
-  for f in "${send_failed[@]+"${send_failed[@]}"}"; do
+  for f in "${send_failed[@]+"${send_failed[@]}"}" ${became_unsafe[@]+"${became_unsafe[@]}"}; do
     [ "$f" = "$i" ] && { skip=1; break; }
   done
   [ -n "$skip" ] && continue
@@ -232,7 +251,8 @@ overall=0
 # `unverifiable` targets (status lookup/parse failed). Omitting them here made
 # a mixed bad+good broadcast exit 0 even though some targets were skipped.
 if [ "${#busy[@]}" -gt 0 ] || [ "${#blocked[@]}" -gt 0 ] \
-   || [ "${#unverifiable[@]}" -gt 0 ] || [ "${#send_failed[@]}" -gt 0 ]; then
+   || [ "${#unverifiable[@]}" -gt 0 ] || [ "${#send_failed[@]}" -gt 0 ] \
+   || [ "${#became_unsafe[@]}" -gt 0 ]; then
   overall=1
 fi
 for i in "${wait_indices[@]+"${wait_indices[@]}"}"; do
@@ -255,9 +275,13 @@ done
 for i in "${send_failed[@]+"${send_failed[@]}"}"; do
   echo "===== ${labels[$i]} (${panes[$i]}) [SEND-FAILED, not waited] =====" >&2
 done
+for i in "${became_unsafe[@]+"${became_unsafe[@]}"}"; do
+  echo "===== ${labels[$i]} (${panes[$i]}) [BECAME-UNSAFE before dispatch, not sent] =====" >&2
+done
 
-if [ "${#send_failed[@]}" -gt 0 ]; then
-  echo "Partial results: ${#send_failed[@]} of ${#panes[@]} target(s) never received the message (see SEND-FAILED above). Results above are only for targets successfully dispatched." >&2
+if [ "${#send_failed[@]}" -gt 0 ] || [ "${#became_unsafe[@]}" -gt 0 ]; then
+  ndrop=$(( ${#send_failed[@]} + ${#became_unsafe[@]} ))
+  echo "Partial results: $ndrop of ${#panes[@]} target(s) never received the message (see SEND-FAILED / BECAME-UNSAFE above). Results above are only for targets successfully dispatched." >&2
 fi
 
 exit "$overall"

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -73,6 +73,11 @@ try:
     pane = d["result"]["pane"]
 except Exception:
     sys.exit(1)   # lookup/parse failure — NOT a safe empty status
+if not isinstance(pane, dict):
+    # Valid JSON but a null / non-object `pane` ({"result":{"pane":null}}):
+    # calling .get() would raise AttributeError (an ugly traceback). Treat it
+    # as an unverifiable status and exit cleanly.
+    sys.exit(1)
 raw = pane.get("agent_status")
 if raw is None:
     print("unknown")                 # validly absent (non-integrated CLI)

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -58,13 +58,21 @@ except Exception:
 }
 
 pane_status() {
-  herdr pane get "$1" 2>/dev/null | python3 -c '
+  # Print the pane's agent_status and return 0 ONLY when the lookup+parse
+  # actually succeeded. A failed `herdr pane get` or malformed JSON must
+  # return non-zero (NOT an empty "safe" status) so the caller can reject the
+  # target instead of sending into an unverifiable pane. A validly-absent
+  # status field prints "unknown" (non-integrated CLIs report that normally).
+  local out
+  out="$(herdr pane get "$1" 2>/dev/null)" || return 1
+  printf '%s' "$out" | python3 -c '
 import sys, json
 try:
     d = json.load(sys.stdin)
-    print(d["result"]["pane"].get("agent_status", ""))
+    pane = d["result"]["pane"]
 except Exception:
-    print("")
+    sys.exit(1)   # lookup/parse failure — NOT a safe empty status
+print(pane.get("agent_status") or "unknown")
 '
 }
 
@@ -110,10 +118,17 @@ fi
 # Skip both rather than risk a false "settled" report or a swallowed dialog.
 busy=()
 blocked=()
+unverifiable=()
 ready_panes=()
 ready_labels=()
 for i in "${!panes[@]}"; do
-  st="$(pane_status "${panes[$i]}")"
+  # A failed status lookup must NOT fall through as "safe to send" — reject
+  # the target rather than risk sending into a working/blocked pane whose
+  # state we couldn't confirm.
+  if ! st="$(pane_status "${panes[$i]}")"; then
+    unverifiable+=("${labels[$i]} (${panes[$i]})")
+    continue
+  fi
   if [ "$st" = "working" ]; then
     busy+=("${labels[$i]} (${panes[$i]})")
     continue
@@ -122,6 +137,7 @@ for i in "${!panes[@]}"; do
     blocked+=("${labels[$i]} (${panes[$i]})")
     continue
   fi
+  # idle / done / unknown (validly reported) are sendable.
   ready_panes+=("${panes[$i]}")
   ready_labels+=("${labels[$i]}")
 done
@@ -132,6 +148,10 @@ fi
 if [ "${#blocked[@]}" -gt 0 ]; then
   echo "Error: these targets are blocked (trust/auth dialog) and were skipped: ${blocked[*]}" >&2
   echo "A human must answer the dialog first — see: herdr agent focus <name>." >&2
+fi
+if [ "${#unverifiable[@]}" -gt 0 ]; then
+  echo "Error: could not verify status for these targets (lookup/parse failed) and skipped them: ${unverifiable[*]}" >&2
+  echo "Refusing to send into a pane whose working/blocked state is unknown — check 'herdr pane get <id>'." >&2
 fi
 panes=("${ready_panes[@]+"${ready_panes[@]}"}")
 labels=("${ready_labels[@]+"${ready_labels[@]}"}")

--- a/skills/herdr-agent-comms/scripts/broadcast.sh
+++ b/skills/herdr-agent-comms/scripts/broadcast.sh
@@ -11,6 +11,7 @@
 #
 # Options (env vars):
 #   HAC_TIMEOUT       per-agent wait timeout in seconds (default: 180)
+#   HAC_LINES         transcript lines used for baseline + reply (default: 60)
 #   HAC_WAIT_ARGS     extra args passed to wait_for_idle.py (e.g. "--full")
 #
 # Exit 0 if all agents settled idle/done; otherwise 1.
@@ -20,6 +21,7 @@ set -u
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 waiter="$here/wait_for_idle.py"
 timeout="${HAC_TIMEOUT:-180}"
+lines="${HAC_LINES:-60}"
 
 if [ "$#" -lt 2 ]; then
   echo "Error: need a message and at least one target." >&2
@@ -73,23 +75,43 @@ if [ "${#missing[@]}" -gt 0 ]; then
   exit 1
 fi
 
-# Phase 2: fan out (pane run = text + Enter)
-for p in "${panes[@]}"; do
-  herdr pane run "$p" "$msg" >/dev/null || {
+# Phase 2: snapshot every pane BEFORE send. A fast agent can finish before its
+# waiter starts; stable output after this baseline still proves new activity.
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/hac_broadcast.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+for i in "${!panes[@]}"; do
+  if ! herdr pane read "${panes[$i]}" --source recent-unwrapped --lines "$lines" \
+    >"$tmpdir/$i.baseline"; then
+    echo "Error: could not capture baseline for ${panes[$i]}" >&2
+    exit 1
+  fi
+done
+
+# Phase 3: fan out. The full marker is deliberately absent from the prompt:
+# prompt echo contains its two halves; only the completed reply joins them.
+markers=()
+for i in "${!panes[@]}"; do
+  p="${panes[$i]}"
+  suffix="$(date +%s)_$$_${i}_${RANDOM}"
+  markers+=("HERDR_DONE_$suffix")
+  task="$msg
+
+After fully finishing the task, concatenate and print these two parts without spaces: HERDR_DONE_ and $suffix"
+  herdr pane run "$p" "$task" >/dev/null || {
     echo "Error: pane run failed for $p" >&2
     exit 1
   }
 done
 
-# Phase 3: wait concurrently
-tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/hac_broadcast.XXXXXX")"
-trap 'rm -rf "$tmpdir"' EXIT
+# Phase 4: wait concurrently
 pids=()
 for i in "${!panes[@]}"; do
   p="${panes[$i]}"
   # shellcheck disable=SC2086
   (
     python3 "$waiter" "$p" --timeout "$timeout" ${HAC_WAIT_ARGS:-} \
+      --lines "$lines" --baseline-file "$tmpdir/$i.baseline" \
+      --completion-marker "${markers[$i]}" \
       >"$tmpdir/$i.out" 2>"$tmpdir/$i.err"
     echo "$?" >"$tmpdir/$i.code"
   ) &
@@ -97,7 +119,7 @@ for i in "${!panes[@]}"; do
 done
 for pid in "${pids[@]}"; do wait "$pid"; done
 
-# Phase 4: emit labeled blocks
+# Phase 5: emit labeled blocks
 overall=0
 for i in "${!panes[@]}"; do
   label="${labels[$i]}"

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -27,15 +27,17 @@ herdr server (see SKILL.md "Equal-width columns — verified semantics"):
 So the reliable strategy this script encodes is:
 
   1. Add column N by splitting the current rightmost column `right` with
-     `--ratio (N-1)/N` so the new pane is born at the 1/N target share.
+     `--ratio 1/N`. `--ratio R` is the fraction the EXISTING (left) child of
+     the split column keeps, so the NEW (right) pane gets `1 - R = (N-1)/N`
+     of that column — which, since the rightmost column is `1/(N-1)` of the
+     tab when the N-1 existing columns are equal, equals `1/N` of the whole
+     tab (the equal target). See `split_ratio()` for the derivation.
   2. Run an iterative boundary equalizer: sweep internal boundaries left
      to right, moving each toward its target cumulative position by GROWING
      the neighbor-bearing pane; repeat until the width spread is <= 1 cell
-     (or a small iteration cap). Each pass re-reads the live layout.
-
-`--emit-plan` prints the split line only (for a shell caller that runs the
-equalizer via `equalize_columns.py`). `--equalize` runs the full live
-equalizer itself against `herdr` and exits.
+     (or a small iteration cap). Each pass re-reads the live layout. A resize
+     command failure or non-convergence is a HARD error (exit 1), never
+     suppressed — the caller must not launch workers into an unequal layout.
 
 Usage:
     # plan the split for the next column (default)
@@ -46,10 +48,10 @@ Usage:
 
 Default output (one split line a caller feeds to `herdr pane split`):
 
-    split <rightmost_pane_id> right --ratio <existing_child_ratio>
+    split <rightmost_pane_id> right --ratio <1/N>
 
-where <existing_child_ratio> = (N-1)/N and N is the column count AFTER the
-split. Follow it with the equalizer (see SKILL.md Phase 2a).
+where N is the column count AFTER the split. Follow it with `--equalize`
+(see SKILL.md Phase 2a).
 
 Exit codes:
     0 success
@@ -209,6 +211,25 @@ def plan_next_split(panes: list[dict], root_pane: str | None) -> tuple[str, int]
     return ordered[-1], len(ordered) + 1
 
 
+def split_ratio(new_count: int) -> float:
+    """`--ratio` for `herdr pane split` when adding column `new_count` (= N).
+
+    In herdr 0.7.4 `--ratio R` is the fraction the EXISTING (left) child of
+    the split pane keeps; the NEW (right) pane gets `1 - R` of that pane. We
+    split the current rightmost column, which — when the N-1 existing columns
+    are already equal — is `1/(N-1)` of the whole tab. To make the new pane
+    the equal target `1/N` of the tab, it must take `((1/N)/(1/(N-1))) =
+    (N-1)/N` of the split column, so the existing child keeps `R = 1/N`.
+
+    Verified live against herdr 0.7.4: from two equal 105/105 columns,
+    splitting the rightmost with `--ratio 0.333` (=1/3) yields a new pane of
+    width 70 (= 210/3, the equal target). See SKILL.md / herdr-recipes.md.
+    """
+    if new_count < 2:
+        raise SystemExit("new column count must be >= 2 to split")
+    return 1.0 / new_count
+
+
 def _run_herdr(*args: str) -> subprocess.CompletedProcess:
     return subprocess.run(["herdr", *args], text=True, capture_output=True, check=False)
 
@@ -248,23 +269,38 @@ def equalize_live(root_pane: str | None) -> int:
             if op is None:
                 continue
             pane_id, direction, amount = op
-            _run_herdr(
+            cp = _run_herdr(
                 "pane", "resize", "--pane", pane_id,
                 "--direction", direction, "--amount", f"{amount:.6f}",
             )
+            # A failed resize is a HARD error — silently swallowing it (the
+            # old `|| true` behaviour) leaves an unequal layout that the
+            # caller then launches workers into. Surface the exact command
+            # and herdr's message so the caller can act.
+            if cp.returncode != 0:
+                detail = (cp.stderr.strip() or cp.stdout.strip()
+                          or f"exit {cp.returncode}")
+                raise SystemExit(
+                    f"herdr pane resize failed for {pane_id} "
+                    f"(--direction {direction} --amount {amount:.6f}): {detail}. "
+                    f"Layout left unequal; inspect with "
+                    f"`herdr pane layout --pane {root_pane or '--current'}`."
+                )
 
-    # Final check after the cap.
+    # Final check after the cap. Non-convergence is also a hard error — do
+    # not report "best-effort" and let the caller proceed onto an unequal grid.
     data = load_layout(root_pane, None)
     _, widths = _ordered_columns(panes_from_layout(data))
     spread = max(widths) - min(widths)
     if spread <= EQUAL_TOLERANCE_CELLS:
         return 0
-    print(
-        f"Warning: columns not fully equal after {MAX_EQUALIZE_PASSES} passes "
-        f"(spread {spread:.0f} cells); layout is best-effort.",
-        file=sys.stderr,
+    raise SystemExit(
+        f"columns did not converge to equal width after {MAX_EQUALIZE_PASSES} "
+        f"passes (widths {[int(w) for w in widths]}, spread {spread:.0f} cells). "
+        f"Do NOT launch workers into this layout; inspect with "
+        f"`herdr pane layout --pane {root_pane or '--current'}` and retry, or "
+        f"reduce the column count."
     )
-    return 1
 
 
 def main() -> int:
@@ -300,9 +336,10 @@ def main() -> int:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    # existing (left) child keeps (N-1)/N so the NEW pane is born at 1/N.
-    existing_child_ratio = (new_count - 1) / new_count
-    print(f"split {rightmost} right --ratio {existing_child_ratio:.6f}")
+    # `--ratio R` = the existing/left child's fraction of the split column.
+    # R = 1/N makes the NEW (right) pane the equal 1/N target (see split_ratio).
+    ratio = split_ratio(new_count)
+    print(f"split {rightmost} right --ratio {ratio:.6f}")
     return 0
 
 

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -100,6 +100,10 @@ def _unwrap_layout(data: dict) -> dict:
     """Return the inner `layout` object regardless of whether `data` is the
     raw CLI envelope (`{"result": {"layout": {...}}}`), a `{"layout": {...}}`
     fixture, or the layout dict itself."""
+    # A top-level `null` (or any non-object) parses to a non-dict here; calling
+    # .get() on it would raise an uncaught AttributeError. Reject cleanly.
+    if not isinstance(data, dict):
+        raise SystemExit("layout JSON is not an object")
     node = data.get("result", data)
     if isinstance(node, dict) and "layout" in node:
         node = node["layout"]
@@ -113,6 +117,12 @@ def panes_from_layout(data: dict) -> list[dict]:
     panes = layout.get("panes")
     if not isinstance(panes, list) or not panes:
         raise SystemExit("layout JSON has no panes")
+    # A null / non-object element (e.g. `panes: [null]`) would crash every
+    # `pane.get(...)` downstream with an uncaught AttributeError. Validate the
+    # element shape here, once, so callers get a clean SystemExit instead.
+    for i, pane in enumerate(panes):
+        if not isinstance(pane, dict):
+            raise SystemExit(f"layout JSON pane #{i} is not an object")
     return panes
 
 
@@ -209,6 +219,12 @@ def _ordered_columns(panes: list[dict]) -> tuple[list[str], list[float]]:
     """
     ordered: list[tuple[float, str, float]] = []
     for pane in panes:
+        if not isinstance(pane, dict):
+            # A null / non-object element (e.g. `panes: [null]`) — treat as a
+            # layout-shape error, not an uncaught AttributeError. Callers going
+            # through panes_from_layout are pre-validated; this guards direct
+            # callers (e.g. plan_next_split) too.
+            raise SystemExit("layout contains a non-object pane entry")
         pane_id = pane.get("pane_id")
         rect = pane.get("rect") or {}
         try:

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -169,9 +169,13 @@ def validate_single_row(data: dict, tolerance: int = 1) -> None:
         raise SystemExit(f"layout 'area' rect missing x/y/width/height: {e}") from e
 
     panes = panes_from_layout(data)
+    # Reject missing / non-string / empty / duplicate pane ids up front — a
+    # malformed id here would otherwise flow into the split planner and mis-
+    # target a column (see _validate_pane_ids).
+    _validate_pane_ids(panes)
     rects: list[tuple[float, float, float, float, str]] = []
     for pane in panes:
-        pid = pane.get("pane_id")
+        pid = pane["pane_id"]  # validated: unique non-empty str
         rect = pane.get("rect")
         if not isinstance(rect, dict):
             raise SystemExit(f"pane {pid!r} has no rect; cannot validate layout shape")
@@ -210,29 +214,48 @@ def validate_single_row(data: dict, tolerance: int = 1) -> None:
         )
 
 
+def _validate_pane_ids(panes: list[dict]) -> None:
+    """Require every pane to carry a unique, non-empty STRING pane_id.
+
+    Runs as a first pass over the FULL input list, before any rect-based drop.
+    A pane with a missing / non-string / empty / duplicate id is a layout we
+    cannot safely plan against: `_ordered_columns` used to *silently drop* such
+    panes, so a malformed rightmost column would vanish and the planner would
+    split the WRONG pane. Reject up front instead of dropping. Also rejects a
+    non-object element (e.g. `panes: [null]`) rather than crashing on `.get`.
+    """
+    seen_ids: set[str] = set()
+    for i, pane in enumerate(panes):
+        if not isinstance(pane, dict):
+            raise SystemExit(f"layout pane #{i} is not an object")
+        pane_id = pane.get("pane_id")
+        if not isinstance(pane_id, str) or not pane_id:
+            raise SystemExit(f"pane #{i} has a missing / non-string / empty pane_id: {pane_id!r}")
+        if pane_id in seen_ids:
+            raise SystemExit(f"duplicate pane_id {pane_id!r} in layout")
+        seen_ids.add(pane_id)
+
+
 def _ordered_columns(panes: list[dict]) -> tuple[list[str], list[float]]:
     """Order panes by rect.x and return parallel (ids, widths) lists.
 
     Panes without a usable rect are dropped rather than guessed at — a
     missing x/width is a layout-shape error the caller should see, not
-    something to silently default to 0.
+    something to silently default to 0. (Pane ids are validated first via
+    `_validate_pane_ids`, so a missing/duplicate id is a hard error, never a
+    silent drop that could retarget the split.)
     """
+    _validate_pane_ids(panes)
     ordered: list[tuple[float, str, float]] = []
     for pane in panes:
-        if not isinstance(pane, dict):
-            # A null / non-object element (e.g. `panes: [null]`) — treat as a
-            # layout-shape error, not an uncaught AttributeError. Callers going
-            # through panes_from_layout are pre-validated; this guards direct
-            # callers (e.g. plan_next_split) too.
-            raise SystemExit("layout contains a non-object pane entry")
-        pane_id = pane.get("pane_id")
+        pane_id = pane["pane_id"]  # validated above: a non-empty unique str
         rect = pane.get("rect") or {}
         try:
             x = float(rect.get("x", 0))
             width = float(rect.get("width", 0))
         except (TypeError, ValueError):
             continue
-        if not pane_id or width <= 0:
+        if width <= 0:
             continue
         ordered.append((x, pane_id, width))
     if not ordered:

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -82,7 +82,14 @@ def choose_target(panes: list[dict], root_pane: str | None) -> tuple[str, str]:
     if best is None:
         raise SystemExit("no usable pane rects in layout")
 
-    # Prefer vertical panels first: stack top/bottom unless the cell is clearly wider.
+    # First split of a single-pane layout always goes down: this is the
+    # documented "vertical panel first" default (root on top, first worker
+    # below), independent of aspect ratio (most terminals are wider than
+    # tall, so a plain aspect check would pick `right` here instead).
+    if len(panes) == 1:
+        return best["pane_id"], "down"
+
+    # Later splits: direction follows the target cell's own aspect.
     direction = "down" if best["height"] >= best["width"] else "right"
     return best["pane_id"], direction
 

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -239,24 +239,29 @@ def _validate_pane_ids(panes: list[dict]) -> None:
 def _ordered_columns(panes: list[dict]) -> tuple[list[str], list[float]]:
     """Order panes by rect.x and return parallel (ids, widths) lists.
 
-    Panes without a usable rect are dropped rather than guessed at — a
-    missing x/width is a layout-shape error the caller should see, not
-    something to silently default to 0. (Pane ids are validated first via
-    `_validate_pane_ids`, so a missing/duplicate id is a hard error, never a
-    silent drop that could retarget the split.)
+    EVERY pane must carry a valid geometry: a `rect` object with a numeric `x`
+    and a strictly-positive numeric `width`. A pane that fails this is a HARD
+    error, never a silent drop — dropping one during a live equalize re-read
+    would compute resize ops for a PARTIAL grid (a column omitted), scrambling
+    the layout. Defaulting a missing `x` to 0 (the old behaviour) also misorders
+    columns. Pane ids are validated first via `_validate_pane_ids`.
     """
     _validate_pane_ids(panes)
     ordered: list[tuple[float, str, float]] = []
     for pane in panes:
         pane_id = pane["pane_id"]  # validated above: a non-empty unique str
-        rect = pane.get("rect") or {}
+        rect = pane.get("rect")
+        if not isinstance(rect, dict):
+            raise SystemExit(f"pane {pane_id!r} has no rect object; cannot order columns")
+        if "x" not in rect or "width" not in rect:
+            raise SystemExit(f"pane {pane_id!r} rect is missing x/width")
         try:
-            x = float(rect.get("x", 0))
-            width = float(rect.get("width", 0))
-        except (TypeError, ValueError):
-            continue
+            x = float(rect["x"])
+            width = float(rect["width"])
+        except (TypeError, ValueError) as e:
+            raise SystemExit(f"pane {pane_id!r} rect x/width is not numeric: {e}") from e
         if width <= 0:
-            continue
+            raise SystemExit(f"pane {pane_id!r} has non-positive width {width:g}")
         ordered.append((x, pane_id, width))
     if not ordered:
         raise SystemExit("no usable pane rects in layout")
@@ -376,6 +381,12 @@ def equalize_live(root_pane: str | None) -> int:
 
     for _ in range(MAX_EQUALIZE_PASSES):
         data = load_layout(root_pane, None)
+        # Revalidate the FULL shape on every live re-read, not just once up
+        # front: a resize (or an external client) could turn the tab into a
+        # 2D/stacked or gappy layout mid-equalize, and computing resize ops for
+        # that would scramble the panes. `_ordered_columns` guarantees per-pane
+        # geometry; `validate_single_row` guarantees the row is still clean.
+        validate_single_row(data)
         ids, widths = _ordered_columns(panes_from_layout(data))
         area = area_width_from_layout(data)
         n = len(ids)
@@ -388,8 +399,9 @@ def equalize_live(root_pane: str | None) -> int:
         for boundary in range(n - 1):
             # Re-read after each resize: one resize shifts every column to the
             # right of the moved boundary, so later ops in this pass need the
-            # updated widths to aim correctly.
+            # updated widths to aim correctly. Revalidate the shape each time too.
             data = load_layout(root_pane, None)
+            validate_single_row(data)
             ids, widths = _ordered_columns(panes_from_layout(data))
             area = area_width_from_layout(data)
             targets = equal_targets(len(ids), area)

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -62,6 +62,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import shutil
 import subprocess
 import sys
@@ -73,6 +74,30 @@ EQUAL_TOLERANCE_CELLS = 1
 # Safety cap so a pathological layout can't loop forever. The sweep is a
 # contraction; real layouts converge in ~5 passes.
 MAX_EQUALIZE_PASSES = 12
+
+
+def _finite_float(value: object, label: str, *, positive: bool = False) -> float:
+    """Convert `value` to a float that is guaranteed FINITE (and, for
+    dimensions, strictly positive).
+
+    Every geometry coordinate/dimension routes through here. `json.loads`
+    accepts `NaN`/`Infinity` by default, and a non-finite value silently defeats
+    every downstream comparison: `nan <= 0`, `nan > tol`, `abs(nan - x) > tol`
+    are all False, so a NaN width/coord would sail past the positive-width and
+    single-row checks and drive a bogus resize. Reject it here instead.
+
+    `positive=True` for dimensions (width/height); coordinates (x/y) may be 0
+    or negative, they just must be finite.
+    """
+    try:
+        f = float(value)
+    except (TypeError, ValueError) as e:
+        raise SystemExit(f"{label} is not numeric: {value!r}") from e
+    if not math.isfinite(f):
+        raise SystemExit(f"{label} is not finite: {value!r}")
+    if positive and f <= 0:
+        raise SystemExit(f"{label} must be positive: {f:g}")
+    return f
 
 
 def load_layout(root_pane: str | None, layout_json: str | None) -> dict:
@@ -129,10 +154,12 @@ def panes_from_layout(data: dict) -> list[dict]:
 def area_width_from_layout(data: dict) -> float:
     layout = _unwrap_layout(data)
     area = layout.get("area") or {}
-    try:
-        width = float(area.get("width", 0))
-    except (TypeError, ValueError):
-        width = 0.0
+    raw = area.get("width", 0)
+    # A PRESENT area width must be finite: NaN/inf would defeat the `<= 0`
+    # fallback trigger AND the `<= 0` error below, returning a poisoned width.
+    # (An absent width reads 0 → finite → falls through to the summed-pane
+    # fallback, which is unchanged.)
+    width = _finite_float(raw, "area width")
     if width <= 0:
         # Fall back to the summed pane widths so fixtures without an explicit
         # area still work.
@@ -162,11 +189,12 @@ def validate_single_row(data: dict, tolerance: int = 1) -> None:
             "layout has no 'area' rect; cannot validate a single-row column "
             "grid (refusing to split/equalize a layout of unknown shape)"
         )
-    try:
-        ax = float(area["x"]); ay = float(area["y"])
-        aw = float(area["width"]); ah = float(area["height"])
-    except (KeyError, TypeError, ValueError) as e:
-        raise SystemExit(f"layout 'area' rect missing x/y/width/height: {e}") from e
+    for k in ("x", "y", "width", "height"):
+        if k not in area:
+            raise SystemExit(f"layout 'area' rect missing {k}")
+    ax = _finite_float(area["x"], "area x"); ay = _finite_float(area["y"], "area y")
+    aw = _finite_float(area["width"], "area width", positive=True)
+    ah = _finite_float(area["height"], "area height", positive=True)
 
     panes = panes_from_layout(data)
     # Reject missing / non-string / empty / duplicate pane ids up front — a
@@ -179,11 +207,12 @@ def validate_single_row(data: dict, tolerance: int = 1) -> None:
         rect = pane.get("rect")
         if not isinstance(rect, dict):
             raise SystemExit(f"pane {pid!r} has no rect; cannot validate layout shape")
-        try:
-            x = float(rect["x"]); y = float(rect["y"])
-            w = float(rect["width"]); h = float(rect["height"])
-        except (KeyError, TypeError, ValueError) as e:
-            raise SystemExit(f"pane {pid!r} rect missing x/y/width/height: {e}") from e
+        for k in ("x", "y", "width", "height"):
+            if k not in rect:
+                raise SystemExit(f"pane {pid!r} rect missing {k}")
+        x = _finite_float(rect["x"], f"pane {pid!r} x"); y = _finite_float(rect["y"], f"pane {pid!r} y")
+        w = _finite_float(rect["width"], f"pane {pid!r} width", positive=True)
+        h = _finite_float(rect["height"], f"pane {pid!r} height", positive=True)
         rects.append((x, y, w, h, str(pid)))
 
     # Every pane must be a full-height column, top-aligned with the area.
@@ -255,13 +284,10 @@ def _ordered_columns(panes: list[dict]) -> tuple[list[str], list[float]]:
             raise SystemExit(f"pane {pane_id!r} has no rect object; cannot order columns")
         if "x" not in rect or "width" not in rect:
             raise SystemExit(f"pane {pane_id!r} rect is missing x/width")
-        try:
-            x = float(rect["x"])
-            width = float(rect["width"])
-        except (TypeError, ValueError) as e:
-            raise SystemExit(f"pane {pane_id!r} rect x/width is not numeric: {e}") from e
-        if width <= 0:
-            raise SystemExit(f"pane {pane_id!r} has non-positive width {width:g}")
+        # _finite_float rejects NaN/inf (which would defeat the width>0 check and
+        # the ordering sort) and, with positive=True, non-positive width.
+        x = _finite_float(rect["x"], f"pane {pane_id!r} x")
+        width = _finite_float(rect["width"], f"pane {pane_id!r} width", positive=True)
         ordered.append((x, pane_id, width))
     if not ordered:
         raise SystemExit("no usable pane rects in layout")
@@ -362,6 +388,23 @@ def _run_herdr(*args: str) -> subprocess.CompletedProcess:
     return subprocess.run(["herdr", *args], text=True, capture_output=True, check=False)
 
 
+def validate_live_layout(data: dict, root_pane: str | None) -> tuple[list[str], list[float]]:
+    """FULL validation of one live layout read, centralized so EVERY re-read
+    (initial, each pass, each boundary, and the final convergence check) applies
+    the SAME checks — shape (single clean row of full-height columns, finite
+    geometry) AND root membership. Omitting either on any re-read is a hole:
+    the post-cap convergence check used to run only `_ordered_columns`, so a
+    final stacked/gapped layout with coincidentally-equal widths returned
+    success, and rereads never reconfirmed the root was still present.
+
+    Returns the ordered (ids, widths) so callers don't re-parse.
+    """
+    validate_single_row(data)
+    ids, widths = _ordered_columns(panes_from_layout(data))
+    require_root_membership(ids, root_pane)
+    return ids, widths
+
+
 def equalize_live(root_pane: str | None) -> int:
     """Drive the iterative boundary equalizer against a live herdr server.
 
@@ -372,22 +415,18 @@ def equalize_live(root_pane: str | None) -> int:
     if not shutil.which("herdr"):
         raise SystemExit("herdr not on PATH")
 
-    # Reject 2D / stacked layouts BEFORE any resize — mutating a layout the
-    # column model misreads would scramble the panes.
+    # Reject 2D / stacked layouts (and a missing root) BEFORE any resize —
+    # mutating a layout the column model misreads would scramble the panes.
     initial = load_layout(root_pane, None)
-    validate_single_row(initial)
-    # And refuse to equalize a tab the requested root isn't even part of.
-    require_root_membership(_ordered_columns(panes_from_layout(initial))[0], root_pane)
+    validate_live_layout(initial, root_pane)
 
     for _ in range(MAX_EQUALIZE_PASSES):
         data = load_layout(root_pane, None)
-        # Revalidate the FULL shape on every live re-read, not just once up
-        # front: a resize (or an external client) could turn the tab into a
-        # 2D/stacked or gappy layout mid-equalize, and computing resize ops for
-        # that would scramble the panes. `_ordered_columns` guarantees per-pane
-        # geometry; `validate_single_row` guarantees the row is still clean.
-        validate_single_row(data)
-        ids, widths = _ordered_columns(panes_from_layout(data))
+        # FULL revalidation on every live re-read (shape + root membership), not
+        # just once up front: a resize or an external client could turn the tab
+        # into a 2D/stacked/gappy layout, or drop the root, mid-equalize — and
+        # computing resize ops for that would scramble the panes.
+        ids, widths = validate_live_layout(data, root_pane)
         area = area_width_from_layout(data)
         n = len(ids)
         if n < 2:
@@ -399,10 +438,9 @@ def equalize_live(root_pane: str | None) -> int:
         for boundary in range(n - 1):
             # Re-read after each resize: one resize shifts every column to the
             # right of the moved boundary, so later ops in this pass need the
-            # updated widths to aim correctly. Revalidate the shape each time too.
+            # updated widths to aim correctly. FULL revalidation each time too.
             data = load_layout(root_pane, None)
-            validate_single_row(data)
-            ids, widths = _ordered_columns(panes_from_layout(data))
+            ids, widths = validate_live_layout(data, root_pane)
             area = area_width_from_layout(data)
             targets = equal_targets(len(ids), area)
             if boundary >= len(ids) - 1:
@@ -429,10 +467,13 @@ def equalize_live(root_pane: str | None) -> int:
                     f"`herdr pane layout --pane {root_pane or '--current'}`."
                 )
 
-    # Final check after the cap. Non-convergence is also a hard error — do
-    # not report "best-effort" and let the caller proceed onto an unequal grid.
+    # Final check after the cap. FULL validation here too — the convergence
+    # check previously ran only `_ordered_columns`, so a final stacked/gapped
+    # layout (or one that lost the root) with coincidentally-equal widths would
+    # return success. Non-convergence is also a hard error — do not report
+    # "best-effort" and let the caller proceed onto an unequal grid.
     data = load_layout(root_pane, None)
-    _, widths = _ordered_columns(panes_from_layout(data))
+    _, widths = validate_live_layout(data, root_pane)
     spread = max(widths) - min(widths)
     if spread <= EQUAL_TOLERANCE_CELLS:
         return 0
@@ -473,9 +514,11 @@ def main() -> int:
 
     try:
         data = load_layout(args.root_pane, args.layout_json)
-        # Refuse to plan a split into a 2D / stacked layout — the "rightmost
-        # column" target is ambiguous there and the caller would split blindly.
-        validate_single_row(data)
+        # FULL validation (shape + finite geometry + root membership) before
+        # planning — the "rightmost column" target is ambiguous in a 2D/stacked
+        # layout and the caller would split blindly. Same centralized check the
+        # equalizer uses on every re-read.
+        validate_live_layout(data, args.root_pane)
         rightmost, new_count = plan_next_split(panes_from_layout(data), args.root_pane)
     except (OSError, json.JSONDecodeError, SystemExit) as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -1,41 +1,55 @@
 #!/usr/bin/env python3
-"""Pick the next pane to split for an equal-width column grid layout.
+"""Plan (and optionally drive) an equal-width column grid in a Herdr tab.
 
 All panes in the tab (root + every sub-agent) are kept as equal-width
-columns side by side, left to right. Adding the Nth pane means:
-  1. Split the rightmost (last) column `right` so the new pane lands as
-     the new rightmost column, sized to the target equal share.
-  2. Resize every pre-existing column down to that same equal share (they
-     were each 1/(N-1) wide before the split; they need to become 1/N).
+columns side by side, left to right. This models the *real* Herdr 0.7.4
+`pane split` / `pane resize` semantics, verified live against a running
+herdr server (see SKILL.md "Equal-width columns — verified semantics"):
 
-This intentionally replaces the older "largest pane by area, direction from
-aspect ratio" heuristic: that heuristic optimized for a balanced 2D grid,
-not for uniform column width. Equal-width columns are a stronger, simpler
-constraint that a single split's ratio cannot satisfy on its own once more
-than one column already exists — the already-placed columns must also be
-resized, which is why this script emits a resize plan, not just a target
-pane and direction.
+  * `herdr pane split <pane> --direction right --ratio R`
+        R is the fraction the EXISTING (first/left) child keeps of the
+        pane being split; the new pane gets (1 - R). It only resizes the
+        pane you split — the other columns are untouched. So a single
+        split can NEVER equalize N >= 3 columns on its own.
 
-Reads `herdr pane layout` for the root/tab area (or a supplied JSON dump).
+  * `herdr pane resize --pane P --direction D --amount A`
+        A is a DELTA expressed as a fraction of the whole tab area width
+        (A * area_width cells), NOT an absolute target width. `--direction`
+        moves the edge on side D: for a pane that has a neighbor on side D
+        it GROWS toward that neighbor; against a wall it shrinks. The freed
+        or absorbed cells redistribute *proportionally* among the panes on
+        the other side of the moved boundary. Because that redistribution
+        perturbs columns you already placed, a single left-to-right sweep
+        does not land equal — but the sweep is a contraction: iterating it
+        converges to equal width within ~1 cell in a handful of passes
+        (verified: spread 25 -> 13 -> 5 -> 3 -> 1 for a 4-column decay).
+
+So the reliable strategy this script encodes is:
+
+  1. Add column N by splitting the current rightmost column `right` with
+     `--ratio (N-1)/N` so the new pane is born at the 1/N target share.
+  2. Run an iterative boundary equalizer: sweep internal boundaries left
+     to right, moving each toward its target cumulative position by GROWING
+     the neighbor-bearing pane; repeat until the width spread is <= 1 cell
+     (or a small iteration cap). Each pass re-reads the live layout.
+
+`--emit-plan` prints the split line only (for a shell caller that runs the
+equalizer via `equalize_columns.py`). `--equalize` runs the full live
+equalizer itself against `herdr` and exits.
 
 Usage:
+    # plan the split for the next column (default)
     python3 next_grid_split.py [--root-pane PANE_ID] [--layout-json PATH|-]
 
-Output: one line per action, so a caller can feed each directly to `herdr`:
+    # run the live iterative equalizer over the current tab
+    python3 next_grid_split.py --equalize [--root-pane PANE_ID]
 
-    split <rightmost_pane_id> right --ratio <new_pane_share>
-    resize <pane_id> <target_width_fraction>
-    resize <pane_id> <target_width_fraction>
-    ...
+Default output (one split line a caller feeds to `herdr pane split`):
 
-`<new_pane_share>` and `<target_width_fraction>` are both `1 / N` where N is
-the column count *after* the split (existing columns + the new one). The
-exact `herdr pane split --ratio` / `herdr pane resize --amount` semantics
-(fraction of remaining space vs. absolute tab fraction vs. cells) are not
-verified against a live `herdr` server by this script or its tests — the
-caller is responsible for confirming those semantics against the installed
-`herdr` version before trusting the resize step blindly (see SKILL.md
-Phase 2a and the "Equal-width columns" note there).
+    split <rightmost_pane_id> right --ratio <existing_child_ratio>
+
+where <existing_child_ratio> = (N-1)/N and N is the column count AFTER the
+split. Follow it with the equalizer (see SKILL.md Phase 2a).
 
 Exit codes:
     0 success
@@ -49,6 +63,14 @@ import json
 import shutil
 import subprocess
 import sys
+
+# Equal within this many cells is "done" — herdr rounds column widths to
+# whole terminal cells, so exact equality is impossible when area_width is
+# not divisible by the column count.
+EQUAL_TOLERANCE_CELLS = 1
+# Safety cap so a pathological layout can't loop forever. The sweep is a
+# contraction; real layouts converge in ~5 passes.
+MAX_EQUALIZE_PASSES = 12
 
 
 def load_layout(root_pane: str | None, layout_json: str | None) -> dict:
@@ -72,22 +94,50 @@ def load_layout(root_pane: str | None, layout_json: str | None) -> dict:
     return json.loads(cp.stdout)
 
 
+def _unwrap_layout(data: dict) -> dict:
+    """Return the inner `layout` object regardless of whether `data` is the
+    raw CLI envelope (`{"result": {"layout": {...}}}`), a `{"layout": {...}}`
+    fixture, or the layout dict itself."""
+    node = data.get("result", data)
+    if isinstance(node, dict) and "layout" in node:
+        node = node["layout"]
+    if not isinstance(node, dict):
+        raise SystemExit("layout JSON is not an object")
+    return node
+
+
 def panes_from_layout(data: dict) -> list[dict]:
-    layout = data.get("result", data).get("layout", data.get("result", data))
-    panes = layout.get("panes") if isinstance(layout, dict) else None
+    layout = _unwrap_layout(data)
+    panes = layout.get("panes")
     if not isinstance(panes, list) or not panes:
         raise SystemExit("layout JSON has no panes")
     return panes
 
 
-def _pane_ids_left_to_right(panes: list[dict]) -> list[str]:
-    """Order panes by rect.x so 'rightmost column' is well-defined.
+def area_width_from_layout(data: dict) -> float:
+    layout = _unwrap_layout(data)
+    area = layout.get("area") or {}
+    try:
+        width = float(area.get("width", 0))
+    except (TypeError, ValueError):
+        width = 0.0
+    if width <= 0:
+        # Fall back to the summed pane widths so fixtures without an explicit
+        # area still work.
+        width = sum(_ordered_columns(panes_from_layout(data))[1])
+    if width <= 0:
+        raise SystemExit("layout JSON has no usable area width")
+    return width
+
+
+def _ordered_columns(panes: list[dict]) -> tuple[list[str], list[float]]:
+    """Order panes by rect.x and return parallel (ids, widths) lists.
 
     Panes without a usable rect are dropped rather than guessed at — a
     missing x/width is a layout-shape error the caller should see, not
     something to silently default to 0.
     """
-    ordered: list[tuple[float, str]] = []
+    ordered: list[tuple[float, str, float]] = []
     for pane in panes:
         pane_id = pane.get("pane_id")
         rect = pane.get("rect") or {}
@@ -98,28 +148,123 @@ def _pane_ids_left_to_right(panes: list[dict]) -> list[str]:
             continue
         if not pane_id or width <= 0:
             continue
-        ordered.append((x, pane_id))
+        ordered.append((x, pane_id, width))
     if not ordered:
         raise SystemExit("no usable pane rects in layout")
     ordered.sort(key=lambda t: t[0])
-    return [pid for _, pid in ordered]
+    return [pid for _, pid, _ in ordered], [w for _, _, w in ordered]
 
 
-def plan_equal_width_split(panes: list[dict], root_pane: str | None) -> tuple[list[str], float]:
-    """Return (ordered_pane_ids_left_to_right, new_column_count) for the
-    caller to build the split + resize plan from. `root_pane` is accepted
-    for interface symmetry with the previous largest-pane heuristic and to
-    let a caller sanity-check root is present; it does not change the
-    equal-width plan (every column — root included — always converges to
-    the same share).
+def _pane_ids_left_to_right(panes: list[dict]) -> list[str]:
+    return _ordered_columns(panes)[0]
+
+
+def equal_targets(n: int, area_width: float) -> list[int]:
+    """Equal-width integer column targets summing to `area_width`.
+
+    Splits the +/-1 rounding remainder onto the leftmost columns, matching
+    how herdr distributes cells that don't divide evenly.
     """
+    if n <= 0:
+        raise SystemExit("column count must be positive")
+    total = int(round(area_width))
+    base = total // n
+    rem = total - base * n
+    return [base + (1 if i < rem else 0) for i in range(n)]
+
+
+def boundary_resize_op(
+    ids: list[str],
+    widths: list[float],
+    targets: list[int],
+    area_width: float,
+    boundary: int,
+) -> tuple[str, str, float] | None:
+    """Compute the single resize op that moves internal `boundary`
+    (between column `boundary` and `boundary+1`) toward its target
+    cumulative position, always by GROWING the neighbor-bearing pane.
+
+    Returns `(pane_id, direction, amount)` or None if already on target.
+    `amount` is a fraction of `area_width` (the herdr `--amount` unit).
+
+    * boundary must move RIGHT  -> grow left column: resize ids[boundary] right
+    * boundary must move LEFT   -> grow right column: resize ids[boundary+1] left
+    """
+    target_cum = sum(targets[: boundary + 1])
+    cur_cum = sum(widths[: boundary + 1])
+    delta = target_cum - cur_cum  # >0: boundary too far left, must move right
+    if abs(delta) < 1:  # sub-cell; nothing herdr can act on
+        return None
+    amount = abs(delta) / area_width
+    if delta > 0:
+        return (ids[boundary], "right", amount)
+    return (ids[boundary + 1], "left", amount)
+
+
+def plan_next_split(panes: list[dict], root_pane: str | None) -> tuple[str, int]:
+    """Return `(rightmost_pane_id, new_column_count)` for adding a column."""
     ordered = _pane_ids_left_to_right(panes)
     if root_pane and root_pane not in ordered:
-        # Not fatal — layout JSON may come from a fixture/test — but the
-        # caller should know root isn't part of what it's about to resize.
         print(f"Warning: root pane {root_pane!r} not found in layout", file=sys.stderr)
-    new_count = len(ordered) + 1
-    return ordered, new_count
+    return ordered[-1], len(ordered) + 1
+
+
+def _run_herdr(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["herdr", *args], text=True, capture_output=True, check=False)
+
+
+def equalize_live(root_pane: str | None) -> int:
+    """Drive the iterative boundary equalizer against a live herdr server.
+
+    Re-reads the layout each pass (resizes perturb downstream columns), and
+    stops once the width spread is within EQUAL_TOLERANCE_CELLS or the pass
+    cap is hit. Returns 0 on convergence, 1 if it never converged.
+    """
+    if not shutil.which("herdr"):
+        raise SystemExit("herdr not on PATH")
+
+    for _ in range(MAX_EQUALIZE_PASSES):
+        data = load_layout(root_pane, None)
+        ids, widths = _ordered_columns(panes_from_layout(data))
+        area = area_width_from_layout(data)
+        n = len(ids)
+        if n < 2:
+            return 0  # single column is trivially "equal"
+        targets = equal_targets(n, area)
+        spread = max(widths) - min(widths)
+        if spread <= EQUAL_TOLERANCE_CELLS:
+            return 0
+        for boundary in range(n - 1):
+            # Re-read after each resize: one resize shifts every column to the
+            # right of the moved boundary, so later ops in this pass need the
+            # updated widths to aim correctly.
+            data = load_layout(root_pane, None)
+            ids, widths = _ordered_columns(panes_from_layout(data))
+            area = area_width_from_layout(data)
+            targets = equal_targets(len(ids), area)
+            if boundary >= len(ids) - 1:
+                break
+            op = boundary_resize_op(ids, widths, targets, area, boundary)
+            if op is None:
+                continue
+            pane_id, direction, amount = op
+            _run_herdr(
+                "pane", "resize", "--pane", pane_id,
+                "--direction", direction, "--amount", f"{amount:.6f}",
+            )
+
+    # Final check after the cap.
+    data = load_layout(root_pane, None)
+    _, widths = _ordered_columns(panes_from_layout(data))
+    spread = max(widths) - min(widths)
+    if spread <= EQUAL_TOLERANCE_CELLS:
+        return 0
+    print(
+        f"Warning: columns not fully equal after {MAX_EQUALIZE_PASSES} passes "
+        f"(spread {spread:.0f} cells); layout is best-effort.",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def main() -> int:
@@ -134,21 +279,30 @@ def main() -> int:
         "--layout-json",
         help="layout JSON path, or '-' for stdin (skips herdr pane layout)",
     )
+    ap.add_argument(
+        "--equalize",
+        action="store_true",
+        help="run the live iterative boundary equalizer over the current tab and exit",
+    )
     args = ap.parse_args()
+
+    if args.equalize:
+        try:
+            return equalize_live(args.root_pane)
+        except (OSError, json.JSONDecodeError, SystemExit) as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
 
     try:
         data = load_layout(args.root_pane, args.layout_json)
-        ordered, new_count = plan_equal_width_split(panes_from_layout(data), args.root_pane)
+        rightmost, new_count = plan_next_split(panes_from_layout(data), args.root_pane)
     except (OSError, json.JSONDecodeError, SystemExit) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    share = 1.0 / new_count
-    rightmost = ordered[-1]
-    print(f"split {rightmost} right --ratio {share:.6f}")
-    for pane_id in ordered:
-        print(f"resize {pane_id} {share:.6f}")
-
+    # existing (left) child keeps (N-1)/N so the NEW pane is born at 1/N.
+    existing_child_ratio = (new_count - 1) / new_count
+    print(f"split {rightmost} right --ratio {existing_child_ratio:.6f}")
     return 0
 
 

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Pick the next pane to split for a balanced grid layout.
+
+Reads `herdr pane layout` for the root/tab area and chooses:
+  - the largest pane by area (ties prefer the root pane when provided)
+  - direction `down` when that pane is taller than or as tall as it is wide
+    (vertical panel / stack first), else `right`
+
+This keeps the root agent and every sub-agent in one tiled grid instead of
+stacking every new split off a single pane.
+
+Usage:
+    python3 next_grid_split.py [--root-pane PANE_ID] [--layout-json PATH|-]
+
+Prints: <pane_id> <right|down>
+
+Exit codes:
+    0 success
+    1 usage / environment / parse error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+
+
+def load_layout(root_pane: str | None, layout_json: str | None) -> dict:
+    if layout_json == "-":
+        return json.load(sys.stdin)
+    if layout_json:
+        with open(layout_json, encoding="utf-8") as f:
+            return json.load(f)
+
+    if not shutil.which("herdr"):
+        raise SystemExit("herdr not on PATH")
+
+    cmd = ["herdr", "pane", "layout"]
+    if root_pane:
+        cmd.extend(["--pane", root_pane])
+    else:
+        cmd.append("--current")
+    cp = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    if cp.returncode != 0:
+        raise SystemExit(cp.stderr.strip() or cp.stdout.strip() or "herdr pane layout failed")
+    return json.loads(cp.stdout)
+
+
+def panes_from_layout(data: dict) -> list[dict]:
+    layout = data.get("result", data).get("layout", data.get("result", data))
+    panes = layout.get("panes") if isinstance(layout, dict) else None
+    if not isinstance(panes, list) or not panes:
+        raise SystemExit("layout JSON has no panes")
+    return panes
+
+
+def choose_target(panes: list[dict], root_pane: str | None) -> tuple[str, str]:
+    best: dict | None = None
+    best_area = -1
+    for pane in panes:
+        pane_id = pane.get("pane_id")
+        rect = pane.get("rect") or {}
+        try:
+            width = float(rect.get("width", 0))
+            height = float(rect.get("height", 0))
+        except (TypeError, ValueError):
+            continue
+        if not pane_id or width <= 0 or height <= 0:
+            continue
+        area = width * height
+        # Prefer root on area ties so the orchestrator stays in the grid plan.
+        better = area > best_area or (
+            area == best_area and root_pane and pane_id == root_pane
+        )
+        if better or best is None:
+            best = {"pane_id": pane_id, "width": width, "height": height}
+            best_area = area
+
+    if best is None:
+        raise SystemExit("no usable pane rects in layout")
+
+    # Prefer vertical panels first: stack top/bottom unless the cell is clearly wider.
+    direction = "down" if best["height"] >= best["width"] else "right"
+    return best["pane_id"], direction
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--root-pane",
+        help="root/orchestrator pane id; preferred on area ties",
+    )
+    ap.add_argument(
+        "--layout-json",
+        help="layout JSON path, or '-' for stdin (skips herdr pane layout)",
+    )
+    args = ap.parse_args()
+
+    try:
+        data = load_layout(args.root_pane, args.layout_json)
+        target, direction = choose_target(panes_from_layout(data), args.root_pane)
+    except (OSError, json.JSONDecodeError, SystemExit) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"{target} {direction}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -1,18 +1,41 @@
 #!/usr/bin/env python3
-"""Pick the next pane to split for a balanced grid layout.
+"""Pick the next pane to split for an equal-width column grid layout.
 
-Reads `herdr pane layout` for the root/tab area and chooses:
-  - the largest pane by area (ties prefer the root pane when provided)
-  - direction `down` when that pane is taller than or as tall as it is wide
-    (vertical panel / stack first), else `right`
+All panes in the tab (root + every sub-agent) are kept as equal-width
+columns side by side, left to right. Adding the Nth pane means:
+  1. Split the rightmost (last) column `right` so the new pane lands as
+     the new rightmost column, sized to the target equal share.
+  2. Resize every pre-existing column down to that same equal share (they
+     were each 1/(N-1) wide before the split; they need to become 1/N).
 
-This keeps the root agent and every sub-agent in one tiled grid instead of
-stacking every new split off a single pane.
+This intentionally replaces the older "largest pane by area, direction from
+aspect ratio" heuristic: that heuristic optimized for a balanced 2D grid,
+not for uniform column width. Equal-width columns are a stronger, simpler
+constraint that a single split's ratio cannot satisfy on its own once more
+than one column already exists — the already-placed columns must also be
+resized, which is why this script emits a resize plan, not just a target
+pane and direction.
+
+Reads `herdr pane layout` for the root/tab area (or a supplied JSON dump).
 
 Usage:
     python3 next_grid_split.py [--root-pane PANE_ID] [--layout-json PATH|-]
 
-Prints: <pane_id> <right|down>
+Output: one line per action, so a caller can feed each directly to `herdr`:
+
+    split <rightmost_pane_id> right --ratio <new_pane_share>
+    resize <pane_id> <target_width_fraction>
+    resize <pane_id> <target_width_fraction>
+    ...
+
+`<new_pane_share>` and `<target_width_fraction>` are both `1 / N` where N is
+the column count *after* the split (existing columns + the new one). The
+exact `herdr pane split --ratio` / `herdr pane resize --amount` semantics
+(fraction of remaining space vs. absolute tab fraction vs. cells) are not
+verified against a live `herdr` server by this script or its tests — the
+caller is responsible for confirming those semantics against the installed
+`herdr` version before trusting the resize step blindly (see SKILL.md
+Phase 2a and the "Equal-width columns" note there).
 
 Exit codes:
     0 success
@@ -57,48 +80,55 @@ def panes_from_layout(data: dict) -> list[dict]:
     return panes
 
 
-def choose_target(panes: list[dict], root_pane: str | None) -> tuple[str, str]:
-    best: dict | None = None
-    best_area = -1
+def _pane_ids_left_to_right(panes: list[dict]) -> list[str]:
+    """Order panes by rect.x so 'rightmost column' is well-defined.
+
+    Panes without a usable rect are dropped rather than guessed at — a
+    missing x/width is a layout-shape error the caller should see, not
+    something to silently default to 0.
+    """
+    ordered: list[tuple[float, str]] = []
     for pane in panes:
         pane_id = pane.get("pane_id")
         rect = pane.get("rect") or {}
         try:
+            x = float(rect.get("x", 0))
             width = float(rect.get("width", 0))
-            height = float(rect.get("height", 0))
         except (TypeError, ValueError):
             continue
-        if not pane_id or width <= 0 or height <= 0:
+        if not pane_id or width <= 0:
             continue
-        area = width * height
-        # Prefer root on area ties so the orchestrator stays in the grid plan.
-        better = area > best_area or (
-            area == best_area and root_pane and pane_id == root_pane
-        )
-        if better or best is None:
-            best = {"pane_id": pane_id, "width": width, "height": height}
-            best_area = area
-
-    if best is None:
+        ordered.append((x, pane_id))
+    if not ordered:
         raise SystemExit("no usable pane rects in layout")
+    ordered.sort(key=lambda t: t[0])
+    return [pid for _, pid in ordered]
 
-    # First split of a single-pane layout always goes down: this is the
-    # documented "vertical panel first" default (root on top, first worker
-    # below), independent of aspect ratio (most terminals are wider than
-    # tall, so a plain aspect check would pick `right` here instead).
-    if len(panes) == 1:
-        return best["pane_id"], "down"
 
-    # Later splits: direction follows the target cell's own aspect.
-    direction = "down" if best["height"] >= best["width"] else "right"
-    return best["pane_id"], direction
+def plan_equal_width_split(panes: list[dict], root_pane: str | None) -> tuple[list[str], float]:
+    """Return (ordered_pane_ids_left_to_right, new_column_count) for the
+    caller to build the split + resize plan from. `root_pane` is accepted
+    for interface symmetry with the previous largest-pane heuristic and to
+    let a caller sanity-check root is present; it does not change the
+    equal-width plan (every column — root included — always converges to
+    the same share).
+    """
+    ordered = _pane_ids_left_to_right(panes)
+    if root_pane and root_pane not in ordered:
+        # Not fatal — layout JSON may come from a fixture/test — but the
+        # caller should know root isn't part of what it's about to resize.
+        print(f"Warning: root pane {root_pane!r} not found in layout", file=sys.stderr)
+    new_count = len(ordered) + 1
+    return ordered, new_count
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     ap.add_argument(
         "--root-pane",
-        help="root/orchestrator pane id; preferred on area ties",
+        help="root/orchestrator pane id; checked for presence, not otherwise special",
     )
     ap.add_argument(
         "--layout-json",
@@ -108,12 +138,17 @@ def main() -> int:
 
     try:
         data = load_layout(args.root_pane, args.layout_json)
-        target, direction = choose_target(panes_from_layout(data), args.root_pane)
+        ordered, new_count = plan_equal_width_split(panes_from_layout(data), args.root_pane)
     except (OSError, json.JSONDecodeError, SystemExit) as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
 
-    print(f"{target} {direction}")
+    share = 1.0 / new_count
+    rightmost = ordered[-1]
+    print(f"split {rightmost} right --ratio {share:.6f}")
+    for pane_id in ordered:
+        print(f"resize {pane_id} {share:.6f}")
+
     return 0
 
 

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -271,11 +271,27 @@ def boundary_resize_op(
     return (ids[boundary + 1], "left", amount)
 
 
+def require_root_membership(ids: list[str], root_pane: str | None) -> None:
+    """Fail HARD if a requested root pane isn't part of the layout.
+
+    If the caller named a `root_pane` but it isn't among the ordered column
+    ids, the layout we're about to split/equalize is NOT the root's tab — so
+    the "rightmost column" target and the whole equal-width plan would apply
+    to the wrong tab. That must abort before any mutation, not warn and
+    proceed. `root_pane is None` means "no specific root requested" and is
+    fine (plan from whatever layout was supplied).
+    """
+    if root_pane and root_pane not in ids:
+        raise SystemExit(
+            f"requested root pane {root_pane!r} is not in this layout "
+            f"(columns: {ids}); refusing to split/equalize the wrong tab"
+        )
+
+
 def plan_next_split(panes: list[dict], root_pane: str | None) -> tuple[str, int]:
     """Return `(rightmost_pane_id, new_column_count)` for adding a column."""
     ordered = _pane_ids_left_to_right(panes)
-    if root_pane and root_pane not in ordered:
-        print(f"Warning: root pane {root_pane!r} not found in layout", file=sys.stderr)
+    require_root_membership(ordered, root_pane)
     return ordered[-1], len(ordered) + 1
 
 
@@ -314,7 +330,10 @@ def equalize_live(root_pane: str | None) -> int:
 
     # Reject 2D / stacked layouts BEFORE any resize — mutating a layout the
     # column model misreads would scramble the panes.
-    validate_single_row(load_layout(root_pane, None))
+    initial = load_layout(root_pane, None)
+    validate_single_row(initial)
+    # And refuse to equalize a tab the requested root isn't even part of.
+    require_root_membership(_ordered_columns(panes_from_layout(initial))[0], root_pane)
 
     for _ in range(MAX_EQUALIZE_PASSES):
         data = load_layout(root_pane, None)

--- a/skills/herdr-agent-comms/scripts/next_grid_split.py
+++ b/skills/herdr-agent-comms/scripts/next_grid_split.py
@@ -132,6 +132,74 @@ def area_width_from_layout(data: dict) -> float:
     return width
 
 
+def validate_single_row(data: dict, tolerance: int = 1) -> None:
+    """Reject layouts this script cannot safely treat as a row of columns.
+
+    The split/equalize model assumes every pane is a full-height column
+    tiling the tab left to right. A 2D layout (vertically stacked panes, or a
+    partial-height pane) breaks that: panes sharing an `x` would be counted as
+    separate columns, inflating the column total and making the "rightmost
+    column" split target ambiguous. This validates x/y/width/height BEFORE any
+    mutation and raises SystemExit on anything that isn't a single clean row.
+
+    Requires a real `area` rect (the summed-width fallback in
+    `area_width_from_layout` is unsafe here — stacked panes double-count).
+    """
+    layout = _unwrap_layout(data)
+    area = layout.get("area")
+    if not isinstance(area, dict):
+        raise SystemExit(
+            "layout has no 'area' rect; cannot validate a single-row column "
+            "grid (refusing to split/equalize a layout of unknown shape)"
+        )
+    try:
+        ax = float(area["x"]); ay = float(area["y"])
+        aw = float(area["width"]); ah = float(area["height"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise SystemExit(f"layout 'area' rect missing x/y/width/height: {e}") from e
+
+    panes = panes_from_layout(data)
+    rects: list[tuple[float, float, float, float, str]] = []
+    for pane in panes:
+        pid = pane.get("pane_id")
+        rect = pane.get("rect")
+        if not isinstance(rect, dict):
+            raise SystemExit(f"pane {pid!r} has no rect; cannot validate layout shape")
+        try:
+            x = float(rect["x"]); y = float(rect["y"])
+            w = float(rect["width"]); h = float(rect["height"])
+        except (KeyError, TypeError, ValueError) as e:
+            raise SystemExit(f"pane {pid!r} rect missing x/y/width/height: {e}") from e
+        rects.append((x, y, w, h, str(pid)))
+
+    # Every pane must be a full-height column, top-aligned with the area.
+    for x, y, w, h, pid in rects:
+        if abs(y - ay) > tolerance or abs(h - ah) > tolerance:
+            raise SystemExit(
+                f"pane {pid} is not a full-height column (y={y:g} h={h:g} vs "
+                f"area y={ay:g} h={ah:g}): this looks like a 2D / stacked "
+                f"layout, which this skill does not support. Rearrange to a "
+                f"single row of columns (or spawn agents in separate tabs)."
+            )
+
+    # Columns must tile left-to-right with no overlaps or gaps.
+    rects.sort(key=lambda t: t[0])
+    cursor = ax
+    for x, _y, w, _h, pid in rects:
+        if abs(x - cursor) > tolerance:
+            raise SystemExit(
+                f"column {pid} starts at x={x:g}, expected {cursor:g} — panes "
+                f"overlap or leave a gap; not a clean single row. Refusing to "
+                f"split/equalize."
+            )
+        cursor += w
+    if abs(cursor - (ax + aw)) > tolerance:
+        raise SystemExit(
+            f"columns span to x={cursor:g} but area ends at {ax + aw:g}; the "
+            f"row does not fill the tab width. Refusing to split/equalize."
+        )
+
+
 def _ordered_columns(panes: list[dict]) -> tuple[list[str], list[float]]:
     """Order panes by rect.x and return parallel (ids, widths) lists.
 
@@ -244,6 +312,10 @@ def equalize_live(root_pane: str | None) -> int:
     if not shutil.which("herdr"):
         raise SystemExit("herdr not on PATH")
 
+    # Reject 2D / stacked layouts BEFORE any resize — mutating a layout the
+    # column model misreads would scramble the panes.
+    validate_single_row(load_layout(root_pane, None))
+
     for _ in range(MAX_EQUALIZE_PASSES):
         data = load_layout(root_pane, None)
         ids, widths = _ordered_columns(panes_from_layout(data))
@@ -331,6 +403,9 @@ def main() -> int:
 
     try:
         data = load_layout(args.root_pane, args.layout_json)
+        # Refuse to plan a split into a 2D / stacked layout — the "rightmost
+        # column" target is ambiguous there and the caller would split blindly.
+        validate_single_row(data)
         rightmost, new_count = plan_next_split(panes_from_layout(data), args.root_pane)
     except (OSError, json.JSONDecodeError, SystemExit) as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/skills/herdr-agent-comms/scripts/preflight_send.py
+++ b/skills/herdr-agent-comms/scripts/preflight_send.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Fail-closed pre-send readiness check for a single Herdr pane.
+
+Run this immediately BEFORE typing a task (or a lone Enter) into a pane. It
+answers one question: is this pane safe to deliver to *right now*? A pane that
+is `working`, `blocked`, or whose status can't be verified is NOT safe — sending
+into it either races a prior task's completion signal or types the payload into
+a trust/auth dialog.
+
+This is the single-target twin of `scripts/broadcast.sh` Phase 1b: the exact
+same fail-closed enum validation, in one testable place so the two paths can't
+drift. The status enum lives in `wait_for_idle.py` (imported here).
+
+Exit codes (chosen so callers can branch on the reason):
+    0  sendable   (idle / done / unknown — validly reported)
+    2  working    (a prior task is in flight; wait for it to settle first)
+    3  blocked    (a dialog is on screen; a human must answer it)
+    4  unverifiable (lookup/parse failed OR an off-enum/garbage status value)
+    1  usage error (herdr missing, no pane id)
+
+On a non-zero exit a one-line reason is printed to stderr; nothing is printed
+to stdout unless the pane is sendable (then the resolved status is echoed).
+
+Usage:
+    python3 preflight_send.py <pane_id>
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from wait_for_idle import LOOKUP_FAILED, agent_status  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 1:
+        print("usage: preflight_send.py <pane_id>", file=sys.stderr)
+        return 1
+    pane_id = argv[0]
+    if not shutil.which("herdr"):
+        print("Error: herdr not on PATH", file=sys.stderr)
+        return 1
+
+    # agent_status() is already fail-closed + enum-validated: a failed lookup,
+    # unparseable JSON, or an off-enum value (numeric/garbage) all come back as
+    # LOOKUP_FAILED, never as a spuriously "safe" status.
+    st = agent_status(pane_id)
+    if st == LOOKUP_FAILED:
+        print(
+            f"Error: cannot verify status of {pane_id} (lookup/parse failed or "
+            f"off-enum value) — refusing to send into an unverifiable pane.",
+            file=sys.stderr,
+        )
+        return 4
+    if st == "working":
+        print(
+            f"Error: {pane_id} is already working — wait for it to settle "
+            f"before sending, or this send's completion can't be told apart "
+            f"from the prior task's.",
+            file=sys.stderr,
+        )
+        return 2
+    if st == "blocked":
+        print(
+            f"Error: {pane_id} is blocked (trust/auth/permission dialog) — a "
+            f"human must answer it first (herdr agent focus <name>); typing the "
+            f"task now would submit garbage into the dialog.",
+            file=sys.stderr,
+        )
+        return 3
+    # idle / done / unknown (validly reported) are safe to deliver to.
+    print(st)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -106,10 +106,35 @@ def resolve_pane(target: str) -> str:
 # genuine "unknown" (non-integrated CLI) still uses the content-stability path.
 LOOKUP_FAILED = "\x00lookup-failed"
 
+# The documented agent-status enum. ANY other value — a number, an empty
+# string, a typo, an out-of-band string the server invents — is unverifiable,
+# NOT a benign "unknown". Accepting arbitrary truthy values fails open: a
+# numeric `123` status would sail past the working/blocked checks and be
+# treated as sendable/settled. Absent/null still maps to "unknown" (the
+# non-integrated-CLI case); everything off-enum maps to LOOKUP_FAILED so it is
+# rejected on --ready and routed to content-stability (which needs real work
+# before it settles) on a normal wait.
+VALID_STATUSES = frozenset({"idle", "working", "blocked", "done", "unknown"})
+
+
+def normalize_status(raw: object) -> str:
+    """Map a raw agent_status value onto the documented enum.
+
+    absent/null   -> "unknown"        (verifiable; non-integrated CLI)
+    in the enum   -> that status
+    anything else -> LOOKUP_FAILED    (wrong type, empty string, off-enum)
+    """
+    if raw is None:
+        return "unknown"
+    if isinstance(raw, str) and raw in VALID_STATUSES:
+        return raw
+    return LOOKUP_FAILED
+
 
 def agent_status(pane_id: str) -> str:
-    """Return the pane's agent status, "unknown" if validly absent, or
-    LOOKUP_FAILED if the `herdr pane get` call failed / didn't parse."""
+    """Return the pane's agent status (a member of VALID_STATUSES), or
+    LOOKUP_FAILED if the `herdr pane get` call failed, didn't parse, or
+    reported a value outside the documented enum."""
     cp = run(["herdr", "pane", "get", pane_id])
     if cp.returncode != 0:
         return LOOKUP_FAILED
@@ -117,7 +142,7 @@ def agent_status(pane_id: str) -> str:
         pane = json.loads(cp.stdout)["result"]["pane"]
     except (json.JSONDecodeError, KeyError):
         return LOOKUP_FAILED
-    return pane.get("agent_status") or "unknown"
+    return normalize_status(pane.get("agent_status"))
 
 
 def _unverifiable(st: str, args) -> bool:

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -266,12 +266,26 @@ def main() -> int:
                 marker_seen = (
                     args.completion_marker is not None
                     and args.completion_marker in cur
+                    and args.completion_marker not in baseline
                 )
-                if args.ready or saw_working or marker_seen:
+                if args.ready:
                     if not args.no_print:
                         print_delta(baseline, cur, args.full)
                     return 0
-                if saw_work and args.completion_marker is None:
+                if args.completion_marker is not None:
+                    # Marker mode: only a fresh marker (absent from baseline) proves
+                    # THIS send finished. A stale `saw_working` from a pane that was
+                    # already busy before this send must not short-circuit success.
+                    if marker_seen:
+                        if not args.no_print:
+                            print_delta(baseline, cur, args.full)
+                        return 0
+                    # Not seen yet: keep waiting (fall through to re-poll below).
+                elif saw_working:
+                    if not args.no_print:
+                        print_delta(baseline, cur, args.full)
+                    return 0
+                elif saw_work:
                     # Legacy fallback when no marker was arranged before send.
                     break
                 # Pre-task idle: wait for working (or transcript change via status loop)
@@ -306,7 +320,11 @@ def main() -> int:
             saw_work = True
             saw_working = True
         cur = pane_read(pane_id, args.lines)
-        if args.completion_marker and args.completion_marker in cur:
+        if (
+            args.completion_marker
+            and args.completion_marker in cur
+            and args.completion_marker not in baseline
+        ):
             if not args.no_print:
                 print_delta(baseline, cur, args.full)
             return 0

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -21,6 +21,8 @@ Usage:
 
 Options:
     --timeout SEC        give up after this many seconds (default: 120)
+    --baseline-file PATH use a pre-send pane-read capture as the baseline
+    --completion-marker S require S when working transition was missed
     --quiet-cycles N     consecutive unchanged reads to call it settled (default: 3)
     --interval SEC       seconds between captures (default: 2)
     --lines N            pane read line window (default: 60)
@@ -101,10 +103,24 @@ def agent_status(pane_id: str) -> str | None:
     if cp.returncode != 0:
         return None
     try:
-        d = json.loads(cp.stdout)
-        return d["result"]["pane"].get("agent_status")
+        return json.loads(cp.stdout)["result"]["pane"].get("agent_status")
     except (json.JSONDecodeError, KeyError):
         return None
+
+
+def extract_pane_text(out: str) -> str:
+    """Normalize either raw text or `herdr pane read` JSON to transcript text."""
+    try:
+        d = json.loads(out)
+        r = d.get("result", d)
+        for key in ("text", "content", "output", "data"):
+            if isinstance(r.get(key), str):
+                return r[key]
+        if isinstance(r.get("lines"), list):
+            return "\n".join(str(x) for x in r["lines"])
+    except (json.JSONDecodeError, AttributeError):
+        pass
+    return out
 
 
 def pane_read(pane_id: str, lines: int) -> str:
@@ -120,20 +136,8 @@ def pane_read(pane_id: str, lines: int) -> str:
             str(lines),
         ]
     )
-    if cp.returncode != 0:
-        return cp.stdout or cp.stderr or ""
-    out = cp.stdout or ""
-    try:
-        d = json.loads(out)
-        r = d.get("result", d)
-        for key in ("text", "content", "output", "data"):
-            if isinstance(r.get(key), str):
-                return r[key]
-        if isinstance(r.get("lines"), list):
-            return "\n".join(str(x) for x in r["lines"])
-    except json.JSONDecodeError:
-        pass
-    return out
+    out = cp.stdout or cp.stderr or ""
+    return extract_pane_text(out)
 
 
 def wait_status(pane_id: str, status: str, timeout_ms: int) -> bool:
@@ -170,6 +174,14 @@ def main() -> int:
     )
     ap.add_argument("target", help="pane id or agent name")
     ap.add_argument("--timeout", type=float, default=120.0)
+    ap.add_argument(
+        "--baseline-file",
+        help="pre-send `herdr pane read` capture; closes the fast-completion race",
+    )
+    ap.add_argument(
+        "--completion-marker",
+        help="marker the agent prints only after finishing the task",
+    )
     ap.add_argument("--quiet-cycles", type=int, default=3)
     ap.add_argument("--interval", type=float, default=2.0)
     ap.add_argument("--lines", type=int, default=60)
@@ -206,13 +218,22 @@ def main() -> int:
         return 1
 
     deadline = time.time() + args.timeout
-    baseline = pane_read(pane_id, args.lines)
+    if args.baseline_file:
+        try:
+            with open(args.baseline_file, encoding="utf-8") as f:
+                baseline = extract_pane_text(f.read())
+        except OSError as e:
+            print(f"Error: could not read baseline file: {e}", file=sys.stderr)
+            return 1
+    else:
+        baseline = pane_read(pane_id, args.lines)
     saw_work = False  # working status or transcript change
+    saw_working = False  # authoritative working transition
 
     st = agent_status(pane_id)
     if st == "blocked":
         if not args.no_print:
-            print(baseline if args.full else "")
+            print_delta(baseline, pane_read(pane_id, args.lines), args.full)
         return 3
 
     if args.ready and st in ("idle", "done") and args.prefer_status:
@@ -230,6 +251,7 @@ def main() -> int:
 
             if st == "working":
                 saw_work = True
+                saw_working = True
                 slice_ms = min(30_000, max(1, int((deadline - time.time()) * 1000)))
                 # Prefer short waits so we can notice idle or done either way
                 half = max(1, slice_ms // 2)
@@ -241,14 +263,22 @@ def main() -> int:
                 cur = pane_read(pane_id, args.lines)
                 if cur != baseline:
                     saw_work = True
-                if saw_work or args.ready:
+                marker_seen = (
+                    args.completion_marker is not None
+                    and args.completion_marker in cur
+                )
+                if args.ready or saw_working or marker_seen:
                     if not args.no_print:
                         print_delta(baseline, cur, args.full)
                     return 0
+                if saw_work and args.completion_marker is None:
+                    # Legacy fallback when no marker was arranged before send.
+                    break
                 # Pre-task idle: wait for working (or transcript change via status loop)
                 slice_ms = min(5_000, max(1, int((deadline - time.time()) * 1000)))
                 if wait_status(pane_id, "working", slice_ms):
                     saw_work = True
+                    saw_working = True
                     continue
                 # Also check blocked while waiting to start
                 if agent_status(pane_id) == "blocked":
@@ -274,7 +304,12 @@ def main() -> int:
             return 3
         if st == "working":
             saw_work = True
+            saw_working = True
         cur = pane_read(pane_id, args.lines)
+        if args.completion_marker and args.completion_marker in cur:
+            if not args.no_print:
+                print_delta(baseline, cur, args.full)
+            return 0
         if cur != last:
             if cur != baseline:
                 saw_work = True
@@ -284,6 +319,10 @@ def main() -> int:
         quiet += 1
         if quiet >= args.quiet_cycles:
             if st == "working":
+                quiet = 0
+                continue
+            if args.completion_marker and not args.ready:
+                # Marker-enabled sends never infer completion from quiet prompt echo.
                 quiet = 0
                 continue
             if not saw_work and not args.ready:

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -60,8 +60,11 @@ def resolve_pane(target: str) -> str:
         if cp.returncode == 0:
             try:
                 d = json.loads(cp.stdout)
+                # A null/non-object `pane` (e.g. {"result":{"pane":null}}) makes
+                # the subscript raise TypeError — catch it and fall through to
+                # the `agent get` path rather than crash with a traceback.
                 return d["result"]["pane"]["pane_id"]
-            except (json.JSONDecodeError, KeyError):
+            except (json.JSONDecodeError, KeyError, TypeError):
                 pass
 
     cp = run(["herdr", "agent", "get", target])
@@ -72,7 +75,7 @@ def resolve_pane(target: str) -> str:
             pane = agent.get("pane_id")
             if pane:
                 return pane
-        except (json.JSONDecodeError, AttributeError, KeyError):
+        except (json.JSONDecodeError, AttributeError, KeyError, TypeError):
             pass
 
     cp = run(["herdr", "agent", "list"])
@@ -140,7 +143,12 @@ def agent_status(pane_id: str) -> str:
         return LOOKUP_FAILED
     try:
         pane = json.loads(cp.stdout)["result"]["pane"]
-    except (json.JSONDecodeError, KeyError):
+    except (json.JSONDecodeError, KeyError, TypeError):
+        return LOOKUP_FAILED
+    # A valid JSON body can still carry a null / non-object `pane` (e.g.
+    # {"result": {"pane": null}}); calling .get() on that raises AttributeError.
+    # Treat a non-mapping pane as unverifiable rather than crashing.
+    if not isinstance(pane, dict):
         return LOOKUP_FAILED
     return normalize_status(pane.get("agent_status"))
 

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -123,7 +123,14 @@ def extract_pane_text(out: str) -> str:
     return out
 
 
-def pane_read(pane_id: str, lines: int) -> str:
+def pane_read(pane_id: str, lines: int) -> str | None:
+    """Read a pane's transcript, or None if the read command FAILED.
+
+    A failed read (e.g. the pane disappeared mid-wait) must NOT be treated as
+    transcript content: the error text would stabilize like any other output
+    and trip a false "completion". Returning None lets callers propagate the
+    failure as an error/timeout instead of a spurious success.
+    """
     cp = run(
         [
             "herdr",
@@ -136,8 +143,9 @@ def pane_read(pane_id: str, lines: int) -> str:
             str(lines),
         ]
     )
-    out = cp.stdout or cp.stderr or ""
-    return extract_pane_text(out)
+    if cp.returncode != 0:
+        return None
+    return extract_pane_text(cp.stdout)
 
 
 def wait_status(pane_id: str, status: str, timeout_ms: int) -> bool:
@@ -227,13 +235,16 @@ def main() -> int:
             return 1
     else:
         baseline = pane_read(pane_id, args.lines)
+        if baseline is None:
+            print(f"Error: could not read pane {pane_id} for baseline", file=sys.stderr)
+            return 1
     saw_work = False  # working status or transcript change
     saw_working = False  # authoritative working transition
 
     st = agent_status(pane_id)
     if st == "blocked":
         if not args.no_print:
-            print_delta(baseline, pane_read(pane_id, args.lines), args.full)
+            print_delta(baseline, pane_read(pane_id, args.lines) or "", args.full)
         return 3
 
     if args.ready and st in ("idle", "done") and args.prefer_status:
@@ -246,7 +257,7 @@ def main() -> int:
             st = agent_status(pane_id)
             if st == "blocked":
                 if not args.no_print:
-                    print_delta(baseline, pane_read(pane_id, args.lines), args.full)
+                    print_delta(baseline, pane_read(pane_id, args.lines) or "", args.full)
                 return 3
 
             if st == "working":
@@ -269,6 +280,11 @@ def main() -> int:
 
             if st in ("idle", "done"):
                 cur = pane_read(pane_id, args.lines)
+                if cur is None:
+                    # Pane vanished while we were reading it — a failed read is
+                    # not a completed task. Report an error, not success.
+                    print(f"Error: pane {pane_id} read failed (pane gone?)", file=sys.stderr)
+                    return 1
                 if cur != baseline:
                     saw_work = True
                 marker_seen = (
@@ -305,7 +321,7 @@ def main() -> int:
                 # Also check blocked while waiting to start
                 if agent_status(pane_id) == "blocked":
                     if not args.no_print:
-                        print_delta(baseline, pane_read(pane_id, args.lines), args.full)
+                        print_delta(baseline, pane_read(pane_id, args.lines) or "", args.full)
                     return 3
                 continue
 
@@ -328,6 +344,11 @@ def main() -> int:
             saw_work = True
             saw_working = True
         cur = pane_read(pane_id, args.lines)
+        if cur is None:
+            # Pane disappeared mid-wait — do NOT let a failed read stabilize
+            # into a false completion. Surface it as an error.
+            print(f"Error: pane {pane_id} read failed (pane gone?)", file=sys.stderr)
+            return 1
         if (
             args.completion_marker
             and args.completion_marker in cur

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -120,6 +120,16 @@ def agent_status(pane_id: str) -> str:
     return pane.get("agent_status") or "unknown"
 
 
+def _unverifiable(st: str, args) -> bool:
+    """True when a status result is UNVERIFIABLE and that must fail a readiness
+    check — i.e. the lookup failed AND we're doing a status-based `--ready`
+    wait. This is checked after EVERY `agent_status` call (not just the first)
+    so a valid status followed by a later lookup failure cannot slip through a
+    loop and return a false ready. A valid "unknown" is verifiable and never
+    trips this; non-ready waits and --no-prefer-status are unaffected."""
+    return args.ready and args.prefer_status and st == LOOKUP_FAILED
+
+
 def extract_pane_text(out: str) -> str:
     """Normalize either raw text or `herdr pane read` JSON to transcript text."""
     try:
@@ -254,10 +264,8 @@ def main() -> int:
     saw_working = False  # authoritative working transition
 
     st = agent_status(pane_id)
-    # A --ready check must NOT report ready when we can't even verify status:
-    # a persistent lookup failure on a blocked pane would otherwise slip
-    # through the content-stability fallback and return rc 0. Fail closed.
-    if args.ready and args.prefer_status and st == LOOKUP_FAILED:
+    # Fail closed on an unverifiable status for a --ready wait (see _unverifiable).
+    if _unverifiable(st, args):
         print(f"Error: cannot verify readiness of {pane_id} (status lookup failed)", file=sys.stderr)
         return 1
     if st == "blocked":
@@ -277,6 +285,9 @@ def main() -> int:
     if args.prefer_status and st not in ("unknown", LOOKUP_FAILED):
         while time.time() < deadline:
             st = agent_status(pane_id)
+            if _unverifiable(st, args):
+                print(f"Error: readiness of {pane_id} became unverifiable (status lookup failed)", file=sys.stderr)
+                return 1
             if st == "blocked":
                 if not args.no_print:
                     print_delta(baseline, pane_read(pane_id, args.lines) or "", args.full)
@@ -340,8 +351,12 @@ def main() -> int:
                     saw_work = True
                     saw_working = True
                     continue
-                # Also check blocked while waiting to start
-                if agent_status(pane_id) == "blocked":
+                # Also check blocked while waiting to start.
+                st = agent_status(pane_id)
+                if _unverifiable(st, args):
+                    print(f"Error: readiness of {pane_id} became unverifiable (status lookup failed)", file=sys.stderr)
+                    return 1
+                if st == "blocked":
                     if not args.no_print:
                         print_delta(baseline, pane_read(pane_id, args.lines) or "", args.full)
                     return 3
@@ -358,6 +373,13 @@ def main() -> int:
     while time.time() < deadline:
         time.sleep(args.interval)
         st = agent_status(pane_id)
+        # A --ready wait that reaches here started from a valid "unknown"; if a
+        # LATER lookup fails we can no longer verify readiness, so fail closed
+        # rather than let content stability report a false ready (the round-9
+        # repro: valid unknown, then lookup failure).
+        if _unverifiable(st, args):
+            print(f"Error: readiness of {pane_id} became unverifiable (status lookup failed)", file=sys.stderr)
+            return 1
         if st == "blocked":
             if not args.no_print:
                 print_delta(baseline, last, args.full)

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -252,11 +252,19 @@ def main() -> int:
             if st == "working":
                 saw_work = True
                 saw_working = True
-                slice_ms = min(30_000, max(1, int((deadline - time.time()) * 1000)))
-                # Prefer short waits so we can notice idle or done either way
-                half = max(1, slice_ms // 2)
-                if not wait_status(pane_id, "done", half):
-                    wait_status(pane_id, "idle", max(1, int((deadline - time.time()) * 1000)))
+                # Single bounded wait, then loop back so the top-of-loop
+                # re-read + the `st in ("idle", "done")` branch handle whichever
+                # terminal state we reach. `wait done` returns the instant the
+                # pane goes `done`, so a working -> done settle is caught fast;
+                # a working -> idle settle is caught by the re-read after the
+                # slice expires (idle hits the same terminal branch). The cap
+                # (min 1s) is load-bearing: control MUST return to the re-read
+                # before the deadline. The old code did a SECOND wait — for
+                # `idle`, over the whole remaining deadline — so a pane that
+                # settled on `done` (never `idle`) blocked there until timeout
+                # and returned code 2 even though it had finished.
+                slice_ms = max(1, min(1_000, int((deadline - time.time()) * 1000)))
+                wait_status(pane_id, "done", slice_ms)
                 continue
 
             if st in ("idle", "done"):

--- a/skills/herdr-agent-comms/scripts/wait_for_idle.py
+++ b/skills/herdr-agent-comms/scripts/wait_for_idle.py
@@ -98,14 +98,26 @@ def resolve_pane(target: str) -> str:
     raise SystemExit(f"target not found: {target!r}")
 
 
-def agent_status(pane_id: str) -> str | None:
+# Distinct sentinel for a FAILED/unparseable `herdr pane get`, kept separate
+# from a valid-but-absent status ("unknown"). Conflating the two is a
+# fail-open bug: a persistent lookup failure on a `blocked` pane would look
+# like "no status → fall back to content-stability → report ready". Callers
+# must treat LOOKUP_FAILED as unverifiable (an error under --ready), while a
+# genuine "unknown" (non-integrated CLI) still uses the content-stability path.
+LOOKUP_FAILED = "\x00lookup-failed"
+
+
+def agent_status(pane_id: str) -> str:
+    """Return the pane's agent status, "unknown" if validly absent, or
+    LOOKUP_FAILED if the `herdr pane get` call failed / didn't parse."""
     cp = run(["herdr", "pane", "get", pane_id])
     if cp.returncode != 0:
-        return None
+        return LOOKUP_FAILED
     try:
-        return json.loads(cp.stdout)["result"]["pane"].get("agent_status")
+        pane = json.loads(cp.stdout)["result"]["pane"]
     except (json.JSONDecodeError, KeyError):
-        return None
+        return LOOKUP_FAILED
+    return pane.get("agent_status") or "unknown"
 
 
 def extract_pane_text(out: str) -> str:
@@ -242,6 +254,12 @@ def main() -> int:
     saw_working = False  # authoritative working transition
 
     st = agent_status(pane_id)
+    # A --ready check must NOT report ready when we can't even verify status:
+    # a persistent lookup failure on a blocked pane would otherwise slip
+    # through the content-stability fallback and return rc 0. Fail closed.
+    if args.ready and args.prefer_status and st == LOOKUP_FAILED:
+        print(f"Error: cannot verify readiness of {pane_id} (status lookup failed)", file=sys.stderr)
+        return 1
     if st == "blocked":
         if not args.no_print:
             print_delta(baseline, pane_read(pane_id, args.lines) or "", args.full)
@@ -252,7 +270,11 @@ def main() -> int:
             print_delta(baseline, baseline, args.full)
         return 0
 
-    if args.prefer_status and st not in (None, "unknown"):
+    # `unknown` (validly absent status) → content-stability fallback below.
+    # LOOKUP_FAILED under --ready was already rejected; for a non-ready wait it
+    # also falls through to content-stability (which reads the transcript and
+    # will itself error if the pane is gone).
+    if args.prefer_status and st not in ("unknown", LOOKUP_FAILED):
         while time.time() < deadline:
             st = agent_status(pane_id)
             if st == "blocked":

--- a/skills/herdr-agent-comms/tests/bin/herdr
+++ b/skills/herdr-agent-comms/tests/bin/herdr
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Shim so `herdr` resolves on PATH during tests, dispatching to fake_herdr.py.
+exec python3 "$(dirname "${BASH_SOURCE[0]}")/../fake_herdr.py" "$@"

--- a/skills/herdr-agent-comms/tests/fake_herdr.py
+++ b/skills/herdr-agent-comms/tests/fake_herdr.py
@@ -11,6 +11,10 @@ State lives in a JSON file at $FAKE_HERDR_STATE, shaped:
       "fail_run": true  # optional: "pane run" on this pane returns exit 1
                         # without mutating state, to simulate a dispatch
                         # failure partway through a broadcast fan-out.
+      "status_after": 1,        # optional: report agent_status for the first
+      "status_flip_to": "working"  # N gets, then flip to status_flip_to. Models
+                        # a target that was safe at preflight but turned
+                        # working/blocked before its pre-dispatch recheck.
     }
   }
 }
@@ -104,7 +108,19 @@ def cmd_pane_get(args):
         # Simulate a 0-exit but unparseable/unexpected-shape response.
         print("not json at all {[")
         return 0
-    print(json.dumps({"result": {"pane": {"pane_id": pid, "agent_status": p["agent_status"]}}}))
+    # Counter-based status FLIP: report agent_status for the first
+    # `status_after` gets, then switch to `status_flip_to` on every get after.
+    # Deterministic "was idle at preflight, turned working/blocked before
+    # dispatch" with no timing race — mirrors the fail_get_after pattern.
+    status = p["agent_status"]
+    n = p.get("status_after")
+    if n is not None:
+        if n <= 0:
+            status = p.get("status_flip_to", status)
+        else:
+            p["status_after"] = n - 1
+            save_state(state)
+    print(json.dumps({"result": {"pane": {"pane_id": pid, "agent_status": status}}}))
     return 0
 
 

--- a/skills/herdr-agent-comms/tests/fake_herdr.py
+++ b/skills/herdr-agent-comms/tests/fake_herdr.py
@@ -7,7 +7,10 @@ State lives in a JSON file at $FAKE_HERDR_STATE, shaped:
     "<pane_id>": {
       "agent_status": "idle|working|done|blocked|unknown",
       "text": "<current transcript>",
-      "name": "<agent name or null>"
+      "name": "<agent name or null>",
+      "fail_run": true  # optional: "pane run" on this pane returns exit 1
+                        # without mutating state, to simulate a dispatch
+                        # failure partway through a broadcast fan-out.
     }
   }
 }
@@ -121,6 +124,9 @@ def cmd_pane_run(args):
     pid = find_pane_by_id(state, args[0])
     text = args[1] if len(args) > 1 else ""
     if pid is not None:
+        if state["panes"][pid].get("fail_run"):
+            print(json.dumps({"error": "simulated pane run failure"}), file=sys.stderr)
+            return 1
         state["panes"][pid]["agent_status"] = "working"
         state["panes"][pid]["text"] += f"\n$ {text}\n"
         save_state(state)

--- a/skills/herdr-agent-comms/tests/fake_herdr.py
+++ b/skills/herdr-agent-comms/tests/fake_herdr.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Fake `herdr` CLI for tests. Not shipped as part of the skill.
+
+State lives in a JSON file at $FAKE_HERDR_STATE, shaped:
+{
+  "panes": {
+    "<pane_id>": {
+      "agent_status": "idle|working|done|blocked|unknown",
+      "text": "<current transcript>",
+      "name": "<agent name or null>"
+    }
+  }
+}
+
+Supported subcommands (only what the scripts under test call):
+  pane get <id>
+  pane read <id> --source ... --lines N
+  pane split <id> --direction d --cwd c --no-focus
+  pane rename <id> <name>
+  pane run <id> <text...>
+  pane send-keys <id> enter
+  agent get <name-or-id>
+  agent list
+  agent rename <id> <name>
+  wait agent-status <id> --status s --timeout ms
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+
+def load_state():
+    path = os.environ["FAKE_HERDR_STATE"]
+    # os.replace() is atomic, but a reader can still land in the brief gap
+    # where the old inode was just unlinked; retry a few times rather than
+    # let a concurrent writer flake the test.
+    for _ in range(20):
+        try:
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            time.sleep(0.01)
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_state(state):
+    # Concurrent `herdr` invocations (broadcast waits on several panes at
+    # once) can read this file mid-write; write-then-rename makes each
+    # update atomic so a reader never sees a truncated/partial JSON file.
+    path = os.environ["FAKE_HERDR_STATE"]
+    tmp_path = f"{path}.tmp.{os.getpid()}.{id(state)}"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(state, f)
+    os.replace(tmp_path, path)
+
+
+def find_pane_by_id(state, pane_id):
+    """`pane <verb> <id>` only accepts literal pane ids, like real herdr."""
+    return pane_id if pane_id in state["panes"] else None
+
+
+def find_pane(state, ident):
+    """`agent <verb> <ident>` accepts a pane id OR an agent name."""
+    panes = state["panes"]
+    if ident in panes:
+        return ident
+    for pid, p in panes.items():
+        if p.get("name") == ident:
+            return pid
+    return None
+
+
+def cmd_pane_get(args):
+    state = load_state()
+    pid = find_pane_by_id(state, args[0])
+    if pid is None:
+        print(json.dumps({"error": "not found"}))
+        return 1
+    p = state["panes"][pid]
+    print(json.dumps({"result": {"pane": {"pane_id": pid, "agent_status": p["agent_status"]}}}))
+    return 0
+
+
+def cmd_pane_read(args):
+    state = load_state()
+    pid = find_pane_by_id(state, args[0])
+    if pid is None:
+        print("")
+        return 1
+    print(state["panes"][pid]["text"])
+    return 0
+
+
+def cmd_pane_split(args):
+    state = load_state()
+    src = args[0]
+    new_id = f"{src}-split{len(state['panes'])}"
+    state["panes"][new_id] = {"agent_status": "unknown", "text": "", "name": None}
+    save_state(state)
+    print(json.dumps({"result": {"pane": {"pane_id": new_id}}}))
+    return 0
+
+
+def cmd_pane_rename(args):
+    state = load_state()
+    pid = find_pane_by_id(state, args[0])
+    if pid is not None:
+        state["panes"][pid]["name"] = args[1]
+        save_state(state)
+    print(json.dumps({"result": {}}))
+    return 0
+
+
+def cmd_pane_run(args):
+    state = load_state()
+    pid = find_pane_by_id(state, args[0])
+    text = args[1] if len(args) > 1 else ""
+    if pid is not None:
+        state["panes"][pid]["agent_status"] = "working"
+        state["panes"][pid]["text"] += f"\n$ {text}\n"
+        save_state(state)
+    print(json.dumps({"result": {}}))
+    return 0
+
+
+def cmd_pane_send_keys(args):
+    print(json.dumps({"result": {}}))
+    return 0
+
+
+def cmd_agent_get(args):
+    state = load_state()
+    pid = find_pane(state, args[0])
+    if pid is None:
+        print(json.dumps({"error": "not found"}))
+        return 1
+    print(json.dumps({"result": {"agent": {"pane_id": pid}}}))
+    return 0
+
+
+def cmd_agent_list(_args):
+    state = load_state()
+    agents = [
+        {"name": p.get("name"), "pane_id": pid, "terminal_id": pid}
+        for pid, p in state["panes"].items()
+    ]
+    print(json.dumps({"result": {"agents": agents}}))
+    return 0
+
+
+def cmd_agent_rename(args):
+    return cmd_pane_rename(args)
+
+
+def cmd_wait_agent_status(args):
+    pid = args[0]
+    status = None
+    timeout_ms = 1000
+    it = iter(args[1:])
+    for a in it:
+        if a == "--status":
+            status = next(it)
+        elif a == "--timeout":
+            timeout_ms = int(next(it))
+    deadline = time.time() + timeout_ms / 1000.0
+    while time.time() < deadline:
+        state = load_state()
+        rpid = find_pane(state, pid)
+        if rpid is not None and state["panes"][rpid]["agent_status"] == status:
+            return 0
+        time.sleep(0.02)
+    return 1
+
+
+def main(argv):
+    if not argv:
+        return 1
+    group = argv[0]
+    if group == "pane":
+        sub = argv[1]
+        rest = argv[2:]
+        if sub == "get":
+            return cmd_pane_get(rest)
+        if sub == "read":
+            return cmd_pane_read(rest)
+        if sub == "split":
+            return cmd_pane_split(rest)
+        if sub == "rename":
+            return cmd_pane_rename(rest)
+        if sub == "run":
+            return cmd_pane_run(rest)
+        if sub == "send-keys":
+            return cmd_pane_send_keys(rest)
+    elif group == "agent":
+        sub = argv[1]
+        rest = argv[2:]
+        if sub == "get":
+            return cmd_agent_get(rest)
+        if sub == "list":
+            return cmd_agent_list(rest)
+        if sub == "rename":
+            return cmd_agent_rename(rest)
+    elif group == "wait":
+        sub = argv[1]
+        rest = argv[2:]
+        if sub == "agent-status":
+            return cmd_wait_agent_status(rest)
+    print(f"fake_herdr: unhandled command: {argv}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/herdr-agent-comms/tests/fake_herdr.py
+++ b/skills/herdr-agent-comms/tests/fake_herdr.py
@@ -108,6 +108,11 @@ def cmd_pane_get(args):
         # Simulate a 0-exit but unparseable/unexpected-shape response.
         print("not json at all {[")
         return 0
+    if p.get("null_pane_get"):
+        # Valid JSON, 0 exit, but a null `pane` — .get() on it would crash a
+        # naive parser. Must be treated as unverifiable, not raise.
+        print(json.dumps({"result": {"pane": None}}))
+        return 0
     # Counter-based status FLIP: report agent_status for the first
     # `status_after` gets, then switch to `status_flip_to` on every get after.
     # Deterministic "was idle at preflight, turned working/blocked before

--- a/skills/herdr-agent-comms/tests/fake_herdr.py
+++ b/skills/herdr-agent-comms/tests/fake_herdr.py
@@ -85,6 +85,15 @@ def cmd_pane_get(args):
         print(json.dumps({"error": "not found"}))
         return 1
     p = state["panes"][pid]
+    if p.get("fail_get"):
+        # Simulate a failing `herdr pane get` (server hiccup / gone pane):
+        # non-zero exit, so a preflight must reject rather than fall open.
+        print(json.dumps({"error": "simulated pane get failure"}), file=sys.stderr)
+        return 1
+    if p.get("malformed_get"):
+        # Simulate a 0-exit but unparseable/unexpected-shape response.
+        print("not json at all {[")
+        return 0
     print(json.dumps({"result": {"pane": {"pane_id": pid, "agent_status": p["agent_status"]}}}))
     return 0
 

--- a/skills/herdr-agent-comms/tests/fake_herdr.py
+++ b/skills/herdr-agent-comms/tests/fake_herdr.py
@@ -90,6 +90,16 @@ def cmd_pane_get(args):
         # non-zero exit, so a preflight must reject rather than fall open.
         print(json.dumps({"error": "simulated pane get failure"}), file=sys.stderr)
         return 1
+    # Counter-based fault: succeed the first `fail_get_after` calls, then fail
+    # every subsequent one. Deterministic "valid status, THEN lookup failure"
+    # with no timing race. The counter is persisted in the state file.
+    remaining = p.get("fail_get_after")
+    if remaining is not None:
+        if remaining <= 0:
+            print(json.dumps({"error": "simulated pane get failure (after N)"}), file=sys.stderr)
+            return 1
+        p["fail_get_after"] = remaining - 1
+        save_state(state)
     if p.get("malformed_get"):
         # Simulate a 0-exit but unparseable/unexpected-shape response.
         print("not json at all {[")

--- a/skills/herdr-agent-comms/tests/test_broadcast.py
+++ b/skills/herdr-agent-comms/tests/test_broadcast.py
@@ -48,7 +48,7 @@ class FakeHerdrHarness:
             return json.load(f)
 
     def set_pane(self, pane_id, status, text, name=None, fail_run=False,
-                 fail_get=False, malformed_get=False,
+                 fail_get=False, malformed_get=False, null_pane_get=False,
                  status_after=None, status_flip_to=None):
         state = self.read_state()
         pane = {
@@ -58,6 +58,7 @@ class FakeHerdrHarness:
             "fail_run": fail_run,
             "fail_get": fail_get,
             "malformed_get": malformed_get,
+            "null_pane_get": null_pane_get,
         }
         if status_after is not None:
             pane["status_after"] = status_after
@@ -213,6 +214,20 @@ class BroadcastDedupeTests(unittest.TestCase):
         self.assertEqual(self.h.count_pane_run_invocations("bad1"), 0,
                          msg=f"malformed-status pane must not be sent to. stdout={cp.stdout!r}")
         self.assertNotEqual(cp.returncode, 0)
+
+    def test_null_pane_status_is_rejected_cleanly_not_traceback(self):
+        """Round 13 note: a valid-JSON 0-exit `pane get` with a null `pane`
+        ({"result":{"pane":null}}) must be rejected as unverifiable WITHOUT an
+        AttributeError traceback (None.get(...)) leaking to stderr. Rejected +
+        not sent + non-zero exit, and no Python traceback."""
+        self.h.set_pane("bad1", "idle", "resolves but pane is null\n",
+                        name="nullp", null_pane_get=True)
+        cp = self.h.run_broadcast("do the thing", ["nullp"], timeout=4)
+        self.assertEqual(self.h.count_pane_run_invocations("bad1"), 0,
+                         msg=f"null-pane must not be sent to. stdout={cp.stdout!r}")
+        self.assertNotEqual(cp.returncode, 0)
+        self.assertNotIn("Traceback", cp.stderr)
+        self.assertNotIn("AttributeError", cp.stderr)
 
     def test_offenum_numeric_status_is_rejected_not_sent(self):
         """Regression (round 10, finding #1): a 0-exit `herdr pane get` that

--- a/skills/herdr-agent-comms/tests/test_broadcast.py
+++ b/skills/herdr-agent-comms/tests/test_broadcast.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Behavioral tests for broadcast.sh against a fake `herdr` CLI.
+
+Covers:
+  P2.6 - name+pane aliases resolving to the same pane must not double-send.
+  P1.1 - a pane already `working` before the broadcast must be rejected,
+         not silently waited on as if this broadcast made it busy.
+
+Run directly (stdlib unittest only):
+    python3 -m unittest discover -s skills/herdr-agent-comms/tests -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE.parent / "scripts"
+FAKE_BIN = HERE / "bin"
+BROADCAST = SCRIPTS / "broadcast.sh"
+
+
+class FakeHerdrHarness:
+    def __init__(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hac_bcast_test_")
+        self.state_path = os.path.join(self.tmpdir, "state.json")
+        self.write_state({"panes": {}})
+        self.env = dict(os.environ)
+        self.env["FAKE_HERDR_STATE"] = self.state_path
+        self.env["PATH"] = f"{FAKE_BIN}{os.pathsep}{self.env.get('PATH', '')}"
+
+    def write_state(self, state):
+        with open(self.state_path, "w", encoding="utf-8") as f:
+            json.dump(state, f)
+
+    def read_state(self):
+        with open(self.state_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def set_pane(self, pane_id, status, text, name=None):
+        state = self.read_state()
+        state["panes"][pane_id] = {"agent_status": status, "text": text, "name": name}
+        self.write_state(state)
+
+    def set_status(self, pane_id, status):
+        state = self.read_state()
+        state["panes"][pane_id]["agent_status"] = status
+        self.write_state(state)
+
+    def append_text(self, pane_id, text):
+        state = self.read_state()
+        state["panes"][pane_id]["text"] += text
+        self.write_state(state)
+
+    def count_pane_run_invocations(self, pane_id):
+        state = self.read_state()
+        text = state["panes"][pane_id]["text"]
+        return text.count("$ ")
+
+    def run_broadcast(self, msg, targets, timeout=8, env_extra=None):
+        env = dict(self.env)
+        env["HAC_TIMEOUT"] = str(timeout - 2)
+        if env_extra:
+            env.update(env_extra)
+        cmd = ["bash", str(BROADCAST), msg] + list(targets)
+        return subprocess.run(cmd, env=env, text=True, capture_output=True, timeout=timeout + 15)
+
+
+class BroadcastDedupeTests(unittest.TestCase):
+    def setUp(self):
+        self.h = FakeHerdrHarness()
+
+    def test_name_and_pane_alias_send_only_once(self):
+        """P2.6: 'reviewer' and its own pane id 'p1' both resolve to pane p1
+        — broadcast must send exactly once, not twice."""
+        self.h.set_pane("p1", "idle", "boot complete\n", name="reviewer")
+
+        def finish_quickly():
+            time.sleep(0.3)
+            self.h.set_status("p1", "working")
+            time.sleep(0.2)
+            st = self.h.read_state()
+            sent_text = st["panes"]["p1"]["text"]
+            # Extract the marker suffix from the sent task text and echo the
+            # joined marker back, as a real agent's reply would.
+            m = re.search(r"HERDR_DONE_ and (\S+)", sent_text)
+            if m:
+                self.h.append_text("p1", f"HERDR_DONE_{m.group(1)}\n")
+            self.h.set_status("p1", "idle")
+
+        t = threading.Thread(target=finish_quickly)
+        t.start()
+        cp = self.h.run_broadcast("do the thing", ["reviewer", "p1"], timeout=6)
+        t.join()
+
+        sends = self.h.count_pane_run_invocations("p1")
+        self.assertEqual(sends, 1, msg=f"expected exactly 1 send, got {sends}. stdout={cp.stdout!r} stderr={cp.stderr!r}")
+        self.assertIn("skipping duplicate", cp.stderr.lower())
+
+    def test_already_working_pane_is_rejected_not_sent(self):
+        """P1.1: a pane that is already `working` before broadcast starts
+        must be skipped, never sent to (can't distinguish its completion
+        from a send this broadcast never made)."""
+        self.h.set_pane("busy1", "working", "prior task in flight\n", name="busy")
+        self.h.set_pane("idle1", "idle", "ready\n", name="ready")
+
+        def finish_ready():
+            time.sleep(0.2)
+            st = self.h.read_state()
+            sent_text = st["panes"]["idle1"]["text"]
+            m = re.search(r"HERDR_DONE_ and (\S+)", sent_text)
+            if m:
+                self.h.append_text("idle1", f"HERDR_DONE_{m.group(1)}\n")
+            self.h.set_status("idle1", "idle")
+
+        t = threading.Thread(target=finish_ready)
+        t.start()
+        cp = self.h.run_broadcast("do the thing", ["busy", "ready"], timeout=6)
+        t.join()
+
+        # busy pane must never have received a pane run (no new "$ " line)
+        busy_sends = self.h.count_pane_run_invocations("busy1")
+        self.assertEqual(busy_sends, 0, msg=f"busy pane should not be sent to. stdout={cp.stdout!r}")
+        self.assertIn("already working", cp.stderr.lower())
+        # overall exit must be non-zero since a target was skipped
+        self.assertNotEqual(cp.returncode, 0)
+        # the ready pane should still be reported as settled
+        self.assertIn("ready", cp.stdout)
+
+    def test_all_busy_exits_error_with_nothing_sent(self):
+        self.h.set_pane("busy1", "working", "prior\n", name="busy")
+        cp = self.h.run_broadcast("do the thing", ["busy"], timeout=4)
+        self.assertNotEqual(cp.returncode, 0)
+        self.assertEqual(self.h.count_pane_run_invocations("busy1"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/herdr-agent-comms/tests/test_broadcast.py
+++ b/skills/herdr-agent-comms/tests/test_broadcast.py
@@ -47,13 +47,16 @@ class FakeHerdrHarness:
         with open(self.state_path, encoding="utf-8") as f:
             return json.load(f)
 
-    def set_pane(self, pane_id, status, text, name=None, fail_run=False):
+    def set_pane(self, pane_id, status, text, name=None, fail_run=False,
+                 fail_get=False, malformed_get=False):
         state = self.read_state()
         state["panes"][pane_id] = {
             "agent_status": status,
             "text": text,
             "name": name,
             "fail_run": fail_run,
+            "fail_get": fail_get,
+            "malformed_get": malformed_get,
         }
         self.write_state(state)
 
@@ -181,6 +184,51 @@ class BroadcastDedupeTests(unittest.TestCase):
         cp = self.h.run_broadcast("do the thing", ["gated"], timeout=4)
         self.assertNotEqual(cp.returncode, 0)
         self.assertEqual(self.h.count_pane_run_invocations("dlg1"), 0)
+
+    def test_failed_status_lookup_is_rejected_not_sent(self):
+        """P2 round 6: a pane whose `herdr pane get` FAILS during the status
+        preflight must be rejected, not treated as an empty (safe) status.
+        Otherwise a working/blocked pane whose state can't be confirmed would
+        be sent to (fail-open)."""
+        self.h.set_pane("bad1", "idle", "resolves but status get fails\n",
+                        name="flaky", fail_get=True)
+        cp = self.h.run_broadcast("do the thing", ["flaky"], timeout=4)
+        # never sent, error exit, and the reason is surfaced.
+        self.assertEqual(self.h.count_pane_run_invocations("bad1"), 0,
+                         msg=f"unverifiable pane must not be sent to. stdout={cp.stdout!r}")
+        self.assertNotEqual(cp.returncode, 0)
+        self.assertIn("verify", cp.stderr.lower())
+
+    def test_malformed_status_response_is_rejected_not_sent(self):
+        """A 0-exit but unparseable `herdr pane get` must also be rejected,
+        not fall through as empty/safe."""
+        self.h.set_pane("bad1", "idle", "resolves but status is garbage\n",
+                        name="garbled", malformed_get=True)
+        cp = self.h.run_broadcast("do the thing", ["garbled"], timeout=4)
+        self.assertEqual(self.h.count_pane_run_invocations("bad1"), 0,
+                         msg=f"malformed-status pane must not be sent to. stdout={cp.stdout!r}")
+        self.assertNotEqual(cp.returncode, 0)
+
+    def test_failed_status_lookup_skips_only_bad_target(self):
+        """A verifiable idle pane alongside an unverifiable one: the good pane
+        still gets the message; the bad one is skipped."""
+        self.h.set_pane("bad1", "idle", "status get fails\n", name="flaky", fail_get=True)
+        self.h.set_pane("ok1", "idle", "ready\n", name="ready")
+
+        def finish_ready():
+            time.sleep(0.2)
+            st = self.h.read_state()
+            m = re.search(r"HERDR_DONE_ and (\S+)", st["panes"]["ok1"]["text"])
+            if m:
+                self.h.append_text("ok1", f"HERDR_DONE_{m.group(1)}\n")
+            self.h.set_status("ok1", "idle")
+
+        t = threading.Thread(target=finish_ready)
+        t.start()
+        cp = self.h.run_broadcast("do the thing", ["flaky", "ready"], timeout=6)
+        t.join()
+        self.assertEqual(self.h.count_pane_run_invocations("bad1"), 0)
+        self.assertGreaterEqual(self.h.count_pane_run_invocations("ok1"), 1)
 
 
 class BroadcastPartialFailureTests(unittest.TestCase):

--- a/skills/herdr-agent-comms/tests/test_broadcast.py
+++ b/skills/herdr-agent-comms/tests/test_broadcast.py
@@ -4,7 +4,9 @@
 Covers:
   P2.6 - name+pane aliases resolving to the same pane must not double-send.
   P1.1 - a pane already `working` before the broadcast must be rejected,
-         not silently waited on as if this broadcast made it busy.
+         not silently waited on as if this broadcast made it busy. A pane
+         that is `blocked` (trust/auth dialog) must be rejected too — typing
+         a task into that dialog would submit garbage, not reach the agent.
 
 Run directly (stdlib unittest only):
     python3 -m unittest discover -s skills/herdr-agent-comms/tests -p 'test_*.py'
@@ -45,9 +47,14 @@ class FakeHerdrHarness:
         with open(self.state_path, encoding="utf-8") as f:
             return json.load(f)
 
-    def set_pane(self, pane_id, status, text, name=None):
+    def set_pane(self, pane_id, status, text, name=None, fail_run=False):
         state = self.read_state()
-        state["panes"][pane_id] = {"agent_status": status, "text": text, "name": name}
+        state["panes"][pane_id] = {
+            "agent_status": status,
+            "text": text,
+            "name": name,
+            "fail_run": fail_run,
+        }
         self.write_state(state)
 
     def set_status(self, pane_id, status):
@@ -140,6 +147,109 @@ class BroadcastDedupeTests(unittest.TestCase):
         cp = self.h.run_broadcast("do the thing", ["busy"], timeout=4)
         self.assertNotEqual(cp.returncode, 0)
         self.assertEqual(self.h.count_pane_run_invocations("busy1"), 0)
+
+    def test_blocked_pane_is_rejected_not_sent(self):
+        """P1.1: a pane showing `blocked` (trust/auth dialog) must be
+        skipped, never sent to — typing a task into the dialog would submit
+        garbage to the prompt, not reach the agent."""
+        self.h.set_pane("dlg1", "blocked", "Do you trust this workspace? [y/n]\n", name="gated")
+        self.h.set_pane("idle1", "idle", "ready\n", name="ready")
+
+        def finish_ready():
+            time.sleep(0.2)
+            st = self.h.read_state()
+            sent_text = st["panes"]["idle1"]["text"]
+            m = re.search(r"HERDR_DONE_ and (\S+)", sent_text)
+            if m:
+                self.h.append_text("idle1", f"HERDR_DONE_{m.group(1)}\n")
+            self.h.set_status("idle1", "idle")
+
+        t = threading.Thread(target=finish_ready)
+        t.start()
+        cp = self.h.run_broadcast("do the thing", ["gated", "ready"], timeout=6)
+        t.join()
+
+        # blocked pane must never have received a pane run (no new "$ " line)
+        blocked_sends = self.h.count_pane_run_invocations("dlg1")
+        self.assertEqual(blocked_sends, 0, msg=f"blocked pane should not be sent to. stdout={cp.stdout!r}")
+        self.assertIn("blocked", cp.stderr.lower())
+        self.assertNotEqual(cp.returncode, 0)
+        self.assertIn("ready", cp.stdout)
+
+    def test_all_blocked_exits_error_with_nothing_sent(self):
+        self.h.set_pane("dlg1", "blocked", "trust dialog\n", name="gated")
+        cp = self.h.run_broadcast("do the thing", ["gated"], timeout=4)
+        self.assertNotEqual(cp.returncode, 0)
+        self.assertEqual(self.h.count_pane_run_invocations("dlg1"), 0)
+
+
+class BroadcastPartialFailureTests(unittest.TestCase):
+    """P2.1: if a later pane's `pane run` fails mid fan-out, panes already
+    dispatched must still be waited on and reported, not silently abandoned.
+    """
+
+    def setUp(self):
+        self.h = FakeHerdrHarness()
+
+    def test_later_send_failure_does_not_abandon_earlier_dispatch(self):
+        self.h.set_pane("ok1", "idle", "ready\n", name="first")
+        self.h.set_pane("bad1", "idle", "ready\n", name="second", fail_run=True)
+
+        def finish_first():
+            # Poll for the send (not a fixed sleep): preflight/baseline work
+            # ahead of Phase 3 dispatch means the exact send timing isn't
+            # fixed, so wait for the marker to actually appear in the task
+            # text before echoing the reply.
+            deadline = time.time() + 5
+            m = None
+            while time.time() < deadline and m is None:
+                sent_text = self.h.read_state()["panes"]["ok1"]["text"]
+                m = re.search(r"HERDR_DONE_ and (\S+)", sent_text)
+                if m is None:
+                    time.sleep(0.02)
+            if m:
+                self.h.append_text("ok1", f"HERDR_DONE_{m.group(1)}\n")
+            self.h.set_status("ok1", "idle")
+
+        t = threading.Thread(target=finish_first)
+        t.start()
+        cp = self.h.run_broadcast("do the thing", ["first", "second"], timeout=6)
+        t.join()
+
+        # The first pane was sent to and must still be waited on / reported.
+        self.assertEqual(self.h.count_pane_run_invocations("ok1"), 1)
+        self.assertIn("first", cp.stdout)
+        self.assertIn("idle/done", cp.stdout)
+        # The second pane's send failed and must be surfaced, not silently dropped.
+        self.assertIn("send-failed", cp.stderr.lower())
+        self.assertIn("partial results", cp.stderr.lower())
+        self.assertNotEqual(cp.returncode, 0)
+
+    def test_first_send_failure_still_waits_on_later_dispatched_panes(self):
+        self.h.set_pane("bad1", "idle", "ready\n", name="first", fail_run=True)
+        self.h.set_pane("ok1", "idle", "ready\n", name="second")
+
+        def finish_second():
+            deadline = time.time() + 5
+            m = None
+            while time.time() < deadline and m is None:
+                sent_text = self.h.read_state()["panes"]["ok1"]["text"]
+                m = re.search(r"HERDR_DONE_ and (\S+)", sent_text)
+                if m is None:
+                    time.sleep(0.02)
+            if m:
+                self.h.append_text("ok1", f"HERDR_DONE_{m.group(1)}\n")
+            self.h.set_status("ok1", "idle")
+
+        t = threading.Thread(target=finish_second)
+        t.start()
+        cp = self.h.run_broadcast("do the thing", ["first", "second"], timeout=6)
+        t.join()
+
+        self.assertEqual(self.h.count_pane_run_invocations("ok1"), 1)
+        self.assertIn("second", cp.stdout)
+        self.assertIn("idle/done", cp.stdout)
+        self.assertNotEqual(cp.returncode, 0)
 
 
 if __name__ == "__main__":

--- a/skills/herdr-agent-comms/tests/test_broadcast.py
+++ b/skills/herdr-agent-comms/tests/test_broadcast.py
@@ -209,6 +209,20 @@ class BroadcastDedupeTests(unittest.TestCase):
                          msg=f"malformed-status pane must not be sent to. stdout={cp.stdout!r}")
         self.assertNotEqual(cp.returncode, 0)
 
+    def test_offenum_numeric_status_is_rejected_not_sent(self):
+        """Regression (round 10, finding #1): a 0-exit `herdr pane get` that
+        reports an off-enum status VALUE (numeric 123) must be rejected as
+        unverifiable, NOT accepted as a truthy 'sendable' status. The old
+        `agent_status or "unknown"` let 123 fall into the idle/done/unknown
+        branch and the task was sent. fake_herdr passes the status straight
+        through json.dumps, so this injects a genuine numeric status."""
+        self.h.set_pane("bad1", 123, "off-enum numeric status\n", name="weird")
+        cp = self.h.run_broadcast("do the thing", ["weird"], timeout=4)
+        self.assertEqual(self.h.count_pane_run_invocations("bad1"), 0,
+                         msg=f"off-enum-status pane must not be sent to. stdout={cp.stdout!r}")
+        self.assertNotEqual(cp.returncode, 0)
+        self.assertIn("verify", cp.stderr.lower())
+
     def test_failed_status_lookup_skips_only_bad_target(self):
         """A verifiable idle pane alongside an unverifiable one: the good pane
         still gets the message; the bad one is skipped. AND the overall exit is

--- a/skills/herdr-agent-comms/tests/test_broadcast.py
+++ b/skills/herdr-agent-comms/tests/test_broadcast.py
@@ -48,9 +48,10 @@ class FakeHerdrHarness:
             return json.load(f)
 
     def set_pane(self, pane_id, status, text, name=None, fail_run=False,
-                 fail_get=False, malformed_get=False):
+                 fail_get=False, malformed_get=False,
+                 status_after=None, status_flip_to=None):
         state = self.read_state()
-        state["panes"][pane_id] = {
+        pane = {
             "agent_status": status,
             "text": text,
             "name": name,
@@ -58,6 +59,10 @@ class FakeHerdrHarness:
             "fail_get": fail_get,
             "malformed_get": malformed_get,
         }
+        if status_after is not None:
+            pane["status_after"] = status_after
+            pane["status_flip_to"] = status_flip_to
+        state["panes"][pane_id] = pane
         self.write_state(state)
 
     def set_status(self, pane_id, status):
@@ -222,6 +227,52 @@ class BroadcastDedupeTests(unittest.TestCase):
                          msg=f"off-enum-status pane must not be sent to. stdout={cp.stdout!r}")
         self.assertNotEqual(cp.returncode, 0)
         self.assertIn("verify", cp.stderr.lower())
+
+    def test_target_that_turns_working_before_dispatch_is_skipped(self):
+        """Regression (round 11, finding #3): a target that passes the Phase 1b
+        preflight (idle) but turns `working` in the window before its Phase 3
+        dispatch must be re-checked and SKIPPED, not sent to. `status_after=1`
+        flips the pane get result idle->working: get #1 (Phase 1b) sees idle,
+        get #2 (the new pre-dispatch recheck) sees working. Targeting by NAME
+        keeps the get count deterministic — resolve_pane's name lookup doesn't
+        consume a `pane get` on the pane id."""
+        self.h.set_pane("racy1", "idle", "was idle at preflight\n", name="racy",
+                        status_after=1, status_flip_to="working")
+        cp = self.h.run_broadcast("do the thing", ["racy"], timeout=5)
+        # never sent (turned working before dispatch), error exit, reason surfaced.
+        self.assertEqual(self.h.count_pane_run_invocations("racy1"), 0,
+                         msg=f"target that turned working must not be sent to. stdout={cp.stdout!r} stderr={cp.stderr!r}")
+        self.assertNotEqual(cp.returncode, 0)
+        self.assertIn("before dispatch", cp.stderr.lower())
+
+    def test_target_that_turns_working_before_dispatch_still_sends_good_one(self):
+        """Mixed: one target stays idle (gets the message), another turns
+        working before dispatch (skipped). Good pane settles; overall exit is
+        still non-zero because the racy target was dropped."""
+        self.h.set_pane("racy1", "idle", "flips\n", name="racy",
+                        status_after=1, status_flip_to="working")
+        self.h.set_pane("ok1", "idle", "stays ready\n", name="ready")
+
+        def finish_ready():
+            deadline = time.time() + 5
+            m = None
+            while time.time() < deadline and m is None:
+                m = re.search(r"HERDR_DONE_ and (\S+)", self.h.read_state()["panes"]["ok1"]["text"])
+                if m is None:
+                    time.sleep(0.02)
+            if m:
+                self.h.append_text("ok1", f"HERDR_DONE_{m.group(1)}\n")
+            self.h.set_status("ok1", "idle")
+
+        t = threading.Thread(target=finish_ready)
+        t.start()
+        cp = self.h.run_broadcast("do the thing", ["racy", "ready"], timeout=7)
+        t.join()
+        self.assertEqual(self.h.count_pane_run_invocations("racy1"), 0,
+                         msg=f"racy target must not be sent. stdout={cp.stdout!r}")
+        self.assertGreaterEqual(self.h.count_pane_run_invocations("ok1"), 1)
+        self.assertIn("ready", cp.stdout)
+        self.assertNotEqual(cp.returncode, 0)
 
     def test_failed_status_lookup_skips_only_bad_target(self):
         """A verifiable idle pane alongside an unverifiable one: the good pane

--- a/skills/herdr-agent-comms/tests/test_broadcast.py
+++ b/skills/herdr-agent-comms/tests/test_broadcast.py
@@ -211,24 +211,42 @@ class BroadcastDedupeTests(unittest.TestCase):
 
     def test_failed_status_lookup_skips_only_bad_target(self):
         """A verifiable idle pane alongside an unverifiable one: the good pane
-        still gets the message; the bad one is skipped."""
+        still gets the message; the bad one is skipped. AND the overall exit is
+        non-zero — a mixed bad+good broadcast must NOT report success just
+        because the good pane went through (P3 round 6/7: `unverifiable` was
+        omitted from the final aggregation, so mixed broadcasts returned 0)."""
         self.h.set_pane("bad1", "idle", "status get fails\n", name="flaky", fail_get=True)
         self.h.set_pane("ok1", "idle", "ready\n", name="ready")
 
         def finish_ready():
-            time.sleep(0.2)
-            st = self.h.read_state()
-            m = re.search(r"HERDR_DONE_ and (\S+)", st["panes"]["ok1"]["text"])
+            # Poll for the send (timing isn't fixed — the fail_get target adds
+            # preflight latency), then reply with the joined marker so the good
+            # pane's waiter settles cleanly (rc 0). This is important for THIS
+            # test: the good pane MUST complete successfully so the only reason
+            # the broadcast can exit non-zero is the unverifiable aggregation.
+            deadline = time.time() + 6
+            m = None
+            while time.time() < deadline and m is None:
+                m = re.search(r"HERDR_DONE_ and (\S+)", self.h.read_state()["panes"]["ok1"]["text"])
+                if m is None:
+                    time.sleep(0.02)
             if m:
                 self.h.append_text("ok1", f"HERDR_DONE_{m.group(1)}\n")
             self.h.set_status("ok1", "idle")
 
         t = threading.Thread(target=finish_ready)
         t.start()
-        cp = self.h.run_broadcast("do the thing", ["flaky", "ready"], timeout=6)
+        cp = self.h.run_broadcast("do the thing", ["flaky", "ready"], timeout=8)
         t.join()
-        self.assertEqual(self.h.count_pane_run_invocations("bad1"), 0)
+        # good pane got the message and settled...
         self.assertGreaterEqual(self.h.count_pane_run_invocations("ok1"), 1)
+        self.assertIn("ready", cp.stdout)
+        # ...bad pane was skipped...
+        self.assertEqual(self.h.count_pane_run_invocations("bad1"), 0)
+        # ...and DESPITE the good pane succeeding, the mixed result is a FAILURE
+        # (the unverifiable target must fold into the exit status, not vanish).
+        self.assertNotEqual(cp.returncode, 0,
+                            msg=f"mixed unverifiable+good must exit non-zero. stderr={cp.stderr!r}")
 
 
 class BroadcastPartialFailureTests(unittest.TestCase):

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -28,6 +28,7 @@ from next_grid_split import (  # noqa: E402
     boundary_resize_op,
     equal_targets,
     plan_next_split,
+    require_root_membership,
     split_ratio,
     validate_single_row,
 )
@@ -79,15 +80,20 @@ class PlanNextSplitTests(unittest.TestCase):
         self.assertEqual(rightmost, "sub2")
         self.assertEqual(new_count, 4)
 
-    def test_missing_root_pane_still_plans_from_layout(self):
+    def test_no_root_requested_still_plans_from_layout(self):
+        # root_pane is None => "no specific root requested", plan normally.
         rightmost, new_count = plan_next_split(panes(("a", 0, 50), ("b", 50, 50)), None)
         self.assertEqual(rightmost, "b")
         self.assertEqual(new_count, 3)
 
-    def test_root_pane_not_in_layout_warns_but_still_plans(self):
-        rightmost, new_count = plan_next_split(
-            panes(("a", 0, 50), ("b", 50, 50)), "missing-root"
-        )
+    def test_requested_root_absent_from_layout_is_hard_error(self):
+        # P4 round 6: a named root that isn't in the layout means we'd be
+        # splitting the WRONG tab — must raise before any mutation, not warn.
+        with self.assertRaises(SystemExit):
+            plan_next_split(panes(("a", 0, 50), ("b", 50, 50)), "missing-root")
+
+    def test_requested_root_present_plans_normally(self):
+        rightmost, new_count = plan_next_split(panes(("a", 0, 50), ("b", 50, 50)), "a")
         self.assertEqual(rightmost, "b")
         self.assertEqual(new_count, 3)
 
@@ -103,6 +109,22 @@ class PlanNextSplitTests(unittest.TestCase):
         rightmost, new_count = plan_next_split(layout, "root")
         self.assertEqual(rightmost, "root")
         self.assertEqual(new_count, 2)
+
+
+class RequireRootMembershipTests(unittest.TestCase):
+    def test_none_root_is_allowed(self):
+        require_root_membership(["a", "b"], None)  # must not raise
+
+    def test_present_root_is_allowed(self):
+        require_root_membership(["a", "b"], "a")
+
+    def test_absent_root_raises(self):
+        with self.assertRaises(SystemExit):
+            require_root_membership(["a", "b"], "missing")
+
+    def test_absent_root_in_empty_layout_raises(self):
+        with self.assertRaises(SystemExit):
+            require_root_membership([], "root")
 
 
 class SplitRatioTests(unittest.TestCase):

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python3
-"""Fixture tests for next_grid_split.py's pane-selection algorithm.
+"""Fixture tests for next_grid_split.py's equal-width column planning.
 
 Run directly (stdlib unittest only, no live herdr needed):
     python3 -m unittest discover -s skills/herdr-agent-comms/tests -p 'test_*.py'
+
+Covers the pure-arithmetic core only (ordering panes left to right, and the
+1/N share for N columns after a split). The actual `herdr pane split
+--ratio` / `herdr pane resize --amount` semantics are NOT exercised here —
+there is no live herdr server in this test harness to confirm what those
+flags actually do; see the module docstring in next_grid_split.py.
 """
 
 from __future__ import annotations
@@ -13,101 +19,88 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from next_grid_split import choose_target  # noqa: E402
+from next_grid_split import plan_equal_width_split  # noqa: E402
 
 
 def panes(*rects):
     return [
-        {"pane_id": pid, "rect": {"width": w, "height": h}}
-        for pid, w, h in rects
+        {"pane_id": pid, "rect": {"x": x, "width": w}}
+        for pid, x, w in rects
     ]
 
 
-class ChooseTargetTests(unittest.TestCase):
-    def test_first_split_of_single_pane_always_down(self):
-        # Regression guard for the documented "vertical panel first" default:
-        # a lone, wide root pane must still split down, not right, even
-        # though a naive aspect check on 200x50 would pick right.
-        layout = panes(("root", 200, 50))
-        target, direction = choose_target(layout, "root")
-        self.assertEqual(target, "root")
-        self.assertEqual(direction, "down")
+class PlanEqualWidthSplitTests(unittest.TestCase):
+    def test_single_pane_plans_two_columns(self):
+        layout = panes(("root", 0, 200))
+        ordered, new_count = plan_equal_width_split(layout, "root")
+        self.assertEqual(ordered, ["root"])
+        self.assertEqual(new_count, 2)
 
-    def test_first_split_of_single_pane_down_even_when_tall(self):
-        layout = panes(("root", 40, 200))
-        target, direction = choose_target(layout, "root")
-        self.assertEqual(target, "root")
-        self.assertEqual(direction, "down")
+    def test_orders_panes_left_to_right_by_x(self):
+        layout = panes(("sub1", 100, 100), ("root", 0, 100))
+        ordered, new_count = plan_equal_width_split(layout, "root")
+        self.assertEqual(ordered, ["root", "sub1"])
+        self.assertEqual(new_count, 3)
 
-    def test_later_split_picks_largest_pane(self):
-        layout = panes(("root", 100, 25), ("sub1", 200, 25))
-        target, _direction = choose_target(layout, "root")
-        self.assertEqual(target, "sub1")
+    def test_three_existing_columns_plans_fourth(self):
+        layout = panes(("root", 0, 66), ("sub1", 66, 67), ("sub2", 133, 67))
+        ordered, new_count = plan_equal_width_split(layout, "root")
+        self.assertEqual(ordered, ["root", "sub1", "sub2"])
+        self.assertEqual(new_count, 4)
 
-    def test_later_split_ties_prefer_root(self):
-        layout = panes(("root", 200, 25), ("sub1", 200, 25))
-        target, _direction = choose_target(layout, "root")
-        self.assertEqual(target, "root")
+    def test_missing_root_pane_still_plans_from_layout(self):
+        layout = panes(("a", 0, 50), ("b", 50, 50))
+        ordered, new_count = plan_equal_width_split(layout, None)
+        self.assertEqual(ordered, ["a", "b"])
+        self.assertEqual(new_count, 3)
 
-    def test_later_split_direction_follows_target_aspect_wide(self):
-        layout = panes(("root", 200, 25), ("sub1", 200, 25))
-        _target, direction = choose_target(layout, "root")
-        self.assertEqual(direction, "right")
-
-    def test_later_split_targets_largest_even_if_another_pane_is_taller(self):
-        # "a" is the largest pane by area (200x25=5000 > 40x50=2000) and is
-        # wide, so it's both the target and gets `right`.
-        layout = panes(("a", 200, 25), ("b", 40, 50))
-        target, direction = choose_target(layout, "a")
-        self.assertEqual(target, "a")
-        self.assertEqual(direction, "right")
-
-    def test_later_split_direction_down_for_tall_target(self):
-        layout = panes(("root", 40, 200), ("sub1", 10, 10))
-        target, direction = choose_target(layout, "root")
-        self.assertEqual(target, "root")
-        self.assertEqual(direction, "down")
-
-    def test_missing_root_pane_falls_back_to_largest(self):
-        layout = panes(("a", 50, 50), ("b", 100, 100))
-        target, _direction = choose_target(layout, None)
-        self.assertEqual(target, "b")
+    def test_root_pane_not_in_layout_warns_but_still_plans(self):
+        layout = panes(("a", 0, 50), ("b", 50, 50))
+        ordered, new_count = plan_equal_width_split(layout, "missing-root")
+        self.assertEqual(ordered, ["a", "b"])
+        self.assertEqual(new_count, 3)
 
     def test_no_usable_rects_raises(self):
-        layout = [{"pane_id": "x", "rect": {"width": 0, "height": 0}}]
+        layout = [{"pane_id": "x", "rect": {"x": 0, "width": 0}}]
         with self.assertRaises(SystemExit):
-            choose_target(layout, "x")
+            plan_equal_width_split(layout, "x")
 
-    def test_three_agent_spawn_sequence_produces_balanced_grid(self):
-        """End-to-end simulation: spawn 3 sub-agents from one root pane and
-        confirm no pane degenerates into a narrow sliver (regression guard
-        for the "wide roots only create narrow columns" bug).
+    def test_panes_missing_rect_fields_are_dropped(self):
+        layout = [
+            {"pane_id": "root", "rect": {"x": 0, "width": 100}},
+            {"pane_id": "ghost"},
+        ]
+        ordered, new_count = plan_equal_width_split(layout, "root")
+        self.assertEqual(ordered, ["root"])
+        self.assertEqual(new_count, 2)
+
+    def test_four_agent_spawn_sequence_converges_to_equal_shares(self):
+        """End-to-end simulation: spawn 3 sub-agents from one root pane,
+        each time re-running the planner and applying the emitted resize
+        plan, and confirm every column ends up the same width.
         """
-        state = {"root": {"w": 200.0, "h": 50.0}}
+        state = {"root": {"x": 0.0, "w": 200.0}}
 
-        def split(pane_id, direction):
-            w, h = state[pane_id]["w"], state[pane_id]["h"]
+        def apply_plan(ordered, new_count):
+            share = 200.0 / new_count
             new_id = f"p{len(state) + 1}"
-            if direction == "down":
-                state[pane_id] = {"w": w, "h": h / 2}
-                state[new_id] = {"w": w, "h": h / 2}
-            else:
-                state[pane_id] = {"w": w / 2, "h": h}
-                state[new_id] = {"w": w / 2, "h": h}
-            return new_id
+            state[new_id] = {"x": 0.0, "w": share}
+            x = 0.0
+            for pane_id in ordered + [new_id]:
+                state[pane_id]["x"] = x
+                state[pane_id]["w"] = share
+                x += share
 
         for _ in range(3):
-            layout = panes(*[(pid, v["w"], v["h"]) for pid, v in state.items()])
-            target, direction = choose_target(layout, "root")
-            split(target, direction)
+            layout = panes(*[(pid, v["x"], v["w"]) for pid, v in state.items()])
+            ordered, new_count = plan_equal_width_split(layout, "root")
+            apply_plan(ordered, new_count)
 
         self.assertEqual(len(state), 4)  # root + 3 sub-agents
-        areas = [v["w"] * v["h"] for v in state.values()]
-        # Balanced grid: no pane should be a sliver relative to an even split.
-        even_share = (200.0 * 50.0) / 4
-        for area in areas:
-            self.assertGreater(area, even_share * 0.4)
-            self.assertLess(area, even_share * 2.5)
+        widths = [v["w"] for v in state.values()]
+        expected = 200.0 / 4
+        for w in widths:
+            self.assertAlmostEqual(w, expected, places=6)
 
 
 if __name__ == "__main__":

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -28,6 +28,7 @@ from next_grid_split import (  # noqa: E402
     boundary_resize_op,
     equal_targets,
     plan_next_split,
+    split_ratio,
 )
 
 
@@ -82,6 +83,43 @@ class PlanNextSplitTests(unittest.TestCase):
         rightmost, new_count = plan_next_split(layout, "root")
         self.assertEqual(rightmost, "root")
         self.assertEqual(new_count, 2)
+
+
+class SplitRatioTests(unittest.TestCase):
+    """`--ratio` = 1/N (the existing/left child's fraction). Verified live
+    against herdr 0.7.4: from two equal 105/105 columns, splitting the
+    rightmost with ratio 1/3 gives a new pane of 70 (= 210/3, the equal
+    target). The earlier (N-1)/N value was BACKWARDS — it made the new pane
+    the *small* child (35, not 70)."""
+
+    def test_second_column_is_half(self):
+        self.assertEqual(split_ratio(2), 0.5)
+
+    def test_third_column_is_one_third(self):
+        self.assertAlmostEqual(split_ratio(3), 1.0 / 3.0, places=9)
+
+    def test_fourth_column_is_one_quarter(self):
+        self.assertEqual(split_ratio(4), 0.25)
+
+    def test_ratio_is_reciprocal_of_new_count(self):
+        for n in range(2, 12):
+            self.assertAlmostEqual(split_ratio(n), 1.0 / n, places=9)
+
+    def test_new_pane_lands_on_equal_target(self):
+        """The point of the ratio: splitting the rightmost of N-1 equal
+        columns (each 1/(N-1) of the tab) at ratio 1/N makes the new pane
+        exactly 1/N of the tab."""
+        area = 210.0
+        for n in range(2, 8):
+            existing = n - 1
+            rightmost_col_width = area / existing  # existing columns are equal
+            r = split_ratio(n)
+            new_pane_width = (1.0 - r) * rightmost_col_width
+            self.assertAlmostEqual(new_pane_width, area / n, places=6)
+
+    def test_below_two_raises(self):
+        with self.assertRaises(SystemExit):
+            split_ratio(1)
 
 
 class EqualTargetsTests(unittest.TestCase):

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -112,6 +112,73 @@ class PlanNextSplitTests(unittest.TestCase):
         self.assertEqual(new_count, 2)
 
 
+class PaneIdValidationTests(unittest.TestCase):
+    """Round 15 finding #3: a malformed pane_id on the rightmost pane must be a
+    HARD error, not a silent drop that retargets the split to another pane."""
+
+    def test_rightmost_null_id_raises_not_mistarget(self):
+        # Without the fix, _ordered_columns drops the null-id rightmost pane and
+        # plan_next_split returns ("a", 3) — splitting the WRONG column.
+        with self.assertRaises(SystemExit):
+            plan_next_split(
+                [{"pane_id": "a", "rect": {"x": 0, "width": 50}},
+                 {"pane_id": None, "rect": {"x": 50, "width": 50}}],
+                None,
+            )
+
+    def test_non_string_id_raises(self):
+        with self.assertRaises(SystemExit):
+            plan_next_split(
+                [{"pane_id": "a", "rect": {"x": 0, "width": 50}},
+                 {"pane_id": 123, "rect": {"x": 50, "width": 50}}],
+                None,
+            )
+
+    def test_empty_string_id_raises(self):
+        with self.assertRaises(SystemExit):
+            plan_next_split(
+                [{"pane_id": "a", "rect": {"x": 0, "width": 50}},
+                 {"pane_id": "", "rect": {"x": 50, "width": 50}}],
+                None,
+            )
+
+    def test_duplicate_ids_raise(self):
+        with self.assertRaises(SystemExit):
+            plan_next_split(
+                [{"pane_id": "dup", "rect": {"x": 0, "width": 50}},
+                 {"pane_id": "dup", "rect": {"x": 50, "width": 50}}],
+                None,
+            )
+
+    def test_missing_id_key_raises(self):
+        with self.assertRaises(SystemExit):
+            plan_next_split(
+                [{"pane_id": "a", "rect": {"x": 0, "width": 50}},
+                 {"rect": {"x": 50, "width": 50}}],
+                None,
+            )
+
+    def test_validate_single_row_rejects_malformed_id(self):
+        with self.assertRaises(SystemExit):
+            validate_single_row({"layout": {
+                "area": {"x": 0, "y": 0, "width": 100, "height": 10},
+                "panes": [
+                    {"pane_id": "a", "rect": {"x": 0, "y": 0, "width": 50, "height": 10}},
+                    {"pane_id": None, "rect": {"x": 50, "y": 0, "width": 50, "height": 10}},
+                ],
+            }})
+
+    def test_all_valid_unique_ids_still_plan(self):
+        # Control: valid unique ids plan normally (fix doesn't over-reach).
+        rightmost, new_count = plan_next_split(
+            [{"pane_id": "a", "rect": {"x": 0, "width": 50}},
+             {"pane_id": "b", "rect": {"x": 50, "width": 50}}],
+            None,
+        )
+        self.assertEqual(rightmost, "b")
+        self.assertEqual(new_count, 3)
+
+
 class MalformedLayoutJsonTests(unittest.TestCase):
     """Round 14 note: malformed-but-valid JSON must yield a clean SystemExit
     validation error, NOT an uncaught AttributeError traceback."""

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -17,6 +17,8 @@ outermost-first grow sweep is a contraction (converges to equal width).
 
 from __future__ import annotations
 
+import json
+import math
 import sys
 import unittest
 from pathlib import Path
@@ -31,6 +33,7 @@ from next_grid_split import (  # noqa: E402
     plan_next_split,
     require_root_membership,
     split_ratio,
+    validate_live_layout,
     validate_single_row,
 )
 
@@ -234,6 +237,110 @@ class PaneGeometryValidationTests(unittest.TestCase):
         rightmost, new_count = self._split({"x": 50, "width": 50})
         self.assertEqual(rightmost, "b")
         self.assertEqual(new_count, 3)
+
+
+class NonFiniteGeometryTests(unittest.TestCase):
+    """Round 17 finding #1: NaN/inf pass float() but defeat every comparison
+    (`nan <= 0`, `nan > tol` are all False), so non-finite geometry would sail
+    past the positive-width and single-row checks. `json.loads` accepts
+    NaN/Infinity by default, so this is reachable, not theoretical. Every
+    coordinate/dimension must be finite (dimensions also strictly positive)."""
+
+    def _split(self, second_rect):
+        return plan_next_split(
+            [{"pane_id": "a", "rect": {"x": 0, "width": 50}},
+             {"pane_id": "b", "rect": second_rect}],
+            None,
+        )
+
+    def test_nan_width_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": 50, "width": float("nan")})
+
+    def test_inf_width_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": 50, "width": float("inf")})
+
+    def test_nan_x_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": float("nan"), "width": 50})
+
+    def test_inf_x_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": float("-inf"), "width": 50})
+
+    def test_nan_area_width_raises(self):
+        # A present-but-NaN area width must be a hard error, not skip the
+        # <=0 fallback trigger and return a poisoned width.
+        with self.assertRaises(SystemExit):
+            area_width_from_layout({"layout": {
+                "area": {"width": float("nan")},
+                "panes": [{"pane_id": "a", "rect": {"x": 0, "width": 50}}],
+            }})
+
+    def test_nan_area_coord_in_single_row_raises(self):
+        with self.assertRaises(SystemExit):
+            validate_single_row(full_rect_layout(
+                (0, float("nan"), 100, 10),
+                ("a", 0, 0, 50, 10), ("b", 50, 0, 50, 10)))
+
+    def test_inf_pane_height_in_single_row_raises(self):
+        with self.assertRaises(SystemExit):
+            validate_single_row(full_rect_layout(
+                (0, 0, 100, 10),
+                ("a", 0, 0, 50, float("inf")), ("b", 50, 0, 50, 10)))
+
+    def test_nan_json_roundtrips_to_float_nan(self):
+        # Sanity: the real JSON path can carry NaN, so float('nan') fixtures
+        # faithfully represent it.
+        self.assertTrue(math.isnan(json.loads('{"w": NaN}')["w"]))
+
+
+class ValidateLiveLayoutTests(unittest.TestCase):
+    """Round 17 finding #2: the centralized live-layout validator must enforce
+    BOTH shape (single clean row) AND root membership. The discriminating case:
+    a stacked/gapped layout with coincidentally-equal widths + a valid root must
+    RAISE — the old final convergence check ran only `_ordered_columns` and
+    returned success on exactly this."""
+
+    def test_stacked_layout_with_equal_widths_raises(self):
+        # Two panes, equal widths, but STACKED (same x, split vertically) —
+        # widths are "equal" yet this is a 2D layout, not a row of columns.
+        stacked = full_rect_layout(
+            (0, 0, 100, 20),
+            ("a", 0, 0, 100, 10), ("b", 0, 10, 100, 10))
+        with self.assertRaises(SystemExit):
+            validate_live_layout(stacked, "a")
+
+    def test_gapped_layout_with_equal_widths_raises(self):
+        # Equal widths but a gap between columns (b starts at 60, not 50).
+        gapped = full_rect_layout(
+            (0, 0, 110, 10),
+            ("a", 0, 0, 50, 10), ("b", 60, 0, 50, 10))
+        with self.assertRaises(SystemExit):
+            validate_live_layout(gapped, "a")
+
+    def test_clean_row_but_root_absent_raises(self):
+        clean = full_rect_layout(
+            (0, 0, 100, 10),
+            ("a", 0, 0, 50, 10), ("b", 50, 0, 50, 10))
+        with self.assertRaises(SystemExit):
+            validate_live_layout(clean, "not-here")
+
+    def test_clean_row_with_present_root_passes(self):
+        clean = full_rect_layout(
+            (0, 0, 100, 10),
+            ("a", 0, 0, 50, 10), ("b", 50, 0, 50, 10))
+        ids, widths = validate_live_layout(clean, "a")
+        self.assertEqual(ids, ["a", "b"])
+        self.assertEqual(widths, [50, 50])
+
+    def test_clean_row_none_root_passes(self):
+        clean = full_rect_layout(
+            (0, 0, 100, 10),
+            ("a", 0, 0, 50, 10), ("b", 50, 0, 50, 10))
+        ids, _ = validate_live_layout(clean, None)
+        self.assertEqual(ids, ["a", "b"])
 
 
 class MalformedLayoutJsonTests(unittest.TestCase):

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -29,6 +29,7 @@ from next_grid_split import (  # noqa: E402
     equal_targets,
     plan_next_split,
     split_ratio,
+    validate_single_row,
 )
 
 
@@ -37,6 +38,25 @@ def panes(*rects):
         {"pane_id": pid, "rect": {"x": x, "width": w}}
         for pid, x, w in rects
     ]
+
+
+def full_rect_layout(area, *rects):
+    """Layout with full x/y/width/height rects, for validate_single_row.
+
+    `area` is (x, y, width, height); each rect is (pid, x, y, width, height).
+    """
+    ax, ay, aw, ah = area
+    return {
+        "result": {
+            "layout": {
+                "area": {"x": ax, "y": ay, "width": aw, "height": ah},
+                "panes": [
+                    {"pane_id": pid, "rect": {"x": x, "y": y, "width": w, "height": h}}
+                    for pid, x, y, w, h in rects
+                ],
+            }
+        }
+    }
 
 
 class PlanNextSplitTests(unittest.TestCase):
@@ -172,6 +192,106 @@ class AreaWidthTests(unittest.TestCase):
     def test_falls_back_to_summed_widths(self):
         data = {"layout": {"panes": panes(("a", 0, 100), ("b", 100, 110))}}
         self.assertEqual(area_width_from_layout(data), 210)
+
+
+class ValidateSingleRowTests(unittest.TestCase):
+    """Reject 2D / stacked layouts before any split or equalize (P3 round 5).
+    Area = (x, y, w, h); panes carry full x/y/w/h rects."""
+
+    AREA = (0, 0, 210, 55)
+
+    def test_valid_single_row_passes(self):
+        layout = full_rect_layout(
+            self.AREA,
+            ("a", 0, 0, 105, 55),
+            ("b", 105, 0, 105, 55),
+        )
+        validate_single_row(layout)  # must not raise
+
+    def test_valid_three_columns_passes(self):
+        layout = full_rect_layout(
+            self.AREA,
+            ("a", 0, 0, 70, 55),
+            ("b", 70, 0, 70, 55),
+            ("c", 140, 0, 70, 55),
+        )
+        validate_single_row(layout)
+
+    def test_stacked_panes_sharing_x_are_rejected(self):
+        # b and c share x=105 but are stacked vertically (half height each) —
+        # the column model would double-count them. Must reject.
+        layout = full_rect_layout(
+            self.AREA,
+            ("a", 0, 0, 105, 55),
+            ("b", 105, 0, 105, 27),
+            ("c", 105, 27, 105, 28),
+        )
+        with self.assertRaises(SystemExit):
+            validate_single_row(layout)
+
+    def test_partial_height_pane_is_rejected(self):
+        layout = full_rect_layout(
+            self.AREA,
+            ("a", 0, 0, 105, 55),
+            ("b", 105, 0, 105, 30),  # not full height
+        )
+        with self.assertRaises(SystemExit):
+            validate_single_row(layout)
+
+    def test_top_offset_pane_is_rejected(self):
+        layout = full_rect_layout(
+            self.AREA,
+            ("a", 0, 0, 105, 55),
+            ("b", 105, 5, 105, 50),  # not top-aligned with area
+        )
+        with self.assertRaises(SystemExit):
+            validate_single_row(layout)
+
+    def test_gap_between_columns_is_rejected(self):
+        layout = full_rect_layout(
+            self.AREA,
+            ("a", 0, 0, 100, 55),
+            ("b", 110, 0, 100, 55),  # gap from 100..110
+        )
+        with self.assertRaises(SystemExit):
+            validate_single_row(layout)
+
+    def test_overlapping_columns_are_rejected(self):
+        layout = full_rect_layout(
+            self.AREA,
+            ("a", 0, 0, 110, 55),
+            ("b", 100, 0, 110, 55),  # overlaps a from 100..110
+        )
+        with self.assertRaises(SystemExit):
+            validate_single_row(layout)
+
+    def test_columns_not_filling_width_are_rejected(self):
+        layout = full_rect_layout(
+            self.AREA,
+            ("a", 0, 0, 70, 55),
+            ("b", 70, 0, 70, 55),  # spans to 140, area ends at 210
+        )
+        with self.assertRaises(SystemExit):
+            validate_single_row(layout)
+
+    def test_missing_area_rect_is_rejected(self):
+        layout = {"result": {"layout": {"panes": panes(("a", 0, 210))}}}
+        with self.assertRaises(SystemExit):
+            validate_single_row(layout)
+
+    def test_pane_missing_yheight_is_rejected(self):
+        # A pane rect with only x/width (the old shape) can't be validated as
+        # a full-height column — must reject rather than assume.
+        layout = {
+            "result": {
+                "layout": {
+                    "area": {"x": 0, "y": 0, "width": 210, "height": 55},
+                    "panes": [{"pane_id": "a", "rect": {"x": 0, "width": 210}}],
+                }
+            }
+        }
+        with self.assertRaises(SystemExit):
+            validate_single_row(layout)
 
 
 class EqualizerConvergenceTests(unittest.TestCase):

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -4,11 +4,15 @@
 Run directly (stdlib unittest only, no live herdr needed):
     python3 -m unittest discover -s skills/herdr-agent-comms/tests -p 'test_*.py'
 
-Covers the pure-arithmetic core only (ordering panes left to right, and the
-1/N share for N columns after a split). The actual `herdr pane split
---ratio` / `herdr pane resize --amount` semantics are NOT exercised here —
-there is no live herdr server in this test harness to confirm what those
-flags actually do; see the module docstring in next_grid_split.py.
+These cover the pure arithmetic that decides the split ratio and each
+equalizer resize op. The exact `herdr pane split --ratio` / `herdr pane
+resize --amount` semantics they encode were verified LIVE against herdr
+0.7.4 (documented in SKILL.md "Equal-width columns — verified semantics"):
+`--ratio` = the existing/left child's fraction of the split pane; `--amount`
+= a cell delta as a fraction of the tab area width, growing the neighbor on
+`--direction`. `test_equalizer_sweep_converges_on_redistribution_model`
+simulates the observed proportional redistribution and confirms the
+outermost-first grow sweep is a contraction (converges to equal width).
 """
 
 from __future__ import annotations
@@ -19,7 +23,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from next_grid_split import plan_equal_width_split  # noqa: E402
+from next_grid_split import (  # noqa: E402
+    area_width_from_layout,
+    boundary_resize_op,
+    equal_targets,
+    plan_next_split,
+)
 
 
 def panes(*rects):
@@ -29,78 +38,175 @@ def panes(*rects):
     ]
 
 
-class PlanEqualWidthSplitTests(unittest.TestCase):
+class PlanNextSplitTests(unittest.TestCase):
     def test_single_pane_plans_two_columns(self):
-        layout = panes(("root", 0, 200))
-        ordered, new_count = plan_equal_width_split(layout, "root")
-        self.assertEqual(ordered, ["root"])
+        rightmost, new_count = plan_next_split(panes(("root", 0, 200)), "root")
+        self.assertEqual(rightmost, "root")
         self.assertEqual(new_count, 2)
 
-    def test_orders_panes_left_to_right_by_x(self):
-        layout = panes(("sub1", 100, 100), ("root", 0, 100))
-        ordered, new_count = plan_equal_width_split(layout, "root")
-        self.assertEqual(ordered, ["root", "sub1"])
+    def test_orders_panes_left_to_right_and_splits_rightmost(self):
+        rightmost, new_count = plan_next_split(
+            panes(("sub1", 100, 100), ("root", 0, 100)), "root"
+        )
+        self.assertEqual(rightmost, "sub1")
         self.assertEqual(new_count, 3)
 
     def test_three_existing_columns_plans_fourth(self):
-        layout = panes(("root", 0, 66), ("sub1", 66, 67), ("sub2", 133, 67))
-        ordered, new_count = plan_equal_width_split(layout, "root")
-        self.assertEqual(ordered, ["root", "sub1", "sub2"])
+        rightmost, new_count = plan_next_split(
+            panes(("root", 0, 66), ("sub1", 66, 67), ("sub2", 133, 67)), "root"
+        )
+        self.assertEqual(rightmost, "sub2")
         self.assertEqual(new_count, 4)
 
     def test_missing_root_pane_still_plans_from_layout(self):
-        layout = panes(("a", 0, 50), ("b", 50, 50))
-        ordered, new_count = plan_equal_width_split(layout, None)
-        self.assertEqual(ordered, ["a", "b"])
+        rightmost, new_count = plan_next_split(panes(("a", 0, 50), ("b", 50, 50)), None)
+        self.assertEqual(rightmost, "b")
         self.assertEqual(new_count, 3)
 
     def test_root_pane_not_in_layout_warns_but_still_plans(self):
-        layout = panes(("a", 0, 50), ("b", 50, 50))
-        ordered, new_count = plan_equal_width_split(layout, "missing-root")
-        self.assertEqual(ordered, ["a", "b"])
+        rightmost, new_count = plan_next_split(
+            panes(("a", 0, 50), ("b", 50, 50)), "missing-root"
+        )
+        self.assertEqual(rightmost, "b")
         self.assertEqual(new_count, 3)
 
     def test_no_usable_rects_raises(self):
-        layout = [{"pane_id": "x", "rect": {"x": 0, "width": 0}}]
         with self.assertRaises(SystemExit):
-            plan_equal_width_split(layout, "x")
+            plan_next_split([{"pane_id": "x", "rect": {"x": 0, "width": 0}}], "x")
 
     def test_panes_missing_rect_fields_are_dropped(self):
         layout = [
             {"pane_id": "root", "rect": {"x": 0, "width": 100}},
             {"pane_id": "ghost"},
         ]
-        ordered, new_count = plan_equal_width_split(layout, "root")
-        self.assertEqual(ordered, ["root"])
+        rightmost, new_count = plan_next_split(layout, "root")
+        self.assertEqual(rightmost, "root")
         self.assertEqual(new_count, 2)
 
-    def test_four_agent_spawn_sequence_converges_to_equal_shares(self):
-        """End-to-end simulation: spawn 3 sub-agents from one root pane,
-        each time re-running the planner and applying the emitted resize
-        plan, and confirm every column ends up the same width.
+
+class EqualTargetsTests(unittest.TestCase):
+    def test_even_division(self):
+        self.assertEqual(equal_targets(5, 210), [42, 42, 42, 42, 42])
+
+    def test_remainder_goes_to_leftmost_columns(self):
+        # 210 / 4 = 52.5 -> two columns get 53, two get 52; sum stays 210.
+        self.assertEqual(equal_targets(4, 210), [53, 53, 52, 52])
+        self.assertEqual(sum(equal_targets(4, 210)), 210)
+
+    def test_single_column(self):
+        self.assertEqual(equal_targets(1, 210), [210])
+
+    def test_zero_columns_raises(self):
+        with self.assertRaises(SystemExit):
+            equal_targets(0, 210)
+
+
+class BoundaryResizeOpTests(unittest.TestCase):
+    ids = ["a", "b", "c"]
+
+    def test_boundary_must_move_right_grows_left_column(self):
+        # widths 40/80/90 (area 210), targets 70/70/70. Boundary 0 cum=40,
+        # target cum=70 -> move right by 30 -> grow column a on its right.
+        op = boundary_resize_op(self.ids, [40, 80, 90], [70, 70, 70], 210, 0)
+        self.assertEqual(op, ("a", "right", 30 / 210))
+
+    def test_boundary_must_move_left_grows_right_column(self):
+        # widths 105/53/52, targets 70/70/70. Boundary 0 cum=105, target=70
+        # -> move left by 35 -> grow the RIGHT column b on its left edge.
+        op = boundary_resize_op(self.ids, [105, 53, 52], [70, 70, 70], 210, 0)
+        self.assertEqual(op, ("b", "left", 35 / 210))
+
+    def test_on_target_returns_none(self):
+        op = boundary_resize_op(self.ids, [70, 70, 70], [70, 70, 70], 210, 0)
+        self.assertIsNone(op)
+
+    def test_sub_cell_delta_returns_none(self):
+        # cum 70.4 vs target 70 -> 0.4 cell, nothing herdr can act on.
+        op = boundary_resize_op(self.ids, [70.4, 70, 69.6], [70, 70, 70], 210, 0)
+        self.assertIsNone(op)
+
+
+class AreaWidthTests(unittest.TestCase):
+    def test_reads_explicit_area(self):
+        data = {"layout": {"area": {"width": 210}, "panes": panes(("a", 0, 210))}}
+        self.assertEqual(area_width_from_layout(data), 210)
+
+    def test_falls_back_to_summed_widths(self):
+        data = {"layout": {"panes": panes(("a", 0, 100), ("b", 100, 110))}}
+        self.assertEqual(area_width_from_layout(data), 210)
+
+
+class EqualizerConvergenceTests(unittest.TestCase):
+    """Simulate the live herdr redistribution behaviour and confirm the
+    outermost-first, always-grow boundary sweep is a contraction toward
+    equal width. The model mirrors what was observed live: a resize moves
+    one boundary by the requested delta and redistributes the freed/absorbed
+    cells *proportionally* among the panes on the other side of that
+    boundary.
+    """
+
+    AREA = 210
+
+    def _resize(self, widths, pane_index, direction, amount):
+        """Apply one resize to a copy of `widths`, returning the new list.
+
+        Moves the boundary between `pane_index` and its neighbor on
+        `direction`, redistributing `delta` cells proportionally across the
+        panes on the far side of that boundary.
         """
-        state = {"root": {"x": 0.0, "w": 200.0}}
+        w = list(widths)
+        delta = amount * self.AREA
+        if direction == "right":
+            # grow pane_index rightward: boundary between pane_index and
+            # pane_index+1 moves right; cells taken from all panes to the right.
+            w[pane_index] += delta
+            right = list(range(pane_index + 1, len(w)))
+            total = sum(w[i] for i in right)
+            for i in right:
+                w[i] -= delta * (w[i] / total)
+        else:  # left: grow pane_index leftward, boundary between it and
+            # pane_index-1 moves left; cells taken from panes to the left.
+            w[pane_index] += delta
+            left = list(range(0, pane_index))
+            total = sum(w[i] for i in left)
+            for i in left:
+                w[i] -= delta * (w[i] / total)
+        return w
 
-        def apply_plan(ordered, new_count):
-            share = 200.0 / new_count
-            new_id = f"p{len(state) + 1}"
-            state[new_id] = {"x": 0.0, "w": share}
-            x = 0.0
-            for pane_id in ordered + [new_id]:
-                state[pane_id]["x"] = x
-                state[pane_id]["w"] = share
-                x += share
+    def _sweep_once(self, widths):
+        ids = [f"c{i}" for i in range(len(widths))]
+        targets = equal_targets(len(widths), self.AREA)
+        for boundary in range(len(widths) - 1):
+            op = boundary_resize_op(ids, widths, targets, self.AREA, boundary)
+            if op is None:
+                continue
+            pane_id, direction, amount = op
+            idx = ids.index(pane_id)
+            widths = self._resize(widths, idx, direction, amount)
+        return widths
 
-        for _ in range(3):
-            layout = panes(*[(pid, v["x"], v["w"]) for pid, v in state.items()])
-            ordered, new_count = plan_equal_width_split(layout, "root")
-            apply_plan(ordered, new_count)
+    def test_four_column_decay_converges(self):
+        # geometric decay a naive split leaves behind: 105/35/18/52-ish.
+        widths = [105.0, 35.0, 18.0, 52.0]
+        # normalize to area
+        scale = self.AREA / sum(widths)
+        widths = [w * scale for w in widths]
+        start_spread = max(widths) - min(widths)
+        for _ in range(12):
+            if max(widths) - min(widths) <= 1.5:
+                break
+            widths = self._sweep_once(widths)
+        # This float model converges to ~1 cell; live herdr (integer cells)
+        # lands at spread 0 for this case. Either way the sweep is a strong
+        # contraction — assert it collapsed to a near-equal fixed point.
+        self.assertLess(max(widths) - min(widths), start_spread)
+        self.assertLessEqual(max(widths) - min(widths), 1.5)
 
-        self.assertEqual(len(state), 4)  # root + 3 sub-agents
-        widths = [v["w"] for v in state.values()]
-        expected = 200.0 / 4
-        for w in widths:
-            self.assertAlmostEqual(w, expected, places=6)
+    def test_already_equal_is_a_fixed_point(self):
+        widths = [70.0, 70.0, 70.0]
+        out = self._sweep_once(widths)
+        for a, b in zip(out, widths):
+            self.assertAlmostEqual(a, b, places=6)
 
 
 if __name__ == "__main__":

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Fixture tests for next_grid_split.py's pane-selection algorithm.
+
+Run directly (stdlib unittest only, no live herdr needed):
+    python3 -m unittest discover -s skills/herdr-agent-comms/tests -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from next_grid_split import choose_target  # noqa: E402
+
+
+def panes(*rects):
+    return [
+        {"pane_id": pid, "rect": {"width": w, "height": h}}
+        for pid, w, h in rects
+    ]
+
+
+class ChooseTargetTests(unittest.TestCase):
+    def test_first_split_of_single_pane_always_down(self):
+        # Regression guard for the documented "vertical panel first" default:
+        # a lone, wide root pane must still split down, not right, even
+        # though a naive aspect check on 200x50 would pick right.
+        layout = panes(("root", 200, 50))
+        target, direction = choose_target(layout, "root")
+        self.assertEqual(target, "root")
+        self.assertEqual(direction, "down")
+
+    def test_first_split_of_single_pane_down_even_when_tall(self):
+        layout = panes(("root", 40, 200))
+        target, direction = choose_target(layout, "root")
+        self.assertEqual(target, "root")
+        self.assertEqual(direction, "down")
+
+    def test_later_split_picks_largest_pane(self):
+        layout = panes(("root", 100, 25), ("sub1", 200, 25))
+        target, _direction = choose_target(layout, "root")
+        self.assertEqual(target, "sub1")
+
+    def test_later_split_ties_prefer_root(self):
+        layout = panes(("root", 200, 25), ("sub1", 200, 25))
+        target, _direction = choose_target(layout, "root")
+        self.assertEqual(target, "root")
+
+    def test_later_split_direction_follows_target_aspect_wide(self):
+        layout = panes(("root", 200, 25), ("sub1", 200, 25))
+        _target, direction = choose_target(layout, "root")
+        self.assertEqual(direction, "right")
+
+    def test_later_split_targets_largest_even_if_another_pane_is_taller(self):
+        # "a" is the largest pane by area (200x25=5000 > 40x50=2000) and is
+        # wide, so it's both the target and gets `right`.
+        layout = panes(("a", 200, 25), ("b", 40, 50))
+        target, direction = choose_target(layout, "a")
+        self.assertEqual(target, "a")
+        self.assertEqual(direction, "right")
+
+    def test_later_split_direction_down_for_tall_target(self):
+        layout = panes(("root", 40, 200), ("sub1", 10, 10))
+        target, direction = choose_target(layout, "root")
+        self.assertEqual(target, "root")
+        self.assertEqual(direction, "down")
+
+    def test_missing_root_pane_falls_back_to_largest(self):
+        layout = panes(("a", 50, 50), ("b", 100, 100))
+        target, _direction = choose_target(layout, None)
+        self.assertEqual(target, "b")
+
+    def test_no_usable_rects_raises(self):
+        layout = [{"pane_id": "x", "rect": {"width": 0, "height": 0}}]
+        with self.assertRaises(SystemExit):
+            choose_target(layout, "x")
+
+    def test_three_agent_spawn_sequence_produces_balanced_grid(self):
+        """End-to-end simulation: spawn 3 sub-agents from one root pane and
+        confirm no pane degenerates into a narrow sliver (regression guard
+        for the "wide roots only create narrow columns" bug).
+        """
+        state = {"root": {"w": 200.0, "h": 50.0}}
+
+        def split(pane_id, direction):
+            w, h = state[pane_id]["w"], state[pane_id]["h"]
+            new_id = f"p{len(state) + 1}"
+            if direction == "down":
+                state[pane_id] = {"w": w, "h": h / 2}
+                state[new_id] = {"w": w, "h": h / 2}
+            else:
+                state[pane_id] = {"w": w / 2, "h": h}
+                state[new_id] = {"w": w / 2, "h": h}
+            return new_id
+
+        for _ in range(3):
+            layout = panes(*[(pid, v["w"], v["h"]) for pid, v in state.items()])
+            target, direction = choose_target(layout, "root")
+            split(target, direction)
+
+        self.assertEqual(len(state), 4)  # root + 3 sub-agents
+        areas = [v["w"] * v["h"] for v in state.values()]
+        # Balanced grid: no pane should be a sliver relative to an even split.
+        even_share = (200.0 * 50.0) / 4
+        for area in areas:
+            self.assertGreater(area, even_share * 0.4)
+            self.assertLess(area, even_share * 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -102,14 +102,18 @@ class PlanNextSplitTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             plan_next_split([{"pane_id": "x", "rect": {"x": 0, "width": 0}}], "x")
 
-    def test_panes_missing_rect_fields_are_dropped(self):
+    def test_pane_missing_rect_is_hard_error(self):
+        # Round 16 finding #2: a pane with a VALID id but no rect must be a HARD
+        # error, not a silent drop — dropping it during a live re-read would
+        # compute resize ops for a partial grid. (Was
+        # test_panes_missing_rect_fields_are_dropped, which asserted the drop;
+        # that lenient behaviour is now the bug.)
         layout = [
             {"pane_id": "root", "rect": {"x": 0, "width": 100}},
             {"pane_id": "ghost"},
         ]
-        rightmost, new_count = plan_next_split(layout, "root")
-        self.assertEqual(rightmost, "root")
-        self.assertEqual(new_count, 2)
+        with self.assertRaises(SystemExit):
+            plan_next_split(layout, "root")
 
 
 class PaneIdValidationTests(unittest.TestCase):
@@ -175,6 +179,59 @@ class PaneIdValidationTests(unittest.TestCase):
              {"pane_id": "b", "rect": {"x": 50, "width": 50}}],
             None,
         )
+        self.assertEqual(rightmost, "b")
+        self.assertEqual(new_count, 3)
+
+
+class PaneGeometryValidationTests(unittest.TestCase):
+    """Round 16 finding #2: every pane must carry valid rect/x/positive-width
+    geometry. A missing/malformed/non-positive value must be a HARD error, not a
+    silent drop — dropping one during a live equalize re-read would compute
+    resize ops for a partial grid (a column omitted)."""
+
+    def _split(self, second_rect):
+        return plan_next_split(
+            [{"pane_id": "a", "rect": {"x": 0, "width": 50}},
+             {"pane_id": "b", "rect": second_rect}],
+            None,
+        )
+
+    def test_missing_rect_raises(self):
+        with self.assertRaises(SystemExit):
+            plan_next_split(
+                [{"pane_id": "a", "rect": {"x": 0, "width": 50}},
+                 {"pane_id": "b"}],
+                None,
+            )
+
+    def test_missing_x_raises(self):
+        # Old behaviour defaulted missing x to 0, misordering columns.
+        with self.assertRaises(SystemExit):
+            self._split({"width": 50})
+
+    def test_missing_width_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": 50})
+
+    def test_zero_width_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": 50, "width": 0})
+
+    def test_negative_width_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": 50, "width": -10})
+
+    def test_non_numeric_width_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": 50, "width": "wide"})
+
+    def test_non_numeric_x_raises(self):
+        with self.assertRaises(SystemExit):
+            self._split({"x": "left", "width": 50})
+
+    def test_all_valid_geometry_still_plans(self):
+        # Control: fully-valid geometry plans normally (no over-reach).
+        rightmost, new_count = self._split({"x": 50, "width": 50})
         self.assertEqual(rightmost, "b")
         self.assertEqual(new_count, 3)
 

--- a/skills/herdr-agent-comms/tests/test_next_grid_split.py
+++ b/skills/herdr-agent-comms/tests/test_next_grid_split.py
@@ -27,6 +27,7 @@ from next_grid_split import (  # noqa: E402
     area_width_from_layout,
     boundary_resize_op,
     equal_targets,
+    panes_from_layout,
     plan_next_split,
     require_root_membership,
     split_ratio,
@@ -109,6 +110,38 @@ class PlanNextSplitTests(unittest.TestCase):
         rightmost, new_count = plan_next_split(layout, "root")
         self.assertEqual(rightmost, "root")
         self.assertEqual(new_count, 2)
+
+
+class MalformedLayoutJsonTests(unittest.TestCase):
+    """Round 14 note: malformed-but-valid JSON must yield a clean SystemExit
+    validation error, NOT an uncaught AttributeError traceback."""
+
+    def test_top_level_null_is_clean_error(self):
+        # json.load of "null" is None; .get() on it would crash.
+        with self.assertRaises(SystemExit):
+            panes_from_layout(None)
+
+    def test_top_level_list_is_clean_error(self):
+        with self.assertRaises(SystemExit):
+            panes_from_layout([1, 2, 3])
+
+    def test_panes_with_null_element_is_clean_error(self):
+        # `panes: [null]` — the null element would crash every pane.get(...).
+        with self.assertRaises(SystemExit):
+            panes_from_layout({"layout": {"panes": [None]}})
+
+    def test_panes_with_non_object_element_is_clean_error(self):
+        with self.assertRaises(SystemExit):
+            panes_from_layout({"layout": {"panes": ["not-a-pane"]}})
+
+    def test_null_element_via_validate_single_row_is_clean_error(self):
+        with self.assertRaises(SystemExit):
+            validate_single_row({"layout": {"area": {"x": 0, "y": 0, "width": 100, "height": 10},
+                                            "panes": [None]}})
+
+    def test_null_element_via_plan_next_split_is_clean_error(self):
+        with self.assertRaises(SystemExit):
+            plan_next_split([None], "root")
 
 
 class RequireRootMembershipTests(unittest.TestCase):

--- a/skills/herdr-agent-comms/tests/test_preflight_send.py
+++ b/skills/herdr-agent-comms/tests/test_preflight_send.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Behavioral tests for preflight_send.py against a fake `herdr` CLI.
+
+The single-target twin of broadcast.sh Phase 1b (round 10, finding #2). Verifies
+the fail-closed enum validation: only idle/done/unknown are sendable; working,
+blocked, unverifiable-lookup, and OFF-ENUM values each get a distinct non-zero
+exit so a caller can never type a task into a working/blocked/unverifiable pane.
+
+Run directly (stdlib unittest only):
+    python3 -m unittest discover -s skills/herdr-agent-comms/tests -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE.parent / "scripts"
+FAKE_BIN = HERE / "bin"
+PREFLIGHT = SCRIPTS / "preflight_send.py"
+
+
+class FakeHerdrHarness:
+    def __init__(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hac_preflight_test_")
+        self.state_path = os.path.join(self.tmpdir, "state.json")
+        self.write_state({"panes": {}})
+        self.env = dict(os.environ)
+        self.env["FAKE_HERDR_STATE"] = self.state_path
+        self.env["PATH"] = f"{FAKE_BIN}{os.pathsep}{self.env.get('PATH', '')}"
+
+    def write_state(self, state):
+        with open(self.state_path, "w", encoding="utf-8") as f:
+            json.dump(state, f)
+
+    def read_state(self):
+        with open(self.state_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def set_pane(self, pane_id, status, text="", name=None,
+                 fail_get=False, malformed_get=False):
+        state = self.read_state()
+        state["panes"][pane_id] = {
+            "agent_status": status, "text": text, "name": name,
+            "fail_get": fail_get, "malformed_get": malformed_get,
+        }
+        self.write_state(state)
+
+    def run_preflight(self, pane_id, timeout=8):
+        cmd = [sys.executable, str(PREFLIGHT), pane_id]
+        return subprocess.run(cmd, env=self.env, text=True, capture_output=True, timeout=timeout)
+
+
+class PreflightSendTests(unittest.TestCase):
+    def setUp(self):
+        self.h = FakeHerdrHarness()
+
+    def test_idle_is_sendable(self):
+        self.h.set_pane("p1", "idle")
+        cp = self.h.run_preflight("p1")
+        self.assertEqual(cp.returncode, 0, msg=f"stderr={cp.stderr!r}")
+        self.assertIn("idle", cp.stdout)
+
+    def test_done_is_sendable(self):
+        self.h.set_pane("p1", "done")
+        self.assertEqual(self.h.run_preflight("p1").returncode, 0)
+
+    def test_unknown_is_sendable(self):
+        """A validly-absent status (non-integrated CLI) is still sendable."""
+        self.h.set_pane("p1", "unknown")
+        self.assertEqual(self.h.run_preflight("p1").returncode, 0)
+
+    def test_working_returns_2(self):
+        self.h.set_pane("p1", "working")
+        cp = self.h.run_preflight("p1")
+        self.assertEqual(cp.returncode, 2, msg=f"stderr={cp.stderr!r}")
+        self.assertIn("working", cp.stderr.lower())
+
+    def test_blocked_returns_3(self):
+        """The reported repro: a blocked trust dialog must NOT be sendable."""
+        self.h.set_pane("p1", "blocked", "Trust this workspace? [y/n]\n")
+        cp = self.h.run_preflight("p1")
+        self.assertEqual(cp.returncode, 3, msg=f"stderr={cp.stderr!r}")
+        self.assertIn("blocked", cp.stderr.lower())
+
+    def test_failed_lookup_returns_4_unverifiable(self):
+        self.h.set_pane("p1", "idle", fail_get=True)
+        cp = self.h.run_preflight("p1")
+        self.assertEqual(cp.returncode, 4, msg=f"stderr={cp.stderr!r}")
+
+    def test_malformed_lookup_returns_4_unverifiable(self):
+        self.h.set_pane("p1", "idle", malformed_get=True)
+        self.assertEqual(self.h.run_preflight("p1").returncode, 4)
+
+    def test_numeric_offenum_status_returns_4_unverifiable(self):
+        """finding #1 hole: a numeric 123 status must be unverifiable, not
+        treated as a truthy sendable status (rc 4, not rc 0)."""
+        self.h.set_pane("p1", 123)
+        cp = self.h.run_preflight("p1")
+        self.assertEqual(cp.returncode, 4, msg=f"stderr={cp.stderr!r}")
+
+    def test_garbage_string_status_returns_4_unverifiable(self):
+        self.h.set_pane("p1", "totally-bogus")
+        self.assertEqual(self.h.run_preflight("p1").returncode, 4)
+
+    def test_empty_string_status_returns_4_unverifiable(self):
+        self.h.set_pane("p1", "")
+        self.assertEqual(self.h.run_preflight("p1").returncode, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/herdr-agent-comms/tests/test_wait_for_idle.py
+++ b/skills/herdr-agent-comms/tests/test_wait_for_idle.py
@@ -44,9 +44,11 @@ class FakeHerdrHarness:
         with open(self.state_path, encoding="utf-8") as f:
             return json.load(f)
 
-    def set_pane(self, pane_id, status, text, name=None):
+    def set_pane(self, pane_id, status, text, name=None, fail_get=False):
         state = self.read_state()
-        state["panes"][pane_id] = {"agent_status": status, "text": text, "name": name}
+        state["panes"][pane_id] = {
+            "agent_status": status, "text": text, "name": name, "fail_get": fail_get,
+        }
         self.write_state(state)
 
     def set_status(self, pane_id, status):
@@ -253,6 +255,46 @@ class WaitForIdleMarkerSemanticsTests(unittest.TestCase):
         self.h.set_pane("p1", "idle", "already done earlier\n")
         cp = self.h.run_waiter("p1", "--ready", "--timeout", "1")
         self.assertEqual(cp.returncode, 0)
+
+    def test_ready_with_status_lookup_failure_is_error_not_ready(self):
+        """Regression (P1 round 8): a `--ready` check must NOT report ready
+        (rc 0) when `herdr pane get` fails — a failed status lookup is
+        unverifiable, not a valid `unknown`. Previously this fell through to
+        content-stability and returned 0. Now it errors (rc 1)."""
+        # Pane resolves (via `agent get`) but every `pane get` status lookup
+        # fails, so status is unverifiable throughout.
+        self.h.set_pane("p1", "idle", "boot\n", name="flaky", fail_get=True)
+        cp = self.h.run_waiter("p1", "--ready", "--timeout", "2")
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_ready_blocked_pane_with_lookup_failure_is_not_ready(self):
+        """The reported repro: a genuinely `blocked` pane whose status lookup
+        also persistently fails must NOT be reproduced as ready rc 0. Since the
+        lookup is unverifiable, `--ready` errors (rc 1) rather than guessing
+        ready — never silently proceeding as if a dialog weren't there.
+
+        Small --interval + short quiet-cycles so that, under the OLD fail-open
+        behaviour, the static dialog text WOULD stabilize and return a false
+        ready rc 0 — that is exactly what the fix must prevent. rc 1 (fixed)
+        vs rc 0 (buggy) is the discriminating outcome."""
+        self.h.set_pane("p1", "blocked", "Trust this workspace? [y/n]\n",
+                        name="gated", fail_get=True)
+        cp = self.h.run_waiter(
+            "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "5"
+        )
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_valid_unknown_status_still_uses_content_stability(self):
+        """A validly-absent status ("unknown", e.g. a non-integrated CLI) must
+        NOT be treated as a lookup failure — it still uses the content-stability
+        path and can settle ready. This guards against over-correcting #1 into
+        breaking integration-less agents. (Small --interval + enough timeout so
+        the quiet-cycle stability check can actually complete.)"""
+        self.h.set_pane("p1", "unknown", "some stable output\n")
+        cp = self.h.run_waiter(
+            "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "5"
+        )
+        self.assertEqual(cp.returncode, 0, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
 
     def test_no_marker_legacy_fallback_uses_saw_working(self):
         """Without a completion marker arranged, a genuine working->idle

--- a/skills/herdr-agent-comms/tests/test_wait_for_idle.py
+++ b/skills/herdr-agent-comms/tests/test_wait_for_idle.py
@@ -323,6 +323,36 @@ class WaitForIdleMarkerSemanticsTests(unittest.TestCase):
         )
         self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
 
+    def test_ready_numeric_status_is_unverifiable_not_ready(self):
+        """Regression (round 10, finding #1): an off-enum status VALUE (here a
+        numeric 123) must be treated as unverifiable, NOT as a benign truthy
+        status that sails through. Under --ready it must error (rc 1), never
+        report ready (rc 0). fake_herdr passes agent_status straight through
+        json.dumps, so this injects a real numeric status into `pane get`."""
+        self.h.set_pane("p1", 123, "some output\n")
+        cp = self.h.run_waiter(
+            "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "3"
+        )
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_ready_garbage_string_status_is_unverifiable_not_ready(self):
+        """Same fail-open hole via an out-of-enum STRING (a typo / server-invented
+        value): must be unverifiable (rc 1 under --ready), not accepted."""
+        self.h.set_pane("p1", "totally-bogus", "some output\n")
+        cp = self.h.run_waiter(
+            "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "3"
+        )
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_empty_string_status_is_unverifiable(self):
+        """An empty-string status is NOT a valid 'unknown' — the old `or
+        "unknown"` masked it. It's off-enum, so unverifiable (rc 1 --ready)."""
+        self.h.set_pane("p1", "", "some output\n")
+        cp = self.h.run_waiter(
+            "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "3"
+        )
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
     def test_no_marker_legacy_fallback_uses_saw_working(self):
         """Without a completion marker arranged, a genuine working->idle
         transition for THIS send is still accepted (legacy behavior)."""

--- a/skills/herdr-agent-comms/tests/test_wait_for_idle.py
+++ b/skills/herdr-agent-comms/tests/test_wait_for_idle.py
@@ -44,11 +44,14 @@ class FakeHerdrHarness:
         with open(self.state_path, encoding="utf-8") as f:
             return json.load(f)
 
-    def set_pane(self, pane_id, status, text, name=None, fail_get=False):
+    def set_pane(self, pane_id, status, text, name=None, fail_get=False, fail_get_after=None):
         state = self.read_state()
         state["panes"][pane_id] = {
             "agent_status": status, "text": text, "name": name, "fail_get": fail_get,
         }
+        if fail_get_after is not None:
+            # pane get succeeds fail_get_after times, then fails every call after.
+            state["panes"][pane_id]["fail_get_after"] = fail_get_after
         self.write_state(state)
 
     def set_status(self, pane_id, status):
@@ -295,6 +298,30 @@ class WaitForIdleMarkerSemanticsTests(unittest.TestCase):
             "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "5"
         )
         self.assertEqual(cp.returncode, 0, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_ready_unknown_then_lookup_failure_is_error_not_ready(self):
+        """Regression (P round 9): the initial status is a VALID `unknown`
+        (passes the first probe → enters content-stability), then a LATER
+        `herdr pane get` fails. That later lookup failure must ALSO fail the
+        --ready check (rc 1), not be ignored so content stability reports a
+        false ready rc 0. `fail_get_after=1` = first lookup ok, then fail.
+        Small interval/quiet so, unfixed, stability would settle ready fast."""
+        self.h.set_pane("p1", "unknown", "stable output\n", name="flaky", fail_get_after=1)
+        cp = self.h.run_waiter(
+            "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "5"
+        )
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_ready_working_then_lookup_failure_is_error_not_ready(self):
+        """The status-loop variant: initial status `working` enters the status
+        loop, then a subsequent `herdr pane get` fails. That in-loop lookup
+        failure must fail the --ready check (rc 1). `fail_get_after=1` = the
+        initial working read succeeds, the next in-loop read fails."""
+        self.h.set_pane("p1", "working", "running\n", name="busy", fail_get_after=1)
+        cp = self.h.run_waiter(
+            "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "5"
+        )
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
 
     def test_no_marker_legacy_fallback_uses_saw_working(self):
         """Without a completion marker arranged, a genuine working->idle

--- a/skills/herdr-agent-comms/tests/test_wait_for_idle.py
+++ b/skills/herdr-agent-comms/tests/test_wait_for_idle.py
@@ -54,6 +54,11 @@ class FakeHerdrHarness:
         state["panes"][pane_id]["agent_status"] = status
         self.write_state(state)
 
+    def delete_pane(self, pane_id):
+        state = self.read_state()
+        state["panes"].pop(pane_id, None)
+        self.write_state(state)
+
     def append_text(self, pane_id, text):
         state = self.read_state()
         state["panes"][pane_id]["text"] += text
@@ -191,6 +196,52 @@ class WaitForIdleMarkerSemanticsTests(unittest.TestCase):
         t.join()
         self.assertEqual(cp.returncode, 0, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
         self.assertIn(marker, cp.stdout)
+
+    def test_pane_disappearing_mid_wait_is_error_not_completion(self):
+        """Regression (P2 round 5): if the pane vanishes during the
+        content-stability wait, a FAILED `herdr pane read` must not stabilize
+        into a false completion (rc 0). It must surface as an error (rc 1).
+        --no-status forces the content-stability path (no agent-status).
+        """
+        baseline_text = "task running\n"
+        self.h.set_pane("p1", "working", baseline_text)
+        baseline = self.h.baseline_file(baseline_text)
+
+        def kill_pane():
+            time.sleep(0.4)
+            self.h.delete_pane("p1")  # pane gone: reads now fail (rc 1)
+
+        t = threading.Thread(target=kill_pane)
+        t.start()
+        cp = self.h.run_waiter(
+            "p1", "--baseline-file", baseline, "--no-status",
+            "--interval", "0.2", "--timeout", "3",
+        )
+        t.join()
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_pane_gone_in_status_path_read_is_error_not_completion(self):
+        """Same disappearance, but on the prefer-status path: pane is idle/done
+        (so we take the terminal branch), then the transcript read fails. A
+        failed read there must be an error (rc 1), never a success. Uses a
+        pane id shaped like a real herdr id (w..:..) so resolve_pane accepts it
+        and the failure happens at the transcript read, not at resolution."""
+        baseline_text = "task running\n"
+        self.h.set_pane("w1:p1", "working", baseline_text)
+        baseline = self.h.baseline_file(baseline_text)
+
+        def flip_then_kill():
+            time.sleep(0.3)
+            self.h.set_status("w1:p1", "done")  # enter terminal branch...
+            time.sleep(0.05)
+            self.h.delete_pane("w1:p1")          # ...then the read fails
+
+        t = threading.Thread(target=flip_then_kill)
+        t.start()
+        cp = self.h.run_waiter("w1:p1", "--baseline-file", baseline, "--timeout", "3")
+        t.join()
+        # rc 1 (read failed) is the correct outcome; the bug returned 0.
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
 
     def test_blocked_status_returns_3(self):
         self.h.set_pane("p1", "blocked", "trust dialog\n")

--- a/skills/herdr-agent-comms/tests/test_wait_for_idle.py
+++ b/skills/herdr-agent-comms/tests/test_wait_for_idle.py
@@ -139,6 +139,59 @@ class WaitForIdleMarkerSemanticsTests(unittest.TestCase):
         self.assertEqual(cp.returncode, 0, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
         self.assertIn(marker, cp.stdout)
 
+    def test_working_to_done_transition_is_success_not_timeout(self):
+        """Regression (P2 round 4): a pane that goes working -> DONE and stays
+        `done` (never `idle`) must be reported as finished (rc 0), not time out
+        (rc 2). The old working-branch waited for `done` in only HALF the slice
+        then spent the WHOLE remaining deadline waiting only for `idle`, so a
+        pane settling on `done` AFTER that half-window blocked until timeout.
+        The fix bounds the idle-wait too and loops back to re-check either
+        terminal state.
+
+        Timing matters: the pane must stay `working` past the first half-window
+        (~half the deadline) and only then flip to `done`, otherwise the old
+        code's initial `wait done` succeeds and the bug never triggers. With a
+        2s deadline the half-window is ~1s, so flip at 1.2s.
+        """
+        baseline_text = "before send\n"
+        self.h.set_pane("p1", "working", baseline_text)
+        baseline = self.h.baseline_file(baseline_text)
+
+        def do_work():
+            time.sleep(1.2)  # past the first half-window; misses the buggy `wait done`
+            self.h.append_text("p1", "reply text, task complete\n")
+            self.h.set_status("p1", "done")  # terminal DONE, never idle
+
+        t = threading.Thread(target=do_work)
+        t.start()
+        cp = self.h.run_waiter("p1", "--baseline-file", baseline, "--timeout", "2")
+        t.join()
+        self.assertEqual(cp.returncode, 0, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_working_to_done_with_marker_is_success(self):
+        """Same working->done transition (flipping past the half-window), but
+        with a completion marker: the fresh marker appearing at the `done`
+        transition must be accepted, not lost because the branch only watched
+        for `idle`."""
+        baseline_text = "before send\n"
+        self.h.set_pane("p1", "working", baseline_text)
+        baseline = self.h.baseline_file(baseline_text)
+        marker = "HERDR_DONE_done_only_42"
+
+        def do_work():
+            time.sleep(1.2)
+            self.h.append_text("p1", f"reply {marker}\n")
+            self.h.set_status("p1", "done")  # terminal DONE, never idle
+
+        t = threading.Thread(target=do_work)
+        t.start()
+        cp = self.h.run_waiter(
+            "p1", "--baseline-file", baseline, "--completion-marker", marker, "--timeout", "2"
+        )
+        t.join()
+        self.assertEqual(cp.returncode, 0, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+        self.assertIn(marker, cp.stdout)
+
     def test_blocked_status_returns_3(self):
         self.h.set_pane("p1", "blocked", "trust dialog\n")
         baseline = self.h.baseline_file("trust dialog\n")

--- a/skills/herdr-agent-comms/tests/test_wait_for_idle.py
+++ b/skills/herdr-agent-comms/tests/test_wait_for_idle.py
@@ -44,10 +44,12 @@ class FakeHerdrHarness:
         with open(self.state_path, encoding="utf-8") as f:
             return json.load(f)
 
-    def set_pane(self, pane_id, status, text, name=None, fail_get=False, fail_get_after=None):
+    def set_pane(self, pane_id, status, text, name=None, fail_get=False,
+                 fail_get_after=None, null_pane_get=False):
         state = self.read_state()
         state["panes"][pane_id] = {
             "agent_status": status, "text": text, "name": name, "fail_get": fail_get,
+            "null_pane_get": null_pane_get,
         }
         if fail_get_after is not None:
             # pane get succeeds fail_get_after times, then fails every call after.
@@ -342,6 +344,29 @@ class WaitForIdleMarkerSemanticsTests(unittest.TestCase):
         cp = self.h.run_waiter(
             "p1", "--ready", "--interval", "0.1", "--quiet-cycles", "2", "--timeout", "3"
         )
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_null_pane_get_is_unverifiable_not_crash(self):
+        """Regression (round 12 note): a valid-JSON 0-exit `pane get` with a
+        null `pane` ({"result":{"pane":null}}) must be treated as unverifiable
+        (rc 1 under --ready), NOT raise AttributeError from `None.get(...)`.
+        A traceback on stderr and a crash exit code is the buggy behavior."""
+        self.h.set_pane("p1", "idle", "boot\n", name="nullpane", null_pane_get=True)
+        cp = self.h.run_waiter("p1", "--ready", "--timeout", "2")
+        self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+        self.assertNotIn("Traceback", cp.stderr)
+        self.assertNotIn("AttributeError", cp.stderr)
+
+    def test_resolve_pane_null_pane_does_not_crash(self):
+        """Regression (round 12): a `w..:..` pane id whose `herdr pane get`
+        returns {"result":{"pane":null}} must NOT crash resolve_pane with an
+        uncaught TypeError (None["pane_id"]). It falls through to `agent get`,
+        resolves, and the subsequent null-pane status read is unverifiable
+        (rc 1 under --ready) — never a traceback."""
+        self.h.set_pane("w1:p1", "idle", "boot\n", name="nullres", null_pane_get=True)
+        cp = self.h.run_waiter("w1:p1", "--ready", "--timeout", "2")
+        self.assertNotIn("Traceback", cp.stderr, msg=f"stderr={cp.stderr!r}")
+        self.assertNotIn("TypeError", cp.stderr)
         self.assertEqual(cp.returncode, 1, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
 
     def test_empty_string_status_is_unverifiable(self):

--- a/skills/herdr-agent-comms/tests/test_wait_for_idle.py
+++ b/skills/herdr-agent-comms/tests/test_wait_for_idle.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Behavioral tests for wait_for_idle.py against a fake `herdr` CLI.
+
+Covers the P1.1/P2.7 false-completion fix: a pane already `working` (or
+already carrying the completion marker) before this send must not be
+reported as settled for THIS send.
+
+Run directly (stdlib unittest only):
+    python3 -m unittest discover -s skills/herdr-agent-comms/tests -p 'test_*.py'
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE.parent / "scripts"
+FAKE_BIN = HERE / "bin"
+WAITER = SCRIPTS / "wait_for_idle.py"
+
+
+class FakeHerdrHarness:
+    def __init__(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="hac_test_")
+        self.state_path = os.path.join(self.tmpdir, "state.json")
+        self.write_state({"panes": {}})
+        self.env = dict(os.environ)
+        self.env["FAKE_HERDR_STATE"] = self.state_path
+        self.env["PATH"] = f"{FAKE_BIN}{os.pathsep}{self.env.get('PATH', '')}"
+
+    def write_state(self, state):
+        with open(self.state_path, "w", encoding="utf-8") as f:
+            json.dump(state, f)
+
+    def read_state(self):
+        with open(self.state_path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def set_pane(self, pane_id, status, text, name=None):
+        state = self.read_state()
+        state["panes"][pane_id] = {"agent_status": status, "text": text, "name": name}
+        self.write_state(state)
+
+    def set_status(self, pane_id, status):
+        state = self.read_state()
+        state["panes"][pane_id]["agent_status"] = status
+        self.write_state(state)
+
+    def append_text(self, pane_id, text):
+        state = self.read_state()
+        state["panes"][pane_id]["text"] += text
+        self.write_state(state)
+
+    def baseline_file(self, text):
+        p = os.path.join(self.tmpdir, f"baseline_{time.time_ns()}.txt")
+        with open(p, "w", encoding="utf-8") as f:
+            f.write(text)
+        return p
+
+    def run_waiter(self, pane_id, *extra_args, timeout=5):
+        cmd = [sys.executable, str(WAITER), pane_id, "--timeout", str(timeout)]
+        cmd.extend(extra_args)
+        return subprocess.run(cmd, env=self.env, text=True, capture_output=True, timeout=timeout + 10)
+
+
+class WaitForIdleMarkerSemanticsTests(unittest.TestCase):
+    def setUp(self):
+        self.h = FakeHerdrHarness()
+
+    def test_stale_marker_in_baseline_is_not_success(self):
+        """P2.7: a marker already present in the pre-send baseline (leftover
+        from a previous task) must not be accepted as proof THIS send
+        finished — the pane should time out waiting for a *fresh* marker.
+        """
+        marker = "HERDR_DONE_stale123"
+        pane_text = f"previous task output\n{marker}\n"
+        self.h.set_pane("p1", "idle", pane_text)
+        baseline = self.h.baseline_file(pane_text)  # baseline == current text (marker included)
+
+        cp = self.h.run_waiter(
+            "p1", "--baseline-file", baseline, "--completion-marker", marker, "--timeout", "1"
+        )
+        self.assertEqual(cp.returncode, 2, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_prior_working_pane_does_not_falsely_complete_this_send(self):
+        """P1.1: pane is ALREADY working (prior task in flight) when the
+        waiter starts. Baseline was captured while working. No fresh marker
+        ever appears. The waiter must NOT report success — it must time out,
+        not short-circuit on a stale `saw_working` transition.
+        """
+        prior_text = "prior task still running...\n"
+        self.h.set_pane("p1", "working", prior_text)
+        baseline = self.h.baseline_file(prior_text)
+        marker = "HERDR_DONE_thissend456"
+
+        # Pane flips to idle shortly after (prior task finishes) but the
+        # fresh marker for THIS send never shows up.
+        def flip():
+            time.sleep(0.3)
+            self.h.set_status("p1", "idle")
+
+        t = threading.Thread(target=flip)
+        t.start()
+        cp = self.h.run_waiter(
+            "p1", "--baseline-file", baseline, "--completion-marker", marker, "--timeout", "1"
+        )
+        t.join()
+        self.assertEqual(cp.returncode, 2, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+    def test_fresh_marker_after_working_is_success(self):
+        """Sanity/control: once the fresh marker actually appears after a
+        real working transition, the waiter must succeed (rc 0)."""
+        baseline_text = "before send\n"
+        self.h.set_pane("p1", "idle", baseline_text)
+        baseline = self.h.baseline_file(baseline_text)
+        marker = "HERDR_DONE_real789"
+
+        def do_work():
+            time.sleep(0.1)
+            self.h.set_status("p1", "working")
+            time.sleep(0.2)
+            self.h.append_text("p1", f"reply text {marker}\n")
+            self.h.set_status("p1", "idle")
+
+        t = threading.Thread(target=do_work)
+        t.start()
+        cp = self.h.run_waiter(
+            "p1", "--baseline-file", baseline, "--completion-marker", marker, "--timeout", "5"
+        )
+        t.join()
+        self.assertEqual(cp.returncode, 0, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+        self.assertIn(marker, cp.stdout)
+
+    def test_blocked_status_returns_3(self):
+        self.h.set_pane("p1", "blocked", "trust dialog\n")
+        baseline = self.h.baseline_file("trust dialog\n")
+        cp = self.h.run_waiter("p1", "--baseline-file", baseline, "--timeout", "1")
+        self.assertEqual(cp.returncode, 3)
+
+    def test_ready_accepts_already_idle_without_working(self):
+        self.h.set_pane("p1", "idle", "already done earlier\n")
+        cp = self.h.run_waiter("p1", "--ready", "--timeout", "1")
+        self.assertEqual(cp.returncode, 0)
+
+    def test_no_marker_legacy_fallback_uses_saw_working(self):
+        """Without a completion marker arranged, a genuine working->idle
+        transition for THIS send is still accepted (legacy behavior)."""
+        baseline_text = "before\n"
+        self.h.set_pane("p1", "idle", baseline_text)
+        baseline = self.h.baseline_file(baseline_text)
+
+        def do_work():
+            time.sleep(0.1)
+            self.h.set_status("p1", "working")
+            time.sleep(0.2)
+            self.h.append_text("p1", "reply without marker\n")
+            self.h.set_status("p1", "idle")
+
+        t = threading.Thread(target=do_work)
+        t.start()
+        cp = self.h.run_waiter("p1", "--baseline-file", baseline, "--timeout", "5")
+        t.join()
+        self.assertEqual(cp.returncode, 0, msg=f"stdout={cp.stdout!r} stderr={cp.stderr!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #79

## Summary

Updates `herdr-agent-comms` to **v1.21.0** (was v1.2.0 when this PR opened; several review rounds landed additional fixes — see Decision Record).

### Default layout
- **Root agent pane stays** (`$HERDR_PANE_ID`)
- Each **sub-agent** is created by splitting the current **rightmost column** `right`
  (`--ratio 1/N` — `R` is the existing/left child's share, so the new right pane gets
  `(N-1)/N` of the split column = the `1/N` equal target of the tab), then running an
  **iterative equalizer** that re-converges every column (root included) to equal width —
  **all panes end up the same width (±1 terminal cell)**, not a largest-pane/aspect-ratio
  balanced grid. Equalization is a **hard gate**: on a resize failure or non-convergence the
  spawn aborts rather than launch a worker into an uneven layout.
- **One tab** shows root + all sub-agent panes together

### Not default anymore
- Creating a separate `fleet` tab and putting workers there
- One tab per sub-agent (still opt-in when user asks)

### Also
- Teardown prefers closing **sub-panes only** (keep root)
- Docs, recipes, and evals updated to match
- Broadcast preflight rejects both `working` and `blocked` panes (not just `working`)
- Helper path resolution (`next_grid_split.py` / `wait_for_idle.py`) now checks project-local
  and repo-local paths before global installs, and fails fast instead of continuing silently
  when nothing resolves
- `scripts/broadcast.sh` no longer abandons already-dispatched panes when a later pane's send
  fails mid fan-out — it still waits on and reports the panes it did reach, with a clear
  partial-results message for the ones it didn't
- Manual broadcast recipe in `references/herdr-recipes.md` now matches `scripts/broadcast.sh`'s
  dedupe + busy/blocked preflight instead of bypassing it
- **Grid layout reworked to equal-width columns, now on verified Herdr semantics.**
  `next_grid_split.py` no longer picks the largest pane by area and alternates `right`/`down` by
  aspect ("vertical panel first"). It targets the current rightmost column for the split
  (`--ratio 1/N`) and exposes `--equalize`, a live iterative boundary equalizer that
  re-converges every column to equal width. The `herdr pane split`/`pane resize` semantics were
  **verified live against herdr 0.7.4** this round — see the follow-up Decision Record.
  `SKILL.md`, `references/herdr-recipes.md`, `docs/README.md`, and `evals/evals.json` updated to
  match; the old largest-pane/`plan_equal_width_split` tests in `tests/test_next_grid_split.py`
  are replaced (not extended) with tests for the verified split-ratio + equalizer arithmetic.

## Test plan
- [x] `quick_validate.py` clean
- [x] `python3 -m py_compile` on all scripts/tests clean
- [x] `bash -n` on `scripts/broadcast.sh` and `tests/bin/herdr` clean
- [x] `python3 -m unittest discover -s skills/herdr-agent-comms/tests -p 'test_*.py'` — 118/118 pass (was 65/65 through round 9; rounds 10–17 added fail-open/enum, preflight-staleness, recovery-masking, pre-task-idle-gating, self-contained-delivery-patterns, mutually-exclusive-waiters, malformed-JSON/null-pane, preflight-before-mutation, executable-path-resolvers, strict-pane-id-validation, resolved-agent-name-pinning, strict-column-geometry, non-finite-geometry, and full-live-layout-revalidation regressions)
      (fake-`herdr` harness; covers dedupe, busy/blocked/**unverifiable-status** rejection,
      partial-send-failure handling, split-ratio (=1/N) + equalizer arithmetic,
      equalizer-contraction convergence, working->done completion, pane-disappearance →
      error (not false completion), requested-root-membership enforcement, single-row
      layout validation, --ready fail-closed on status lookup failure **at every lookup, not
      just the initial probe (valid-status-then-failure)**, and wait/marker semantics)
- [x] Live `herdr pane split $HERDR_PANE_ID` returns `result.pane.pane_id` on same tab
- [x] Live `herdr` 0.7.4 verification of `pane split --ratio` / `pane resize --amount` semantics
      in a throwaway tab (closed after) — see follow-up Decision Record
- [x] Manual: spawned 2–5 columns from a root pane via `next_grid_split.py` split + `--equalize`
      and confirmed near-equal widths via `herdr pane layout` — 2→105/105, 3→70/70/70,
      4→53/53/52/52, 5→42×5 (equal within ≤1 cell)

## Decision Record

**Root cause:** The initial implementation (v1.2.0) only rejected `working` panes in the
broadcast preflight, leaving `blocked` panes (trust/auth dialogs) sendable — a broadcast could
type a task straight into a permission dialog. Helper path resolution probed global install
locations before repo-local ones and degraded silently (echo + continue) instead of failing
when no location resolved. A failed `pane run` partway through fan-out aborted the whole
broadcast via `exit 1`, discarding results for panes already dispatched. The manual broadcast
recipe in `references/herdr-recipes.md` didn't mirror `scripts/broadcast.sh`'s dedupe or
busy/blocked preflight, so following the documented manual fallback reintroduced both bugs.

**Options considered:**
1. Leave `blocked` handling to the caller (rely on `wait_for_idle.py`'s post-send blocked
   detection) — rejected: detection after send is too late, the dialog has already been typed
   into.
2. Merge `blocked` into the existing `busy` rejection message/branch — rejected: collapses two
   distinct causes (unrelated prior work vs. a dialog needing a human) into one message and
   risks breaking the existing `"already working"` stderr assertion in
   `test_already_working_pane_is_rejected_not_sent`.
3. Add a separate `blocked` rejection branch with its own message, and a paired unit test —
   selected.
4. For path resolution: silently continue with `$here` empty when unresolved (matches prior
   behavior) — rejected: violates the fail-fast requirement and produces a confusing
   `python3 "": No such file or directory` further down instead of a clear error.
5. For partial-send-failure: keep `exit 1` on first `pane run` failure (current behavior) —
   rejected: silently abandons panes already mid-task with no report of their outcome.

**Selected option:** Add a distinct `blocked` rejection branch in `scripts/broadcast.sh` (Phase
1b) with its own message, matching Critical Rule 7 in `SKILL.md`. Reorder all 5 path-probe
blocks (`SKILL.md` ×3, `references/herdr-recipes.md` ×2, plus the `delivery-and-waiting.md`
comment) to check `skills/herdr-agent-comms/scripts` and
`.agents/skills/herdr-agent-comms/scripts` before the `$HOME`-rooted global locations, and
replace the silent-continue with `exit 1` + a clear message on total resolution failure.
Rework `scripts/broadcast.sh` Phase 3/4/5 to track per-pane send failures separately from the
busy/blocked preflight rejections, skip waiting only on panes that were never successfully
dispatched, and report a `Partial results: N of M target(s) never received the message` summary
on stderr. Rewrite the manual broadcast recipe to inline the same dedupe and busy/blocked
preflight as the script.

**Options rejected:** See above (2, 4, 5).

**Residual risk:** The broadcast preflight paths (dedupe, busy/blocked/unverifiable rejection,
partial-send-failure) are verified against the `fake_herdr.py` test harness. The equal-width
grid behavior it drives WAS later verified end-to-end against a live herdr 0.7.4 (see the
follow-up Decision Record and the checked "Manual: spawn 2–5 columns" item in the test plan) —
so that item is no longer an open risk. The bash delivery/broadcast snippets in the docs are
verified by `bash -n` + review, not a unit test (bash-in-docs isn't unit-testable).

### Follow-up: equal-width column grid (requested mid-fix-pass, same PR)

**Root cause:** The original grid heuristic (largest pane by area, direction alternating
`right`/`down` by aspect ratio) optimized for a visually balanced 2D tile layout but explicitly
did **not** guarantee equal widths — a request came in mid-fix-pass to make every pane
(root included) the same width, resizing existing panes as needed when a new one is added.

**Options considered:**
1. Layer a width-equalization pass on top of the existing largest-pane/aspect heuristic —
   rejected: the two goals conflict (largest-pane targeting produces a 2D grid; equal-width
   columns is inherently a 1D row), so "layering" would mean the aspect logic never actually
   runs.
2. Equal-width **columns**, one row, resizing existing columns to `1/N` on each add — selected.
3. Equal-width enforced only within a row of a still-2D grid (e.g. 2×2 stays balanced but each
   *row* is forced equal-width) — rejected as unnecessarily complex for the request as stated,
   and ambiguous about row/column count once N isn't a perfect square.

**Selected option:** Option 2, now built on **live-verified Herdr semantics** (a later review
round, R3, flagged that the earlier draft treated `--ratio`/`--amount` as absolute widths).
Verified against a running herdr 0.7.4 in a throwaway tab (`herdr` has no `--help`, so behavior
was probed by reading `herdr pane layout` before/after each op, and the probe tab was closed):
- `pane split <p> --direction right --ratio R` sizes only `p` — `R` is the existing/left child's
  fraction; the new pane gets `1 - R`. A single split therefore cannot equalize `N >= 3` columns.
- `pane resize --pane P --direction D --amount A` is a **delta** — `A` is a fraction of the tab
  area width (`A * area_width` cells), redistributed proportionally among the panes on the far
  side of the moved boundary; `--direction D` grows a pane toward its neighbor on side `D`.
- One left-to-right resize sweep perturbs downstream columns, but the sweep is a **contraction**
  and iterating converges (observed 4-column decay: spread 25→13→5→3→1).

`next_grid_split.py` was rewritten accordingly: `plan_next_split()` emits the split line with
`--ratio 1/N` (see the round-4 note below — an earlier draft of this body said `(N-1)/N`, which
was inverted), and `--equalize` drives the iterative boundary equalizer live — sweep internal
boundaries left to right, grow the neighbor-bearing pane toward each equal target, re-read the
layout after each resize, repeat until the width spread is ≤1 cell (cap 12 passes). This
replaces the "largest pane + `down`-first" model *and* the earlier false absolute-width
`plan_equal_width_split()` draft.

### Round 4 review fixes (three findings)

1. **HIGH — equalization failures were suppressed.** `--equalize` ignored `herdr pane resize`
   returncodes and reported non-convergence only as a "best-effort" warning; the spawn recipes
   wrapped it in `|| true`. Now `--equalize` raises (exit 1) on any resize failure AND on
   non-convergence within the pass cap, with an actionable message (pane/direction/amount or
   final widths). Every spawn recipe drops `|| true` and hard-aborts **without launching a
   worker** into an uneven layout, naming the orphan split pane; `spawn_sub` returns non-zero
   (prints no pane id) so `$(...)` callers propagate the failure.
2. **MEDIUM — `wait_for_idle.py` could miss a `working -> done` settle.** The working branch
   waited for `done` for half a slice, then spent the *whole remaining deadline* waiting only
   for `idle`, so a pane that finished on `done` (never `idle`) returned timeout (code 2).
   Replaced with a single bounded `wait done` slice (≤1s) that always loops back to the
   top-of-loop re-read, where both terminal states are handled. Two regression tests added
   (`working -> done` with and without a completion marker); verified they fail on the old code
   and pass on the fix.
3. **MEDIUM — split-ratio claim was inverted.** `--ratio R` is the *existing/left* child's
   fraction, so `(N-1)/N` made the new pane the *small* child (verified live: 35 cells, not the
   70-cell equal target). Corrected to `--ratio 1/N` in `split_ratio()` (with a regression test
   asserting the new pane lands on `1/N` for N=2..7) and in every doc claim, including this body.

Re-verified live against herdr 0.7.4 with the corrected ratio: 2→105/105, 3→70/70/70,
4→53/53/52/52, 5→42×5 (all `--equalize` rc 0); a forced resize failure now aborts with rc 1.
(Round-4 unit count was 40/40; the suite has since grown to 60/60 — see round 5 & 6 below.)

**Options rejected:** See above (1, 3). Also rejected: claiming absolute-width `--ratio`/`--amount`
semantics (the R3 finding) — corrected to the verified delta/redistribution model above.

**Residual risk:** Low. The split + equalizer was verified end-to-end against live herdr 0.7.4
via the actual script (2→105/105, 3→70/70/70, 4→53/53/52/52, 5→42×5, each equal within ≤1 cell).
Because column widths are whole terminal cells, exact equality holds only when the tab width
divides evenly by the column count; otherwise columns differ by ≤1 cell — documented as such in
`SKILL.md` and `references/herdr-recipes.md` rather than overclaimed. The unit tests cover the
pure arithmetic (split ratio, equal targets, per-boundary resize op) plus an approximate float
model of herdr's proportional redistribution that demonstrates the sweep is a contraction; the
live run above is the semantics evidence, not the float model.

### Round 5 review fixes (three findings)

1. **HIGH — spawn recipes masked failures.** Guarded every critical step of the canonical
   `spawn_sub` and the SKILL.md Phase 2a block (planning, split, pane-id parse, equalize,
   rename, launch, readiness), printing the pane id ONLY after a confirmed launch; `local`
   declared separately from `$(...)` assignment; every caller aborts on non-zero. Removed the
   duplicate `spawn_sub` from SKILL.md (points at the recipes canonical copy).
2. **MEDIUM — failed pane reads became false completions.** `wait_for_idle.py`'s `pane_read`
   now returns `None` on a non-zero `herdr pane read`; baseline/terminal/content-stability
   reads propagate it as an error (rc 1) instead of letting error text stabilize into a
   spurious "done". Two regression tests (disappearance on both the content-stability and
   status paths).
3. **MEDIUM — non-column layouts misread as columns.** Added `validate_single_row()`
   (x/y/width/height: full-height, top-aligned, contiguous, fills the tab), called before any
   mutation in `equalize_live` and `main()`. 10 validation tests.

### Round 6 review fixes (five findings)

1. **MEDIUM — documented delivery paths masked failures.** SKILL.md, `delivery-and-waiting.md`,
   and `herdr-recipes.md` delivery/broadcast snippets no longer use `cmp -s … <(herdr pane
   read …)` (a failed read looked like activity). Reads are captured explicitly and their exit
   checked; sends and each concurrent waiter's exit status are retained (a bare `wait` + `rm`
   no longer returns success after a timeout/blocked). Verified by `bash -n` + review.
2. **MEDIUM — broadcast status preflight failed open.** `scripts/broadcast.sh` `pane_status`
   now returns non-zero on a failed/malformed `herdr pane get` (instead of an empty "safe"
   status); the preflight rejects such **unverifiable** targets. Valid `unknown` stays
   sendable. New tests: `fail_get` + malformed-JSON rejected and never sent.
3. **MEDIUM — canonical readiness masked blocked agents.** `spawn_sub` no longer waits on
   `agent-status idle` internally (which turned a `blocked` boot into a generic 60s timeout);
   readiness moved to a separate concurrent pass using `wait_for_idle.py --ready`, which
   returns 3 for `blocked` and surfaces it immediately.
4. **MEDIUM — missing requested root still permitted planning.** `next_grid_split.py` now hard-
   errors (via `require_root_membership`) when a named `--root-pane` isn't in the layout, in
   both `plan_next_split` and `equalize_live`, before any mutation. `root_pane is None` still
   plans normally. New tests (the round-3 "warns but still plans" test was flipped to expect
   the error).
5. **PR body reconciled** — version, test count, checkbox/residual-risk consistency (this
   update).

Round 5 & 6 all pass: 60/60 unit tests, `quick_validate`, `bash -n` (broadcast.sh, tests/bin,
all doc blocks), `py_compile`, SKILL.md ≤500. Findings that are bash-in-docs (R5 #1, R6 #1/#3)
are verified by `bash -n` + review, not unit tests; the rest have committed regression tests,
revert-checked (buggy → fail, fixed → pass).

### Round 7 review fixes (four findings + masking sweep)

1. **HIGH — SKILL.md workflow skipped readiness and masked failures.** The Phase 2c block and
   the Example now run a concurrent `wait_for_idle.py --ready` pass and **abort before assigning
   work** if any sub-agent isn't ready (blocked → rc 3, not a silent 60s idle timeout). Removed
   the false "spawn_sub guards readiness" claim; baseline reads and sends are guarded; the
   Example delegates baseline/send/wait to `broadcast.sh` and checks its exit.
2. **MEDIUM — canonical readiness pass didn't propagate.** `herdr-recipes.md` "Concurrent
   readiness pass" now sets an aggregate status and aborts after collecting every waiter, not
   just echoing failures.
3. **MEDIUM — mixed unverifiable broadcast exited 0.** `broadcast.sh` folds `unverifiable` into
   the final `overall` aggregation alongside busy/blocked/send_failed. New regression test:
   a mixed unverifiable+good broadcast still delivers to the good pane **and** exits non-zero;
   revert-checked (buggy omission → rc 0 → test fails).
4. **HIGH — manual broadcast preflight failed open.** The recipe's status read is now
   fail-closed (non-zero on lookup/parse failure; valid `unknown` still sendable), rejects
   unverifiable targets, and folds every skipped target into a non-zero exit.

**Sweep (beyond the four named sites, same commit):** fixed two more fail-open status pipelines
the findings didn't list — SKILL.md's single-pane poll and `delivery-and-waiting.md`'s manual
poll — and made `delivery-and-waiting.md` act on the helper's exit code. Confirmed via grep that
no `get("agent_status","")`, bare `wait`, or `<(herdr pane read` masking remains anywhere.

Round 7: 60/60 unit tests, `quick_validate`, `bash -n` on all 30 doc bash blocks + scripts,
`py_compile`, SKILL.md 499 lines. Version bumped to **v1.11.0**. Findings 1/2/4 + the sweep are
bash-in-docs (`bash -n` + review); #3 has a committed, revert-checked test.

### Round 8 review fixes (three findings)

1. **HIGH — readiness failed open when status lookup failed.** `wait_for_idle.py`'s
   `agent_status()` returned `None` for BOTH a failed/malformed `herdr pane get` AND a
   validly-absent status, so a `--ready` check on a `blocked` pane with a *persistent* lookup
   failure slipped through the content-stability fallback and returned ready rc 0. It now
   returns a distinct `LOOKUP_FAILED` sentinel vs. valid `"unknown"`; `--ready` treats
   `LOOKUP_FAILED` as an error (rc 1) while a genuine `"unknown"` (non-integrated CLI) still
   uses content-stability. 3 regression tests (fail_get+`--ready`, blocked+fail_get,
   valid-unknown-still-settles); revert-checked (buggy → false ready rc 0). This was the
   **Python sibling** of the round-6 broadcast.sh/`pane_read` fail-closed fix that the bash-only
   grep couldn't see.
2. **MEDIUM — unchanged output falsely reported as delivery activity.** The delivery-verify
   snippets compared `after="$(herdr pane read …)"` against the baseline FILE with `cmp` —
   `$(...)` strips trailing newlines the file keeps, so identical transcripts compared as
   "different" → false activity. Now read post-send into a second guarded file and `cmp`
   file-to-file (SKILL.md, `delivery-and-waiting.md`).
3. **MEDIUM — single-pane send/wait failures didn't propagate.** Guarded the primary `herdr
   pane run` send, and after the waiter, capture `rc` BEFORE cleanup and exit non-zero on
   rc 1/2/3 instead of letting `rm` (rc 0) mask it (SKILL.md, `delivery-and-waiting.md`). Swept
   two more single-send examples for the same guard.

Round 8: 63/63 unit tests, `quick_validate`, `bash -n` on all 30 doc bash blocks + scripts,
`py_compile`, SKILL.md 500 lines. Version **v1.12.0**. #1 has committed, revert-checked tests;
#2/#3 are bash-in-docs (`bash -n` + review).

### Round 9 review fix (last finding)

**HIGH — readiness failed open after the initial status probe.** Round 8's `LOOKUP_FAILED`
rejection under `--ready` was applied only at the *first* `agent_status()` call. A status that
was valid initially but degraded later still slipped through: a valid `unknown` enters the
content-stability loop, a *subsequent* `herdr pane get` fails, and the loop reported ready rc 0
(the reproduced repro). The status loop and the pre-task `blocked` re-check had the same hole.
Centralized the check in `_unverifiable(st, args)` (lookup failed AND `--ready` AND
prefer-status) and applied it after **every** `agent_status()` call — initial probe, status
loop, content-stability loop, and pre-task blocked re-check — so any lookup failure during a
`--ready` wait fails closed (rc 1). Non-ready waits, `--no-prefer-status`, and a valid `unknown`
are unchanged (a valid unknown still uses content-stability and can settle ready).

Added counter-based fault injection to `fake_herdr` (`fail_get_after: N` — succeed N calls, then
fail every one) for a **race-free** "valid status, THEN lookup failure", and two regression
tests (unknown→lookup-failure and working→lookup-failure under `--ready` both return rc 1).
Revert-checked: removing the loop guards makes both report false-ready rc 0 while the
valid-unknown-still-settles test stays green (fix doesn't over-reach).

Round 9: 65/65 unit tests, `quick_validate`, `bash -n`, `py_compile`, SKILL.md unchanged (500
lines). Version **v1.13.0**. Committed, revert-checked regression tests.

### Round 10 review fixes (two findings)

1. **HIGH — malformed status still failed open.** Every status parser accepted any truthy
   `agent_status`, so a numeric `123` (or garbage/empty string) sailed past the working/blocked
   checks and read as sendable/settled. Now the documented enum
   `{idle,working,blocked,done,unknown}` is the only accepted set: absent/null → `unknown`,
   in-enum → itself, anything else → unverifiable (`LOOKUP_FAILED` in `wait_for_idle.py`,
   non-zero exit in the bash/inline parsers). Fixed in all six parser sites.
2. **HIGH — single-target sends lacked a blocked-status preflight.** The canonical single-target
   path sent (and did NOT-DELIVERED recovery Enter) with no status check, so a task could be
   typed into a blocked trust dialog and still report success. Added a shared, fail-closed
   `scripts/preflight_send.py` (the single-target twin of broadcast.sh Phase 1b; distinct exit
   codes 0/2/3/4) called immediately before delivery and before the recovery Enter.

Round 10: version **v1.14.0**; new off-enum + preflight regression tests.

### Round 11 review fixes (three findings)

1. **HIGH — follow-up sends bypassed the new preflight.** Phase 6's steer/follow-up `pane run`
   sent directly; now preflighted.
2. **HIGH — recovery Enter failures stayed masked.** The NOT-DELIVERED recovery sent the Enter
   unguarded and swallowed a failed re-wait via `|| echo NOT-DELIVERED` (exit 0). Now the
   keystroke is guarded and the re-wait for `working` propagates a non-zero exit (SKILL.md,
   delivery-and-waiting.md, herdr-recipes.md troubleshooting).
3. **MEDIUM — broadcast preflight went stale before dispatch.** `broadcast.sh` re-checks each
   target's enum-validated status immediately before its `pane run`; targets that turned
   working/blocked/unverifiable go in a `became_unsafe` bucket, are excluded from the wait loop,
   and fold into the non-zero exit. New counter-based status-flip test harness + regressions.

Round 11: version **v1.15.0**.

### Round 12 review fixes (three findings + two notes)

1. **HIGH — follow-up workflow reused deleted/stale completion state.** Phase 6 said to send a
   follow-up then "run Phase 5 again" without a fresh baseline (Phase 5 deleted it) or marker
   (the stale joined marker is already in the transcript). Phase 6 now routes follow-ups through
   the whole Phase 4→5 workflow with a fresh baseline + fresh marker per message.
2. **MEDIUM — manual completion fallback reported failure as success.** The
   `delivery-and-waiting.md` poll loop broke on `blocked` and let deadline exhaustion fall
   through, both exiting 0. Now `blocked` exits 3, timeout exits 2, only idle/done exits 0.
3. **MEDIUM — documented preflights went stale before sending.** The single-target Phase 4
   preflight and the manual-broadcast recipe checked status before baseline/task prep. Both now
   recheck immediately before each `pane run`, matching broadcast.sh.
   Notes fixed: `wait_for_idle.py` `agent_status()` and `resolve_pane()` no longer raise on a
   valid-JSON null `pane` (`{"result":{"pane":null}}`) — treated as unverifiable/fall-through,
   not a crash; this PR-body version/test-count reconciled.

Round 12: 83/83 unit tests, `quick_validate`, `bash -n` on changed doc blocks + scripts,
SKILL.md 490 lines. Version **v1.16.0**. Committed, revert-checked regressions; bash-in-docs
findings verified by `bash -n` + review.

### Round 13 review fixes (three findings + one note)

1. **HIGH — reference delivery preflights remained stale.** `delivery-and-waiting.md`'s
   single-target path preflighted before baseline + task prep then sent without rechecking, and
   its illustrative fleet loops dispatched with no pre-dispatch recheck. The single-target
   preflight moved to immediately before `pane run`; both fleet loops now recheck each target's
   enum-validated status right before its dispatch (skipping working/blocked/unverifiable into a
   `became_unsafe`/`unsafe` bucket, excluded from the wait set and folded into the non-zero exit)
   — matching `scripts/broadcast.sh`.
2. **MEDIUM — manual broadcast waited on failed sends.** `herdr-recipes.md` recorded
   send failures by pane ID while the wait-loop exclusion checked only `became_unsafe` indices,
   so a failed dispatch still got a completion waiter. `send_failed` is now index-keyed, the
   exclusion checks both index arrays, and the report maps indices back to pane ids.
3. **MEDIUM — manual completion fallback accepted pre-task idle.** The helper-free poll in
   `delivery-and-waiting.md` accepted the first idle/done it saw (a false completion for a pane
   idle before the task landed). It now gates acceptance on having first observed `working` (or a
   fresh completion marker absent from the baseline); the preferred path already delegates to
   `wait_for_idle.py`. The raw-waits fleet variant got the same `saw_working` gate.
   Note: `broadcast.sh` `pane_status` no longer emits an AttributeError traceback for a
   valid-JSON null/non-object `result.pane` — it detects a non-dict pane and exits cleanly as
   unverifiable. Regression test added.

Round 13: 84/84 unit tests, `quick_validate`, `bash -n` on all changed doc blocks + scripts,
SKILL.md 490 lines. Version **v1.17.0**. #2/null-pane note have committed tests; the bash-in-docs
findings (#1, #3) are verified by `bash -n` + review.

### Round 14 review fixes (two findings + one already-addressed + one note)

1. **Already addressed (round 13) — reference single-target preflight.** The finding described
   pre-round-13 code; the pushed SHA (f877589) already has the single-target preflight
   immediately before `pane run` (nothing mutating status between), the recovery Enter
   adjacently preflighted, and the fleet loops rechecking before each dispatch. Verified by
   `git show` of the pushed file + a full send-site grep. No change.
2. **HIGH — multi-line delivery patterns were not self-contained.** `herdr-recipes.md`
   Patterns A–C relied on preflight prose above them, and B/C submitted a bare Enter even if
   `send-text`/`agent send` failed. Each pattern is now self-contained: it guards every
   text-delivery step (a failed send can't fall through to Enter) and runs `preflight_send.py`
   immediately before the guarded submission/Enter.
3. **MEDIUM — preferred waiter and fallback ran sequentially.** In `delivery-and-waiting.md` the
   preferred `wait_for_idle.py` path deleted `$baseline` then fell through into the helper-free
   poll (which still greps that file); on preferred-path failure its case exited, making the
   fallback dead code. The two are now mutually exclusive ("pick exactly one / run this
   INSTEAD"), each self-contained; the helper-free path defers its single `rm -f "$baseline"` to
   after the loop and propagates rc, so the baseline survives until the chosen path finishes.
   Note: `next_grid_split.py` no longer emits an uncaught AttributeError for malformed JSON —
   `_unwrap_layout` rejects a non-dict top level (`null`), `panes_from_layout` rejects non-object
   pane elements (`panes: [null]`), and `_ordered_columns` guards direct callers. Clean
   SystemExit validation errors; 6 regression tests.

Round 14: 90/90 unit tests, `quick_validate`, `bash -n` on all changed doc blocks + scripts,
SKILL.md 490 lines. Version **v1.18.0**. The note has committed tests; the bash-in-docs findings
(#2, #3) are verified by `bash -n` + review.

### Round 15 review fixes (three findings)

1. **HIGH — Patterns B/C preflighted after mutating the pane.** `send-text` / `agent send`
   injected text into the pane BEFORE the first preflight, so a working/blocked pane was altered
   before any check. B/C now preflight before the first mutation, guard the text-delivery step
   (a failure can't fall through to the Enter), then preflight AGAIN immediately before the
   guarded Enter (the pane may have flipped `blocked` in between). Pattern A keeps one preflight
   (a single atomic `pane run`).
2. **MEDIUM — "self-contained" reference snippets used undefined paths.** The delivery patterns
   referenced `$sd` only in prose, and the preferred waiter invoked `$here` whose resolver was
   entirely commented. Replaced with executable, fail-fast `$here` resolvers (repo-local first,
   then `.agents`/`.claude`/`$HOME`), standardized on the single `$here` variable — `$sd` is gone
   and every `$here` use is preceded by an executable assignment.
3. **MEDIUM — malformed pane IDs could target the wrong column.** `_ordered_columns` silently
   dropped panes with a missing/falsy id, so a malformed rightmost pane would vanish and the
   planner would split a DIFFERENT pane; `validate_single_row` accepted non-string/duplicate ids.
   Added `_validate_pane_ids` — a first pass over the full list (BEFORE any rect-based drop)
   requiring every pane_id to be a unique, non-empty string — called from both `_ordered_columns`
   and `validate_single_row`. 7 regression tests (null/non-string/empty/duplicate/missing-key id
   raise; valid unique ids still plan; missing-rect-with-valid-id still drops).

Round 15: 97/97 unit tests, `quick_validate`, `bash -n` on all changed doc blocks + scripts,
SKILL.md 490 lines. Version **v1.19.0**. #3 has committed tests; the bash-in-docs findings
(#1, #2) are verified by `bash -n` + review.

**Known residual (deferred, per the Structural note below):** the A/B/C section resolves `$here`
once at the section top rather than inside each pattern block, so copying a single pattern block
in isolation still needs that resolver run first. Tightening to a per-block resolver is the same
duplication the Structural note flags as the actual fix — deferred to the dedup pass, not
patched with yet more duplicated bash.

### Round 16 review fixes (two findings)

1. **HIGH — agent-name sends could validate and submit different panes.** The SKILL.md shorthand
   aside and herdr-recipes Pattern C delivered text to a bare agent name (`agent send reviewer`)
   while preflighting and Entering an independent `$pane_id` — a stale/mismatched id would mutate
   one pane and submit into another. Removed the SKILL.md aside (the finding's "or remove"
   option) and rewrote Pattern C to resolve the agent name to ONE pane id up front, then pin that
   exact id through both preflights, the `send-text` delivery, and the Enter.
2. **MEDIUM — live geometry re-reads could silently drop malformed panes.** `_ordered_columns`
   defaulted a missing `x` to 0 (misordering columns) and silently dropped panes with
   missing/malformed/non-positive width, so an equalize re-read could compute resize ops for a
   PARTIAL grid (a column omitted), scrambling the layout. It now HARD-errors on any pane lacking
   a rect object, missing/non-numeric x or width, or non-positive width; `equalize_live` also
   re-runs `validate_single_row` on every live re-read (per pass and per boundary), not just once
   up front. This is a genuine gap in the *tested script* code (not doc drift). Tests: flipped
   `test_panes_missing_rect_fields_are_dropped` → `test_pane_missing_rect_is_hard_error` (the
   silent drop is now the bug) + 8 geometry-strict regressions.

Round 16: 105/105 unit tests, `quick_validate`, `bash -n` on all changed doc blocks + scripts,
SKILL.md 489 lines. Version **v1.20.0**. #2 has committed tests; #1 is verified by `bash -n` +
review.

### Round 17 review fixes (two findings)

1. **MEDIUM — non-finite geometry was accepted.** `NaN`/`inf` pass `float()`, and NaN defeats
   every downstream comparison (`nan <= 0`, `nan > tol`, `abs(nan - x) > tol` are all False), so
   a NaN/inf width or coordinate would sail past the positive-width and single-row checks and
   drive a bogus resize. `json.loads` accepts NaN/Infinity by default, so this is reachable, not
   theoretical. Routed EVERY geometry parse (area x/y/width/height, pane x/y/width/height,
   ordering x/width, area-width) through one `_finite_float(value, label, positive=?)` helper
   requiring `math.isfinite()` and, for dimensions, strictly positive; coordinates may be
   0/negative but must be finite. In `area_width_from_layout` the finite check precedes the
   `<= 0` fallback so a present NaN is a hard error, not a poisoned return. (Area width is
   positive-enforced on every real path via `validate_single_row`'s `positive=True` check before
   `area_width_from_layout` runs; that function's non-positive branch is the intentional
   absent-area summed-pane fallback, so it stays non-strict by design.)
2. **MEDIUM — the final equalizer reread bypassed full validation.** The post-pass-cap
   convergence reread ran only `_ordered_columns`, so a final stacked/gapped layout with
   coincidentally-equal widths returned success; rereads also never reconfirmed root membership.
   Centralized full live-layout validation in `validate_live_layout` (single-row shape + finite
   geometry + root membership) and applied it to EVERY reread — initial, each pass, each
   boundary, the final convergence check, and main's split path.

Round 17: 118/118 unit tests, `quick_validate`, `bash -n` on all changed doc blocks + scripts,
SKILL.md 489 lines. Version **v1.21.0**. Both findings were in *tested script code* and have
committed regression tests (NaN/inf on width/x, NaN area width/coord, inf pane height;
`validate_live_layout` raises on stacked/gapped-equal-width and root-absent, passes on clean
row). This round **centralized** validation (`validate_live_layout`) and **unified** geometry
parsing (`_finite_float`) — net-negative on duplication, the structural direction the note below
calls for.

### Structural note (recommended follow-up, not this PR)

Nine review rounds have repeatedly surfaced the **same fail-open / failure-masking defect
class** (unguarded reads/sends, statuses that conflate lookup-failure with a valid value, waiter
codes discarded by cleanup). The root cause is that the delivery/status/wait logic is
hand-duplicated across `scripts/wait_for_idle.py`, `scripts/broadcast.sh`, and three docs, so
each copy harbors the class independently and point-fixes don't converge (round 8 #1 was the
untested Python twin of a round-6 bash fix; round 8 #2 regressed from a round-6 change; round 9
was the *same* Python fail-open surviving one guard-placement deeper than round 8 patched).
Ending this needs a **dedup pass as its own change**: treat the scripts as the tested canonical,
have
the docs reference them and keep at most a *minimal* fallback stating invariants (guard every
step; fail-closed status; propagate every waiter rc) rather than a full re-inlined implementation
that can drift. Deliberately kept out of this commit — a large refactor at the buzzer is itself
how masking regressions have slipped in.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|---|---|---|
| 1 | Broadcast preflight rejects `blocked` panes, not just `working` | ✅ Done | `scripts/broadcast.sh` Phase 1b now has a distinct `blocked` branch; `tests/test_broadcast.py::test_blocked_pane_is_rejected_not_sent`, `::test_all_blocked_exits_error_with_nothing_sent` |
| 2 | Helper path resolution checks project-local/repo paths, prefers repo copy over global, fails fast if unresolved | ✅ Done | All 6 probe blocks (`SKILL.md` ×3, `references/herdr-recipes.md` ×2, `references/delivery-and-waiting.md` comment ×1) reordered repo-first and changed to `exit 1` on total miss |
| 3 | Traceability gate: no invented issue numbers; real linked issue with `Closes #N`; PR body carries Decision Record + Acceptance Criteria Verification | ✅ Done | `Closes #79` at top of body (issue [#79](https://github.com/luongnv89/skills/issues/79) opened for this feature — not a fabricated number); Decision Record + this section |
| 4 | Partial send failures don't abandon already-dispatched panes | ✅ Done | `scripts/broadcast.sh` Phase 3 records per-pane send failures and continues; Phase 4 waits only on successfully-dispatched panes; Phase 5 reports a `SEND-FAILED` block + partial-results summary; `tests/test_broadcast.py::BroadcastPartialFailureTests` (2 tests) |
| 5 | Manual broadcast recipe matches `scripts/broadcast.sh` safeguards (dedupe + busy/blocked preflight) | ✅ Done | `references/herdr-recipes.md` "Broadcast pattern (manual)" section rewritten to inline dedupe-by-pane-id and the busy/blocked preflight |
| 6 | All panes in the grid (root + every sub-agent) end up the same width, resizing existing panes as needed | ✅ Done (runtime-verified) | `scripts/next_grid_split.py` rewritten around `plan_next_split()` + live `--equalize`; verified end-to-end against **live herdr 0.7.4** — 2→105/105, 3→70/70/70, 4→53/53/52/52, 5→42×5 (≤1-cell spread). `SKILL.md` Phase 2a, `references/herdr-recipes.md` ("Equal-width columns — verified semantics"), `docs/README.md`, `evals/evals.json` updated to match; `tests/test_next_grid_split.py` rewritten (verified-semantics arithmetic + equalizer-contraction test) |

Acceptance criteria for the tracked issue #79 are listed in that issue; the split + equalizer,
live verification, doc/test consistency, ≤500-line SKILL.md, and version bump are all satisfied
above.

## Traceability

This PR now closes a **real** GitHub issue: [#79](https://github.com/luongnv89/skills/issues/79)
("herdr-agent-comms: equal-width column grid (root + sub-agents in one tab)"), opened for this
feature and referenced via `Closes #79` at the top of this body. This PR is a `feat`, so the
`refactor`/`chore` traceability exemption (per
[#21](https://github.com/luongnv89/skills/issues/21)) does not apply and was **not** used — a
`Type: chore` line would misrepresent the change. No issue number was fabricated at any point.














