### PR TITLE
chore(skills): improve catalog quality and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ npx skills add https://github.com/luongnv89/skills --skill <name>
 
 | Skill | Version | Effort | What it does |
 |---|---|---|---|
-| [**code-review**](skills/code-review/) | 2.0.1 | high | Review or improve code — 4 modes: bugs/security, performance, clean-code audit, slop cleanup |
+| [**code-review**](skills/code-review/) | 2.1.0 | high | Review or improve code — 4 modes: bugs/security, performance, clean-code audit, slop cleanup |
 | [**test-coverage**](skills/test-coverage/) | 1.3.0 | low | Target untested branches and edge cases |
-| [**dont-make-me-think**](skills/dont-make-me-think/) | 1.3.0 | medium | Usability review using Krug's principles |
+| [**dont-make-me-think**](skills/dont-make-me-think/) | 1.3.2 | medium | Usability review using Krug's principles |
 
 **`code-review` has four modes** — pick by intent or pass `mode:<name>`:
 
@@ -174,7 +174,7 @@ Adjacent skills: **test-coverage** (generate tests for untested branches) · **d
 | [**auto-push**](skills/auto-push/) | 1.0.3 | low | Commit message + stage + push with secret and size checks |
 | [**devops-pipeline**](skills/devops-pipeline/) | 2.0.3 | medium | Pre-commit + GitHub Actions quality gates |
 | [**security-setup**](skills/security-setup/) | 1.4.0 | high | Local pre-commit secret scans, dep checks, static analysis, gated CI |
-| [**fork-upstream-sync**](skills/fork-upstream-sync/) | 1.0.3 | medium | Sync a fork with upstream while keeping feature branches and open PRs mergeable |
+| [**fork-upstream-sync**](skills/fork-upstream-sync/) | 1.3.2 | medium | Sync a fork with upstream while keeping feature branches and open PRs mergeable |
 | [**release-manager**](skills/release-manager/) | 2.6.0 | max | Bump, changelog, tag, GitHub release, publish |
 
 ### Product Planning
@@ -186,27 +186,27 @@ Adjacent skills: **test-coverage** (generate tests for untested branches) · **d
 | [**brand-name-checker**](skills/brand-name-checker/) | 1.3.2 | max | Trademark, domain, social, registry conflicts |
 | [**prd-generator**](skills/prd-generator/) | 1.3.2 | max | Structured PRD from idea or validate notes |
 | [**tad-generator**](skills/tad-generator/) | 1.4.0 | max | Technical architecture document from PRD |
-| [**tasks-generator**](skills/tasks-generator/) | 1.3.0 | max | Sprint tasks and plan from PRD |
+| [**tasks-generator**](skills/tasks-generator/) | 1.3.1 | max | Sprint tasks and plan from PRD |
 
 ### Frontend & Design
 
 | Skill | Version | Effort | What it does |
 |---|---|---|---|
-| [**frontend-design**](skills/frontend-design/) | 1.2.3 | high | Production UIs with usability-first approach |
-| [**logo-designer**](skills/logo-designer/) | 1.2.2 | medium | 7 SVG logo variants from project context |
-| [**diagram-generator**](skills/diagram-generator/) | 1.0.0 | high | One entry point for diagrams — routes to draw.io XML or Excalidraw JSON |
-| [**website-cloner**](skills/website-cloner/) | 1.1.6 | high | 6-phase URL to improved Vite/React/Tailwind site |
+| [**frontend-design**](skills/frontend-design/) | 1.2.4 | high | Production UIs with usability-first approach |
+| [**logo-designer**](skills/logo-designer/) | 1.2.3 | medium | 7 SVG logo variants from project context |
+| [**diagram-generator**](skills/diagram-generator/) | 1.1.2 | high | One entry point for diagrams — routes to draw.io XML or Excalidraw JSON |
+| [**website-cloner**](skills/website-cloner/) | 1.2.1 | high | 6-phase URL to improved Vite/React/Tailwind site |
 
 **Website cloner phases** (install individually or as suite):
 
 | Phase | Version | What it does |
 |---|---|---|
-| website-analyzer | 1.0.2 | 6-dimension analysis → JSON |
-| website-clone-report | 1.0.2 | Stakeholder report from analysis |
-| website-improvement-prd | 1.1.1 | Improvement PRD |
-| website-implementation-plan | 1.1.0 | tasks.md from PRD |
-| website-builder | 1.0.2 | Build improved site |
-| website-clone-final-report | 1.0.1 | Before/after summary |
+| website-analyzer | 1.3.0 | 6-dimension analysis → JSON |
+| website-clone-report | 1.2.2 | Stakeholder report from analysis |
+| website-improvement-prd | 1.3.0 | Improvement PRD |
+| website-implementation-plan | 1.3.2 | tasks.md from PRD |
+| website-builder | 1.3.1 | Build improved site |
+| website-clone-final-report | 1.3.0 | Before/after summary |
 
 **Diagram generator engines** (install the umbrella or a single engine):
 
@@ -219,9 +219,9 @@ Adjacent skills: **test-coverage** (generate tests for untested branches) · **d
 
 | Skill | Version | Effort | What it does |
 |---|---|---|---|
-| [**doc-manager**](skills/doc-manager/) | 2.0.1 | medium | Generate/update docs to match code, cited to path:line, never invented |
-| [**landing-page-generator**](skills/landing-page-generator/) | 1.2.0 | high | Landing pages: marketing copy from a brief, or a README-to-landing rewrite |
-| [**seo-ai-optimizer**](skills/seo-ai-optimizer/) | 1.2.1 | high | Technical SEO + AI-bot directives |
+| [**doc-manager**](skills/doc-manager/) | 2.0.2 | medium | Generate/update docs to match code, cited to path:line, never invented |
+| [**landing-page-generator**](skills/landing-page-generator/) | 1.2.1 | high | Landing pages: marketing copy from a brief, or a README-to-landing rewrite |
+| [**seo-ai-optimizer**](skills/seo-ai-optimizer/) | 1.2.3 | high | Technical SEO + AI-bot directives |
 | [**oss-ready**](skills/oss-ready/) | 1.2.1 | low | Add OSS files and templates |
 | [**agent-config**](skills/agent-config/) | 1.3.1 | medium | CLAUDE.md + AGENTS.md per best practices |
 | [**subagent-creator**](skills/subagent-creator/) | 1.1.2 | high | Create, evaluate, improve Claude Code subagent files (.claude/agents/*.md) |
@@ -231,18 +231,18 @@ Adjacent skills: **test-coverage** (generate tests for untested branches) · **d
 | Skill | Version | Effort | What it does |
 |---|---|---|---|
 | [**aso-marketing**](skills/aso-marketing/) | 1.2.1 | max | App Store + Google Play keyword and metadata optimization |
-| [**appstore-review-checker**](skills/appstore-review-checker/) | 1.2.0 | high | Pre-submission audit vs Apple guidelines |
+| [**appstore-review-checker**](skills/appstore-review-checker/) | 1.2.1 | high | Pre-submission audit vs Apple guidelines |
 
 ### Tooling
 
 | Skill | Version | Effort | What it does |
 |---|---|---|---|
-| [**cli-builder**](skills/cli-builder/) | 1.0.4 | high | 5-step CLI tool builder with approval gates |
-| [**ollama-optimizer**](skills/ollama-optimizer/) | 1.1.0 | medium | Hardware-aware Ollama tuning |
-| [**install-script-generator**](skills/install-script-generator/) | 2.2.0 | high | Cross-platform install.sh with env detection |
+| [**cli-builder**](skills/cli-builder/) | 1.0.5 | high | 5-step CLI tool builder with approval gates |
+| [**ollama-optimizer**](skills/ollama-optimizer/) | 1.1.1 | medium | Hardware-aware Ollama tuning |
+| [**install-script-generator**](skills/install-script-generator/) | 2.2.1 | high | Cross-platform install.sh with env detection |
 | [**opencode-runner**](skills/opencode-runner/) | 1.4.1 | medium | Delegate work to opencode free cloud models |
-| [**herdr-agent-comms**](skills/herdr-agent-comms/) | 1.21.0 | medium | Manage Herdr agent fleets: tile panes, message/wait/read, steer |
-| [**tmux-agent-comms**](skills/tmux-agent-comms/) | 1.9.0 | medium | Spawn, message, read CLI agents in tmux |
+| [**herdr-agent-comms**](skills/herdr-agent-comms/) | 1.22.0 | medium | Manage Herdr agent fleets: tile panes, message/wait/read, steer |
+| [**tmux-agent-comms**](skills/tmux-agent-comms/) | 2.1.0 | medium | Spawn, message, read CLI agents in tmux |
 
 ---
 

--- a/skills/appstore-review-checker/SKILL.md
+++ b/skills/appstore-review-checker/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: appstore-review-checker
-description: "Audit iOS/macOS app projects against Apple App Store Review Guidelines to catch rejection risks before submission, with per-guideline PASS/FAIL/WARNING verdicts and fix suggestions. Don't use for Google Play/Android submissions, general code review, or post-rejection appeal drafting."
+description: "Audit iOS/macOS apps against App Store Review Guidelines before submission, with evidence-backed verdicts and fixes. Don't use for Google Play, general code review, or rejection appeals."
 license: MIT
 effort: high
 metadata:
-  version: 1.2.0
+  version: 1.2.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/cli-builder/SKILL.md
+++ b/skills/cli-builder/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: cli-builder
-description: "Build a production-quality CLI tool for any module or application. Auto-detects language, recommends CLI libraries, and follows a 5-step approval-gated workflow: Analyze, Design, Plan, Execute, Summarize. Don't use for building GUI/TUI apps, web APIs, or authoring one-off shell scripts."
+description: "Build production-quality CLIs with language detection and a five-step approval-gated workflow. Use when wrapping an existing module or app. Don't use for GUI/TUI apps, web APIs, or one-off shell scripts."
 license: MIT
 effort: high
 metadata:
-  version: 1.0.4
+  version: 1.0.5
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -4,7 +4,7 @@ description: "Review or improve code — one skill, four modes: bug/security rev
 license: MIT
 effort: high
 metadata:
-  version: 2.0.1
+  version: 2.1.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
   architecture: "router (4 modes, each a self-contained workflow in references/)"
 ---
@@ -74,3 +74,58 @@ execute each mode's phases inline (less rigorous, but functional).
 Modes compose: a common flow is **clean** (audit → `CLEAN_CODE_AUDIT.md`) then **cleanup** (apply the
 refactors), or **review**/**perf** to find issues before fixing. Run one mode at a time; confirm with
 the user before switching into the code-writing `cleanup` mode.
+
+## Prerequisites
+
+- Require a readable target diff, PR, file set, or repository; ask for scope when none is provided.
+- Check that every reference and agent required by the selected mode is available before starting.
+- For `clean` or `cleanup`, validate repository state and follow that mode's sync, backup, dry-run,
+  confirmation, and rollback instructions. Stop on sync errors or failed safety checks.
+
+## Acceptance Criteria
+
+Verify every run against the selected mode's own acceptance criteria, then assert all of these router
+criteria:
+
+- Exactly one mode was selected and its reference workflow was followed end to end.
+- Read-only modes changed no source files; verify with a path-scoped `git diff` when applicable.
+- Every finding cites concrete evidence and the expected output artifact or report was produced.
+- Tests or validation commands required by the selected mode completed with their expected result.
+- Edge cases, limitations, skipped files, and degraded subagent coverage are disclosed.
+
+## Expected Output
+
+Example response after a read-only review:
+
+```text
+Mode: review
+Result: PASS
+Findings: 1 critical, 2 major, 0 minor
+Output: CODE_REVIEW.md
+Validation: reviewer pass complete; no source files changed
+```
+
+## Step Completion Reports
+
+After routing and after the selected workflow, emit a compact report:
+
+```text
+◆ Code Review ([mode])
+  Mode selection:      √ pass
+  Workflow criteria:   √ pass
+  Output verified:     √ pass
+  Safety boundary:     √ pass
+  Result:              PASS | FAIL | PARTIAL
+```
+
+Use `× fail — reason` for any unmet check. Never report PASS while a selected-mode acceptance
+criterion, expected output, required test, or safety guardrail is unresolved.
+
+## Edge Cases
+
+- Unknown `mode:` value → reject it and list the four valid modes.
+- Mixed intents across modes → ask which mode to run first; never merge workflows implicitly.
+- Missing target or inaccessible files → stop and request a concrete scope instead of guessing.
+- Agent tool unavailable → use the selected reference's inline fallback and disclose reduced coverage.
+- A read-only mode requests edits mid-run → finish the report, then require explicit approval before
+  starting a separate `cleanup` run.

--- a/skills/diagram-generator/SKILL.md
+++ b/skills/diagram-generator/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate a diagram and route to the right engine — draw.io XML (
 license: MIT
 effort: high
 metadata:
-  version: 1.1.0
+  version: 1.1.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -49,8 +49,14 @@ stays short to protect the agent's context budget; it only routes.
 3. Check whether the requested output path already exists. Let the selected engine run its own
    confirmation, backup, dry-run, error, and rollback safeguards before any overwrite.
 
-If neither engine is available, fail with an installation error and name both required skills. Never
-invent XML or JSON under the wrong engine as a fallback.
+If the user explicitly requested a format, tool, editing target, or aesthetic and its engine is unavailable,
+stop and explain which nested skill must be installed; provide the matching command
+(`asm install github:luongnv89/skills:skills/diagram-generator/drawio-generator` or
+`asm install github:luongnv89/skills:skills/diagram-generator/excalidraw-generator`) and ask the user to
+install it or explicitly change the requested output. Do not substitute the other engine. If no format or aesthetic was explicit, an available
+engine may be offered as a fallback only after explaining the output difference and receiving user approval.
+If neither engine is available, fail with an installation error and name both required skills. Never invent
+XML or JSON under the wrong engine as a fallback.
 
 ## Example
 
@@ -88,5 +94,6 @@ criteria and expected result are verified.
 ## Edge Cases
 
 - **User explicitly wants both formats** — generate with one engine first, then offer to regenerate the same diagram in the other.
-- **Ambiguous, no answer to the routing question** — default to draw.io and note the choice; the user can ask for an Excalidraw version.
-- **A nested engine is not installed** — fall back to the one that is, and note the limitation.
+- **Ambiguous, no answer to the routing question** — default to draw.io only when it is available; note the choice so the user can request an Excalidraw version.
+- **Explicitly requested engine is unavailable** — do not fall back. Report the unavailable nested skill, provide its installation guidance, and ask the user to install it or explicitly approve a different format/aesthetic.
+- **No explicit format and the selected engine is unavailable** — offer the installed engine as an alternative, explain its format/aesthetic, and route only after explicit user approval.

--- a/skills/diagram-generator/SKILL.md
+++ b/skills/diagram-generator/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate a diagram and route to the right engine — draw.io XML (
 license: MIT
 effort: high
 metadata:
-  version: 1.1.1
+  version: 1.1.2
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -27,7 +27,7 @@ Routing rules:
 - The user names a format or tool ("draw.io", "diagrams.net", "Excalidraw", "whiteboard sketch") → use that engine.
 - The user names an editing target ("I'll tweak it in draw.io", "import to Confluence") → **draw.io**.
 - The user wants a hand-drawn / sketch / wireframe look → **Excalidraw**.
-- No format signal → ask one question: "Precise and editable (draw.io) or hand-drawn sketch (Excalidraw)?" Default to **draw.io** for architecture/C4/technical diagrams and **Excalidraw** for wireframes/brainstorms if the user says "just pick".
+- No format signal → ask one question: "Precise and editable (draw.io) or hand-drawn sketch (Excalidraw)?" Keep routing blocked until the user answers. Only after explicit delegation such as "just pick", "choose for me", or "use the default", choose **draw.io** for architecture/C4/technical diagrams and **Excalidraw** for wireframes/brainstorms.
 - The user asks for **Mermaid**, a slide deck, or brand/marketing graphics → out of scope; say so (Mermaid is native markdown; use a presentation or design tool for the others).
 
 ## How to use
@@ -94,6 +94,6 @@ criteria and expected result are verified.
 ## Edge Cases
 
 - **User explicitly wants both formats** — generate with one engine first, then offer to regenerate the same diagram in the other.
-- **Ambiguous, no answer to the routing question** — default to draw.io only when it is available; note the choice so the user can request an Excalidraw version.
+- **Ambiguous, no answer to the routing question** — keep routing blocked and ask the question again; silence or timeout is not approval to choose an engine. Apply the routing heuristics only when the user explicitly delegates the choice (for example, "just pick", "choose for me", or "use the default").
 - **Explicitly requested engine is unavailable** — do not fall back. Report the unavailable nested skill, provide its installation guidance, and ask the user to install it or explicitly approve a different format/aesthetic.
 - **No explicit format and the selected engine is unavailable** — offer the installed engine as an alternative, explain its format/aesthetic, and route only after explicit user approval.

--- a/skills/diagram-generator/SKILL.md
+++ b/skills/diagram-generator/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate a diagram and route to the right engine — draw.io XML (
 license: MIT
 effort: high
 metadata:
-  version: 1.0.0
+  version: 1.1.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -41,22 +41,49 @@ of filesystem path:
 Each engine owns its full workflow, `references/`, `agents/`, and validation checks. This umbrella
 stays short to protect the agent's context budget; it only routes.
 
-## Layout
+## Prerequisites
 
-This umbrella and its engines live together in one suite folder:
+1. Confirm at least one nested engine is installed and callable.
+2. Require enough diagram content to identify nodes, relationships, and intended audience; ask for
+   missing essentials before routing.
+3. Check whether the requested output path already exists. Let the selected engine run its own
+   confirmation, backup, dry-run, error, and rollback safeguards before any overwrite.
 
+If neither engine is available, fail with an installation error and name both required skills. Never
+invent XML or JSON under the wrong engine as a fallback.
+
+## Example
+
+```text
+Input: "Draw a sketchy onboarding wireframe for mobile."
+Route: excalidraw-generator
+Expected output: one validated .excalidraw JSON artifact
 ```
-skills/diagram-generator/            ← this umbrella (router)
-├── SKILL.md                         ← you are here
-├── drawio-generator/                ← draw.io XML engine
-└── excalidraw-generator/            ← Excalidraw JSON engine
+
+## Acceptance Criteria
+
+Verify every routed run:
+
+- Exactly one engine is selected unless the user explicitly requests both formats.
+- The selected engine matches the requested format, editing target, or aesthetic.
+- The nested workflow reaches its Validate phase and produces its expected output artifact.
+- The artifact passes the engine's structural checks; validation errors are reported, not hidden.
+- Existing files are not overwritten without the selected engine's required confirmation or backup.
+
+## Step Completion Reports
+
+After routing, emit:
+
+```text
+◆ Route Diagram
+  Engine available:    √ pass
+  Route justified:     √ pass
+  Output validated:    √ pass
+  Result:              PASS | FAIL | PARTIAL
 ```
 
-Why nested: both engines serve one intent ("make a diagram") and differ only by output format, so a
-single entry point removes the "which diagram skill do I use?" decision. Each engine stays
-independently installable — the installers (`install.sh`, `remote-install.sh`) discover both
-top-level and nested skills. This mirrors the `website-cloner` suite convention (see README
-*Suite Folders*).
+Use `× fail — reason` when a check fails. Report PASS only after the nested engine's acceptance
+criteria and expected result are verified.
 
 ## Edge Cases
 

--- a/skills/doc-manager/SKILL.md
+++ b/skills/doc-manager/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate or update docs to match the code, citing each claim to pa
 license: MIT
 effort: medium
 metadata:
-  version: 2.0.1
+  version: 2.0.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -166,7 +166,7 @@ Use `√` pass, `×` fail, `—` for context. Per-phase checks:
 
 ## Guidelines
 
-- **Concise, for developers and AI agents.** State the fact, cite it, move on. No filler, no restating the obvious, no marketing tone.
+- **Protect the context budget.** State the fact, cite it, move on. No filler, no restating the obvious, no marketing tone.
 - Adapt structure to project type — not every `docs/` category applies.
 - Prefer code-derived facts over stale prose; keep existing accurate docs untouched (`verified-current`).
 - Maintain cross-references; remove content only when it's wrong or orphaned, and say so in the summary.

--- a/skills/dont-make-me-think/SKILL.md
+++ b/skills/dont-make-me-think/SKILL.md
@@ -4,7 +4,7 @@ description: "Review UI usability using Steve Krug's principles and produce a sc
 license: MIT
 effort: medium
 metadata:
-  version: 1.3.1
+  version: 1.3.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/dont-make-me-think/SKILL.md
+++ b/skills/dont-make-me-think/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: dont-make-me-think
-description: "Review UI for usability issues using Steve Krug's principles and produce a scannable report. Use when asked for a usability audit, UX review, or UI feedback on screenshots, URLs, or code. Don't use for visual/brand design critique, accessibility (WCAG) audits, or backend/API review."
+description: "Review UI usability using Steve Krug's principles and produce a scannable report. Use for UX audits of screenshots, URLs, or code. Don't use for brand critique, WCAG audits, or backend/API review."
 license: MIT
 effort: medium
 metadata:
-  version: 1.3.0
+  version: 1.3.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/dont-make-me-think/scripts/process_screenshots.py
+++ b/skills/dont-make-me-think/scripts/process_screenshots.py
@@ -765,7 +765,11 @@ def main():
             for path in missing_paths:
                 print(f"✗ Path not found: {path}", file=sys.stderr)
         else:
-            print("○ No supported images found.", file=sys.stderr)
+            print("○ No supported images found in the supplied paths.", file=sys.stderr)
+        print(
+            "Pass an existing PNG, JPEG, GIF, WebP, or BMP path; add --recursive for directories.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     if not args.quiet:
@@ -796,6 +800,10 @@ def main():
     if not analyses and errors:
         for path, err in errors:
             print(f"✗ {path}: {err}", file=sys.stderr)
+        print(
+            "Use a readable, non-empty supported image and retry; inspect the per-path errors above.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     # Build report

--- a/skills/dont-make-me-think/scripts/process_screenshots.py
+++ b/skills/dont-make-me-think/scripts/process_screenshots.py
@@ -67,6 +67,14 @@ class ColorPalette:
 
 
 @dataclass
+class ImageCollection:
+    """Supported images collected from inputs plus paths that were not found."""
+
+    images: list[Path]
+    missing: list[str]
+
+
+@dataclass
 class ScreenshotAnalysis:
     """Complete analysis of a single screenshot."""
 
@@ -600,8 +608,8 @@ def analyze_single(path: Path) -> ScreenshotAnalysis:
     )
 
 
-def collect_images(paths: list[str], recursive: bool = False) -> list[Path]:
-    """Collect all image files from the given paths."""
+def collect_images(paths: list[str], recursive: bool = False) -> ImageCollection:
+    """Collect supported images and report input paths that do not exist."""
     images = []
     missing = []
     for p in paths:
@@ -624,9 +632,7 @@ def collect_images(paths: list[str], recursive: bool = False) -> list[Path]:
         if abs_path not in seen:
             seen.add(abs_path)
             unique.append(img)
-    # Store missing paths for reporting (attached to the returned list as metadata)
-    unique._missing = missing  # type: ignore[attr-defined]
-    return sorted(unique)
+    return ImageCollection(images=sorted(unique), missing=missing)
 
 
 def build_report(analyses: list[ScreenshotAnalysis]) -> dict:
@@ -756,15 +762,16 @@ def main():
     if not args.quiet:
         print(f"● Collecting images from {len(args.paths)} path(s)...", file=sys.stderr)
 
-    image_paths = collect_images(args.paths, recursive=args.recursive)
+    collection = collect_images(args.paths, recursive=args.recursive)
+    image_paths = collection.images
+    missing_paths = collection.missing
 
-    # Check for missing paths before validation
-    missing_paths = getattr(image_paths, "_missing", None)
+    # Report missing inputs before validating any images that were found.
+    for path in missing_paths:
+        print(f"✗ Path not found: {path}", file=sys.stderr)
+
     if not image_paths:
-        if missing_paths:
-            for path in missing_paths:
-                print(f"✗ Path not found: {path}", file=sys.stderr)
-        else:
+        if not missing_paths:
             print("○ No supported images found in the supplied paths.", file=sys.stderr)
         print(
             "Pass an existing PNG, JPEG, GIF, WebP, or BMP path; add --recursive for directories.",

--- a/skills/fork-upstream-sync/SKILL.md
+++ b/skills/fork-upstream-sync/SKILL.md
@@ -4,13 +4,22 @@ description: "Sync a GitHub fork with upstream while keeping unmerged feature br
 license: MIT
 effort: medium
 metadata:
-  version: 1.0.3
+  version: 1.3.0
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
 # Fork Upstream Sync
 
 **Integration main** means fork `main` = `upstream/main` plus your unmerged commits in linear history (not a merge commit that duplicates feature work).
+
+## Prerequisites
+
+Before selecting a path, validate all requirements:
+
+- **Tools:** require Git 2.30+; require `gh` only for PR-state checks.
+- **Access:** confirm authenticated fetch and push access to `origin`, plus fetch access to `upstream`.
+- **State:** check that the working tree is clean or stashable and that the target branches are not checked out in another worktree.
+- **Recovery:** record the current branch and SHA. If fetch, stash, rebase, reset, or push fails, stop at that command; never continue with stale assumptions.
 
 ## Branch selector
 
@@ -106,17 +115,9 @@ git push origin main --force-with-lease
 
 ---
 
-## Routine cheat sheet
+## Verify with the command reference
 
-```bash
-git fetch upstream origin
-git checkout <feature-branch> && git rebase upstream/main
-git push origin <feature-branch> --force-with-lease
-git checkout main && git reset --hard upstream/main
-git merge --ff-only <feature-branch> && git push origin main --force-with-lease
-```
-
-If `--ff-only` fails, do not push — re-run the rebase step against the current `upstream/main`, then retry.
+Protect the context budget: read `references/command-checks.md` only when executing or diagnosing a path. See that reference for the routine command sequence and exact SHA, ancestry, ahead-count, and clean-tree checks.
 
 ## What not to do
 
@@ -124,9 +125,28 @@ If `--ff-only` fails, do not push — re-run the rebase step against the current
 - Do not force-push without `--force-with-lease`.
 - Do not treat `origin` as upstream; `origin` is your fork, `upstream` is the parent.
 
-## Optional verification
+## Acceptance criteria
+
+Verify the selected path before reporting success:
+
+- [ ] Required remotes resolve and the working tree has no unresolved conflicts.
+- [ ] The expected branch ancestry or equality check for the selected path passes.
+- [ ] Every push used `--force-with-lease`; no destructive push targeted the wrong branch.
+- [ ] For Path B, the PR response is `MERGEABLE`, or CI delay is explicitly reported as partial.
+
+Run:
 
 ```bash
 git log --oneline -1 upstream/main main <feature-branch>
 git rev-list --count upstream/main..main
+git merge-base --is-ancestor upstream/main main
 ```
+
+**Expected output:** the log identifies the intended tips, the ahead count equals the retained feature commits, and the ancestry command exits 0. For Paths C and D, also assert the exact SHA equality required by that path.
+
+## Edge cases
+
+- **Renamed default branch:** discover it with `gh repo view --json defaultBranchRef`; do not assume `main`.
+- **Protected fork branch:** if GitHub rejects a lease-protected push, stop and report the protection rule; do not weaken it.
+- **Deleted PR branch:** recreate only from a verified local or remote SHA after user confirmation.
+- **Upstream rewrote history:** fetch, compare old and new tips, and ask before rebasing or resetting across the rewrite.

--- a/skills/fork-upstream-sync/SKILL.md
+++ b/skills/fork-upstream-sync/SKILL.md
@@ -4,7 +4,7 @@ description: "Sync a GitHub fork with upstream while keeping unmerged feature br
 license: MIT
 effort: medium
 metadata:
-  version: 1.3.1
+  version: 1.3.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/fork-upstream-sync/SKILL.md
+++ b/skills/fork-upstream-sync/SKILL.md
@@ -4,7 +4,7 @@ description: "Sync a GitHub fork with upstream while keeping unmerged feature br
 license: MIT
 effort: medium
 metadata:
-  version: 1.3.0
+  version: 1.3.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/fork-upstream-sync/references/command-checks.md
+++ b/skills/fork-upstream-sync/references/command-checks.md
@@ -1,0 +1,31 @@
+# Command checks
+
+Use these commands after selecting a path; replace placeholders before running them.
+
+## Routine sync
+
+```bash
+git fetch upstream origin
+git checkout <feature-branch>
+git rebase upstream/<default-branch>
+git push origin <feature-branch> --force-with-lease
+git checkout <default-branch>
+git reset --hard upstream/<default-branch>
+git merge --ff-only <feature-branch>
+git push origin <default-branch> --force-with-lease
+```
+
+If `--ff-only` fails, do not push. Rebase the feature branch against the current upstream tip, verify it, then retry.
+
+## Equality and ancestry
+
+```bash
+git rev-parse upstream/<default-branch>
+git rev-parse <default-branch>
+git rev-parse <feature-branch>
+git merge-base --is-ancestor upstream/<default-branch> <default-branch>
+git rev-list --count upstream/<default-branch>..<default-branch>
+git status --short
+```
+
+Path C requires the default branch and feature branch SHAs to match. Path D requires the default branch and upstream SHAs to match. An empty `git status --short` confirms no unresolved working-tree changes.

--- a/skills/fork-upstream-sync/references/command-checks.md
+++ b/skills/fork-upstream-sync/references/command-checks.md
@@ -1,8 +1,10 @@
 # Command checks
 
-Use these commands after selecting a path; replace placeholders before running them.
+Use only the sequence for the path the user approved. Replace every placeholder before running a command.
 
-## Routine sync
+## Path B only — repair the PR branch
+
+Use this sequence when the request is only to repair a conflicting PR. It stops after updating and verifying the feature branch.
 
 ```bash
 git fetch upstream
@@ -10,23 +12,90 @@ git fetch origin
 git checkout <feature-branch>
 git rebase upstream/<default-branch>
 git push origin <feature-branch> --force-with-lease
+gh pr view <pr-number> --repo <owner>/<repo> --json mergeable,mergeStateStatus
+```
+
+**Do not run Path C commands for a Path B-only request.** In particular, do not check out, reset, or push the default branch unless the user separately approves Path C or an explicit combined B+C operation.
+
+Path B is complete when the rebase succeeds, the feature branch is lease-protected on `origin`, and the PR is mergeable (or a CI delay is reported as partial).
+
+## Path C only — approved integration-main rebuild
+
+Run this sequence only when the user explicitly approved rebuilding the fork's integration default branch and the feature branch is already rebased on the current upstream tip:
+
+```bash
+git fetch upstream
+git fetch origin
 git checkout <default-branch>
 git reset --hard upstream/<default-branch>
 git merge --ff-only <feature-branch>
 git push origin <default-branch> --force-with-lease
 ```
 
-If `--ff-only` fails, do not push. Rebase the feature branch against the current upstream tip, verify it, then retry.
+If `--ff-only` fails, do not push. Re-run Path B against the current upstream tip, verify the feature branch, then retry Path C only if its approval still applies.
 
-## Equality and ancestry
+## Explicit combined Path B+C
+
+Use the combined sequence only when the user asked both to repair the PR branch and to rebuild integration main:
+
+```bash
+git fetch upstream
+git fetch origin
+git checkout <feature-branch>
+git rebase upstream/<default-branch>
+git push origin <feature-branch> --force-with-lease
+gh pr view <pr-number> --repo <owner>/<repo> --json mergeable,mergeStateStatus
+git checkout <default-branch>
+git reset --hard upstream/<default-branch>
+git merge --ff-only <feature-branch>
+git push origin <default-branch> --force-with-lease
+```
+
+If the fast-forward merge fails, do not push the default branch.
+
+## Path D — approved post-merge cleanup
+
+Use this only after verifying that upstream contains the merged PR and the user asked to make the fork default branch identical to upstream:
+
+```bash
+git fetch upstream
+git fetch origin
+git checkout <default-branch>
+git reset --hard upstream/<default-branch>
+git push origin <default-branch> --force-with-lease
+```
+
+## Path-specific verification
+
+### Path B
+
+```bash
+git rev-parse upstream/<default-branch>
+git rev-parse <feature-branch>
+git merge-base --is-ancestor upstream/<default-branch> <feature-branch>
+git status --short
+gh pr view <pr-number> --repo <owner>/<repo> --json mergeable,mergeStateStatus
+```
+
+### Path C or explicit B+C
 
 ```bash
 git rev-parse upstream/<default-branch>
 git rev-parse <default-branch>
 git rev-parse <feature-branch>
 git merge-base --is-ancestor upstream/<default-branch> <default-branch>
+test "$(git rev-parse <default-branch>)" = "$(git rev-parse <feature-branch>)"
 git rev-list --count upstream/<default-branch>..<default-branch>
 git status --short
 ```
 
-Path C requires the default branch and feature branch SHAs to match. Path D requires the default branch and upstream SHAs to match. An empty `git status --short` confirms no unresolved working-tree changes.
+### Path D
+
+```bash
+git rev-parse upstream/<default-branch>
+git rev-parse <default-branch>
+test "$(git rev-parse <default-branch>)" = "$(git rev-parse upstream/<default-branch>)"
+git status --short
+```
+
+An empty `git status --short` confirms no unresolved working-tree changes. Path C requires the default and feature branch SHAs to match; Path D requires the default and upstream SHAs to match.

--- a/skills/fork-upstream-sync/references/command-checks.md
+++ b/skills/fork-upstream-sync/references/command-checks.md
@@ -5,7 +5,8 @@ Use these commands after selecting a path; replace placeholders before running t
 ## Routine sync
 
 ```bash
-git fetch upstream origin
+git fetch upstream
+git fetch origin
 git checkout <feature-branch>
 git rebase upstream/<default-branch>
 git push origin <feature-branch> --force-with-lease

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: frontend-design
-description: "Build production-grade frontend interfaces with distinctive aesthetics and working code. Use when asked to create a UI, component, page, or frontend feature. Skip for backend/API work or usability-only audits."
+description: "Build production-grade frontend interfaces with distinctive aesthetics and working code. Use for UI components, pages, or frontend features. Don't use for backend/API work or usability-only audits."
 license: MIT
 effort: high
 metadata:
-  version: 1.2.3
+  version: 1.2.4
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/install-script-generator/SKILL.md
+++ b/skills/install-script-generator/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate cross-platform install scripts for any software or librar
 license: MIT
 effort: high
 metadata:
-  version: 2.2.0
+  version: 2.2.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/install-script-generator/scripts/executor.py
+++ b/skills/install-script-generator/scripts/executor.py
@@ -343,6 +343,10 @@ def main():
     plan_file = Path(args.plan)
     if not plan_file.exists():
         print(f"Error: Plan file not found: {plan_file}", file=sys.stderr)
+        print(
+            "Generate it with plan_generator.py or pass the correct path with --plan.",
+            file=sys.stderr,
+        )
         return 1
 
     with open(plan_file) as f:
@@ -363,7 +367,14 @@ def main():
             f.write(markdown)
         print(f"Report saved to: {output_file}")
 
-    return 0 if report["success"] else 1
+    if not report["success"]:
+        print(
+            f"Error: plan {plan_file} failed at step {report['failed_step']}. "
+            "Inspect the report and command error above, fix that step, then rerun --dry-run.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/skills/landing-page-generator/SKILL.md
+++ b/skills/landing-page-generator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: landing-page-generator
-description: "Generate landing pages with PAS, AIDA, or StoryBrand — marketing copy from a product brief, or a scannable landing-page rewrite of an existing README. The one skill for landing-page work. Not for blog posts, UX audits, or HTML builds."
+description: "Generate landing pages with PAS, AIDA, or StoryBrand from a product brief or existing README. Use for sales copy, hero sections, CTAs, or README rewrites. Don't use for blog posts, UX audits, or HTML builds."
 license: MIT
 effort: high
 metadata:
-  version: 1.2.0
+  version: 1.2.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 

--- a/skills/logo-designer/SKILL.md
+++ b/skills/logo-designer/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: logo-designer
-description: "Generate professional SVG logos from project context, producing 7 brand variants (mark, full, wordmark, icon, favicon, white, black) plus a showcase HTML page. Skip for raster-only logos, product illustrations, or full brand-guideline docs."
+description: "Generate professional SVG logos from project context: 7 brand variants plus a showcase HTML page. Use for product marks, wordmarks, icons, and favicons. Don't use for raster-only logos, illustrations, or full brand guidelines."
 license: MIT
 effort: medium
 metadata:
-  version: 1.2.2
+  version: 1.2.3
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 
@@ -29,8 +29,8 @@ This skill uses an **Explorer+Executor (A) + Review Loop (C)** architecture:
 Phase 1: Brand Research
   ↓ (brand-researcher agent)
   ↓
-Phase 2-3: SVG Generation (Interactive Style Selection)
-  ↓ Main agent: interactive style selection with user
+Phase 2: Interactive Style Selection
+  ↓ Main agent: confirm style selection with user
   ↓
 Phase 3: Generate All 7 SVGs
   ↓ (svg-generator agent)

--- a/skills/ollama-optimizer/SKILL.md
+++ b/skills/ollama-optimizer/SKILL.md
@@ -4,7 +4,7 @@ description: "Optimize Ollama configuration for the current machine's hardware. 
 license: MIT
 effort: medium
 metadata:
-  version: 1.1.0
+  version: 1.1.1
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/ollama-optimizer/scripts/benchmark_ollama.py
+++ b/skills/ollama-optimizer/scripts/benchmark_ollama.py
@@ -180,17 +180,31 @@ def main():
     # Check Ollama is running
     stdout, _, code = run_command(["ollama", "ps"])
     if code != 0:
-        print(json.dumps({"error": "Ollama is not running. Start it with 'ollama serve'"}))
+        print(
+            json.dumps({"error": "Ollama check failed for 'ollama ps'. Start it with 'ollama serve' and retry."}),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     models = get_ollama_models()
     if not models:
-        print(json.dumps({"error": "No models installed. Install a model with 'ollama pull <model>'"}))
+        print(
+            json.dumps({"error": "No models returned by 'ollama list'. Install one with 'ollama pull <model>' and retry."}),
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     if args.model:
         if args.model not in models:
-            print(json.dumps({"error": f"Model '{args.model}' not found. Available: {models}"}))
+            print(
+                json.dumps({
+                    "error": (
+                        f"Requested model '{args.model}' was not found. Available: {models}. "
+                        "Choose an available model or run 'ollama pull <model>', then retry."
+                    )
+                }),
+                file=sys.stderr,
+            )
             sys.exit(1)
         models_to_test = [args.model]
     elif args.all:

--- a/skills/seo-ai-optimizer/SKILL.md
+++ b/skills/seo-ai-optimizer/SKILL.md
@@ -4,7 +4,7 @@ description: "Audit and optimize websites for technical SEO, content SEO, and AI
 license: MIT
 effort: high
 metadata:
-  version: 1.2.2
+  version: 1.2.3
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/seo-ai-optimizer/SKILL.md
+++ b/skills/seo-ai-optimizer/SKILL.md
@@ -4,7 +4,7 @@ description: "Audit and optimize websites for technical SEO, content SEO, and AI
 license: MIT
 effort: high
 metadata:
-  version: 1.2.1
+  version: 1.2.2
   author: Luong NGUYEN <luongnv89@gmail.com>
 ---
 

--- a/skills/seo-ai-optimizer/scripts/audit_seo.py
+++ b/skills/seo-ai-optimizer/scripts/audit_seo.py
@@ -9,6 +9,7 @@ Usage:
     python audit_seo.py <project-root> [--max-files N]
 """
 
+import argparse
 import sys
 import os
 import re
@@ -525,40 +526,47 @@ def detect_framework(project_root):
     return None
 
 
-def main():
-    if len(sys.argv) < 2:
-        print(
-            "Error: missing required <project-root> input. "
-            "Run `python audit_seo.py <project-root> [--max-files N]`.",
-            file=sys.stderr,
+def positive_file_limit(value):
+    """Parse a strictly positive --max-files value for argparse."""
+    try:
+        limit = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"must be an integer greater than 0, got {value!r}; "
+            "use a value such as `--max-files 50`"
+        ) from exc
+
+    if limit <= 0:
+        raise argparse.ArgumentTypeError(
+            f"must be greater than 0, got {value!r}; "
+            "use a value such as `--max-files 50`"
         )
-        sys.exit(1)
+    return limit
 
-    project_root = sys.argv[1]
-    max_files = 50
 
-    if "--max-files" in sys.argv:
-        idx = sys.argv.index("--max-files")
-        if idx + 1 < len(sys.argv):
-            try:
-                max_files = int(sys.argv[idx + 1])
-            except ValueError:
-                print(
-                    f"Error: --max-files must be an integer, got {sys.argv[idx + 1]!r}. "
-                    "Replace it with a positive number such as `--max-files 50`.",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
+def main():
+    parser = argparse.ArgumentParser(
+        description="Audit a web project for common SEO and AI bot issues."
+    )
+    parser.add_argument("project_root", metavar="project-root")
+    parser.add_argument(
+        "--max-files",
+        type=positive_file_limit,
+        default=50,
+        metavar="N",
+        help="maximum number of representative files to audit (must be greater than 0)",
+    )
+    args = parser.parse_args()
 
-    if not Path(project_root).exists():
+    if not Path(args.project_root).exists():
         print(
-            f"Error: project root does not exist: {project_root!r}. "
+            f"Error: project root does not exist: {args.project_root!r}. "
             "Pass the path to an existing web project directory.",
             file=sys.stderr,
         )
         sys.exit(1)
 
-    audit_project(project_root, max_files)
+    audit_project(args.project_root, args.max_files)
 
 
 if __name__ == "__main__":

--- a/skills/seo-ai-optimizer/scripts/audit_seo.py
+++ b/skills/seo-ai-optimizer/scripts/audit_seo.py
@@ -527,9 +527,11 @@ def detect_framework(project_root):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python audit_seo.py <project-root> [--max-files N]")
-        print("\nScans HTML/template files for SEO and AI bot issues.")
-        print("Outputs a JSON report to stdout.")
+        print(
+            "Error: missing required <project-root> input. "
+            "Run `python audit_seo.py <project-root> [--max-files N]`.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     project_root = sys.argv[1]
@@ -541,11 +543,19 @@ def main():
             try:
                 max_files = int(sys.argv[idx + 1])
             except ValueError:
-                print(f"Error: --max-files must be a number, got '{sys.argv[idx + 1]}'")
+                print(
+                    f"Error: --max-files must be an integer, got {sys.argv[idx + 1]!r}. "
+                    "Replace it with a positive number such as `--max-files 50`.",
+                    file=sys.stderr,
+                )
                 sys.exit(1)
 
     if not Path(project_root).exists():
-        print(f"Error: Project root not found: {project_root}")
+        print(
+            f"Error: project root does not exist: {project_root!r}. "
+            "Pass the path to an existing web project directory.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     audit_project(project_root, max_files)

--- a/skills/tasks-generator/SKILL.md
+++ b/skills/tasks-generator/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: tasks-generator
-description: "Generate development tasks from a PRD file with sprint-based planning. Use when users ask to create tasks from PRD, break down the PRD, generate sprint tasks, or want to convert product requirements into actionable development tasks. Creates/updates tasks.md and always reports GitHub links to changed files. Don't use for writing a PRD, authoring a TAD, or executing tasks (see openspec-task-loop)."
+description: "Generate sprint-based development tasks from a PRD. Use when asked to create tasks or break down requirements. Don't use for PRD/TAD authoring or task execution."
 license: MIT
 effort: max
 metadata:
-  version: 1.3.0
+  version: 1.3.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 

--- a/skills/website-cloner/SKILL.md
+++ b/skills/website-cloner/SKILL.md
@@ -4,7 +4,7 @@ description: "Build an improved website clone from a URL via 6-phase gated workf
 license: MIT
 effort: high
 metadata:
-  version: 1.2.0
+  version: 1.2.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -44,7 +44,7 @@ Phase 6 — Final Report   → website-clone-final-report
 
 Approval gates after Phase 2, 3, and 4: the orchestrator **must not advance** without explicit user approval.
 
-**Artifacts** (each written once, then referenced by name in the phases below): `analysis.json` — Phase 1's structured findings; `report.md` — Phase 2's plain-language summary; `prd.md` — Phase 3's improvement proposal; `tasks.md` — Phase 4's phased implementation plan; `builder-metadata.json` — Phase 5's build metadata, Pages URL, and structured post-deployment performance/SEO/security snapshot consumed by Phase 6; `after-analysis.json` — the comparable Phase 5 re-audit source.
+**Artifacts** (each written once, then referenced by name in the phases below): `analysis.json` — Phase 1's structured findings; `report.md` — Phase 2's plain-language summary; `prd.md` — Phase 3's improvement proposal; `tasks.md` — Phase 4's phased implementation plan, including the approved GitHub Actions artifact-deployment task; `builder-metadata.json` — Phase 5's build metadata, workflow-produced Pages URL, and structured post-deployment performance/SEO/security snapshot consumed by Phase 6; `after-analysis.json` — the comparable Phase 5 re-audit source. Phase 5 also produces base-aware Vite configuration and `.github/workflows/deploy-pages.yml`, which builds and deploys `dist/` rather than publishing the repository root.
 
 ## Layout
 
@@ -179,7 +179,7 @@ Invoke `website-implementation-plan` with `prd.md`:
 /website-implementation-plan "$PROJECT_DIR/prd.md" --output "$PROJECT_DIR/tasks.md"
 ```
 
-This skill produces a phased implementation plan with landing page first, asset collection vs. creation, and individual tasks — written to `tasks.md` after user approval.
+This skill produces a phased implementation plan with landing page first, asset collection vs. creation, individual tasks, and a deterministic GitHub Actions Pages artifact deployment from base-aware Vite `dist/` output — written to `tasks.md` after user approval.
 
 **Check:** `tasks.md` exists and was approved.
 
@@ -192,6 +192,7 @@ This skill produces a phased implementation plan with landing page first, asset 
   User approved:        √ pass | × pending
   Phases defined:       √ pass (≥ 2 phases)
   Landing page first:   √ pass
+  Pages artifact task:  √ pass (base-aware dist/)
   ____________________________
   Result:               PASS | BLOCKED
 ```
@@ -204,7 +205,7 @@ Invoke `website-builder` with `tasks.md` and `prd.md`:
 /website-builder "$PROJECT_DIR/tasks.md" "$PROJECT_DIR/prd.md" --output "$PROJECT_DIR/"
 ```
 
-This skill executes the plan, builds the site (Vite + React + shadcn/ui + Tailwind), deploys static assets, then re-runs `website-analyzer` against the responsive Pages URL. It emits the structured after snapshot in metadata for Phase 6. If deployment or the re-audit is incomplete, Phase 5 must return `PARTIAL` and preserve nulls/errors rather than inventing metrics.
+This skill executes the plan, builds the site (Vite + React + shadcn/ui + Tailwind), and deploys the verified `dist/` artifact through `.github/workflows/deploy-pages.yml`. The workflow sets the Vite base to `/` for a user/organization Pages repository or `/<repo>/` for project Pages; repository-root and branch-folder publishing are forbidden. It then re-runs `website-analyzer` against the responsive workflow-produced Pages URL and emits the structured after snapshot in metadata for Phase 6. If deployment or the re-audit is incomplete, Phase 5 must return `PARTIAL` and preserve nulls/errors rather than inventing metrics.
 
 **Step Completion Report:**
 
@@ -214,6 +215,7 @@ This skill executes the plan, builds the site (Vite + React + shadcn/ui + Tailwi
   Landing page built:   √ pass
   Assets collected:     √ pass (<N> assets)
   Assets created:       √ pass (<N> assets)
+  Pages dist artifact:  √ pass | × unavailable
   GitHub Pages URL:     √ pass (<url>) | × unavailable
   After metrics:        √ complete | × partial ([performance/SEO/security gaps])
   ____________________________

--- a/skills/website-cloner/SKILL.md
+++ b/skills/website-cloner/SKILL.md
@@ -4,7 +4,7 @@ description: "Build an improved website clone from a URL via 6-phase gated workf
 license: MIT
 effort: high
 metadata:
-  version: 1.1.6
+  version: 1.2.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -44,7 +44,7 @@ Phase 6 — Final Report   → website-clone-final-report
 
 Approval gates after Phase 2, 3, and 4: the orchestrator **must not advance** without explicit user approval.
 
-**Artifacts** (each written once, then referenced by name in the phases below): `analysis.json` — Phase 1's structured findings; `report.md` — Phase 2's plain-language summary; `prd.md` — Phase 3's improvement proposal; `tasks.md` — Phase 4's phased implementation plan; `builder-metadata.json` — Phase 5's build-output metadata (asset counts, Pages URL) consumed by Phase 6.
+**Artifacts** (each written once, then referenced by name in the phases below): `analysis.json` — Phase 1's structured findings; `report.md` — Phase 2's plain-language summary; `prd.md` — Phase 3's improvement proposal; `tasks.md` — Phase 4's phased implementation plan; `builder-metadata.json` — Phase 5's build metadata, Pages URL, and structured post-deployment performance/SEO/security snapshot consumed by Phase 6; `after-analysis.json` — the comparable Phase 5 re-audit source.
 
 ## Layout
 
@@ -103,7 +103,7 @@ Invoke `website-analyzer` with the URL:
 /website-analyzer <url> --output "$PROJECT_DIR/analysis.json"
 ```
 
-The analyzer produces a structured analysis covering: UI/UX, category, style, performance (LCP, CLS, TTFB, page weight, request count), surface-level security, and SEO (overall score + per-dimension breakdown).
+The analyzer produces a structured analysis covering: UI/UX, category, style, performance (`lcp_estimate_seconds`, unitless `cls_estimate`, `ttfb_estimate_seconds`, page weight in KB, and request count), surface-level security, and SEO (overall score + per-dimension breakdown).
 
 **Check:** Analysis file exists and covers all 6 dimensions. If any dimension is missing, note it but continue — partial results are acceptable for Phase 2.
 
@@ -204,7 +204,7 @@ Invoke `website-builder` with `tasks.md` and `prd.md`:
 /website-builder "$PROJECT_DIR/tasks.md" "$PROJECT_DIR/prd.md" --output "$PROJECT_DIR/"
 ```
 
-This skill executes the plan, builds the site (Vite + React + shadcn/ui + Tailwind), and deploys static assets. It should emit metadata for Phase 6.
+This skill executes the plan, builds the site (Vite + React + shadcn/ui + Tailwind), deploys static assets, then re-runs `website-analyzer` against the responsive Pages URL. It emits the structured after snapshot in metadata for Phase 6. If deployment or the re-audit is incomplete, Phase 5 must return `PARTIAL` and preserve nulls/errors rather than inventing metrics.
 
 **Step Completion Report:**
 
@@ -214,9 +214,10 @@ This skill executes the plan, builds the site (Vite + React + shadcn/ui + Tailwi
   Landing page built:   √ pass
   Assets collected:     √ pass (<N> assets)
   Assets created:       √ pass (<N> assets)
-  GitHub Pages URL:     √ pass (<url>)
+  GitHub Pages URL:     √ pass (<url>) | × unavailable
+  After metrics:        √ complete | × partial ([performance/SEO/security gaps])
   ____________________________
-  Result:               PASS | PARTIAL
+  Result:               PASS | PARTIAL | FAIL
 ```
 
 ## Phase 6: Final Comparison Report
@@ -227,7 +228,7 @@ Invoke `website-clone-final-report` with the analysis baseline and builder metad
 /website-clone-final-report "$PROJECT_DIR/analysis.json" "$PROJECT_DIR/builder-metadata.json" --output "$PROJECT_DIR/final-report.md"
 ```
 
-This skill produces a before/after comparison covering performance, SEO, security, UI/UX deltas, deviations, and the GitHub Pages URL.
+This skill validates the baseline and structured post-deployment snapshot, then produces a before/after comparison covering performance, SEO, security, UI/UX changes, deviations, and the GitHub Pages URL. It must propagate `PARTIAL` when any required performance, SEO, or security comparison is unavailable.
 
 **Step Completion Report:**
 
@@ -235,11 +236,12 @@ This skill produces a before/after comparison covering performance, SEO, securit
 ◆ Final Report (step 6 of 6 — <site name>)
 ······································································
   final-report.md:      √ pass
-  Performance delta:    √ pass (before→after)
-  SEO delta:            √ pass (before→after)
+  Performance delta:    √ pass (before→after) | × partial ([missing])
+  SEO delta:            √ pass (before→after) | × partial ([missing])
+  Security comparison:  √ pass (before→after) | × partial ([missing])
   Deviations listed:    √ pass | × none
   ____________________________
-  Result:               PASS
+  Result:               PASS | PARTIAL | FAIL
 ```
 
 ## Expected Output
@@ -251,18 +253,22 @@ This skill produces a before/after comparison covering performance, SEO, securit
   Phase 2  Report       √ approved
   Phase 3  Proposal     √ approved (prd.md)
   Phase 4  Plan         √ approved (tasks.md)
-  Phase 5  Build        √ pass
-  Phase 6  Final Report √ pass
+  Phase 5  Build        √ pass | × partial
+  Phase 6  Final Report √ pass | × partial | × fail
+  Overall Result:       PASS | PARTIAL | FAIL
 
   GitHub Pages: https://<user>.github.io/<repo>/
   Project:      <project_dir>
 ```
+
+The overall result is the worst Phase 1–6 result. Never report overall `PASS` when the Phase 5 after snapshot or any Phase 6 required comparison is partial, unavailable, or failed.
 
 ## Edge Cases
 
 - **Unreachable URL**: Stop Phase 1, report error, do not continue. Ask user for a different URL.
 - **JS-heavy SPA with no crawlable content**: Note the limitation in Phase 1, proceed with best-effort analysis. The build phase may need user-supplied assets to compensate.
 - **User denies approval at any gate**: Stop the pipeline. Do not auto-proceed. The user can re-run the skill to resume.
-- **Missing sibling skill**: If a sibling skill is not available, skip that phase and note it in the report. Continue with remaining phases if possible.
-- **Partial Phase 1 results**: If the analyzer returns partial data (e.g., no SEO score), proceed to Phase 2 with a note that the missing dimension was not evaluated.
+- **Missing sibling skill**: If a sibling skill is not available, skip that phase and note it in the report. Continue where possible, but the overall result cannot exceed `PARTIAL`.
+- **Partial Phase 1 results**: If the analyzer returns partial data (e.g., no SEO score), proceed to Phase 2 with a note; Phase 6 and the overall workflow remain `PARTIAL` when a required baseline comparison is unavailable.
+- **Partial Phase 5 re-audit**: Continue to Phase 6 so it can document the gaps, but both Phase 6 and the overall workflow must return `PARTIAL` unless report creation itself fails.
 

--- a/skills/website-cloner/website-analyzer/SKILL.md
+++ b/skills/website-cloner/website-analyzer/SKILL.md
@@ -4,7 +4,7 @@ description: "Analyze a website's UI/UX, category, style, performance, surface s
 license: MIT
 effort: high
 metadata:
-  version: 1.2.1
+  version: 1.3.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -65,9 +65,9 @@ Produce structured JSON at the requested output path (or stdout):
     "aesthetic": "vibe description"
   },
   "performance": {
-    "lcp_estimate": 2.5,
+    "lcp_estimate_seconds": 2.5,
     "cls_estimate": 0.05,
-    "ttfb_estimate": 0.3,
+    "ttfb_estimate_seconds": 0.3,
     "total_page_weight_kb": 1200,
     "request_count": 45,
     "notes": "estimated from static analysis"
@@ -133,9 +133,9 @@ From fetched content, extract:
 |--------|--------|
 | Page weight | Sum of referenced resource sizes; estimate image sizes from layout |
 | Request count | Count `<img>`, `<link rel="stylesheet">`, `<script>`, font refs |
-| LCP | Inferred from above-fold content size; min 0.5s for bare HTML |
-| CLS | Estimated from layout shift indicators (missing dimensions, late loaders) |
-| TTFB | Inferred from hosting signals; static → low, dynamic → moderate |
+| LCP (`lcp_estimate_seconds`) | Inferred from above-fold content size; seconds, with a 0.5-second minimum for bare HTML |
+| CLS (`cls_estimate`) | Estimated from layout shift indicators (missing dimensions, late loaders); unitless |
+| TTFB (`ttfb_estimate_seconds`) | Inferred from hosting signals; seconds; static → low, dynamic → moderate |
 
 All metrics are estimates from static analysis. Note this in output.
 
@@ -185,7 +185,7 @@ Verify the expected output before reporting success:
 
 - JSON parses and contains `url`, `timestamp`, `ui_ux`, `category`, `style`, `performance`, `security`, and `seo`.
 - `seo.score` is an integer from 0 through 100 and matches the weighted, null-adjusted dimension calculation.
-- Performance estimates include units or `_kb` suffixes and an explicit static-analysis limitation.
+- Performance estimates use `lcp_estimate_seconds`, unitless `cls_estimate`, `ttfb_estimate_seconds`, and `total_page_weight_kb`, plus an explicit static-analysis limitation.
 - Every unavailable measurement is `null` or an error field, never an invented value.
 - The output is written to the requested destination; assert the file exists and can be parsed when a path is supplied.
 

--- a/skills/website-cloner/website-analyzer/SKILL.md
+++ b/skills/website-cloner/website-analyzer/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: website-analyzer
-description: "Analyze any website URL across 6 dimensions: UI/UX, category, style, performance (LCP/CLS/TTFB/weight/requests), surface-level security, and SEO (score 0-100 with breakdown). Outputs structured JSON for downstream skills. Use when asked to analyze, audit, or scan a website. Don't use for full SEO audits or penetration testing."
+description: "Analyze a website's UI/UX, category, style, performance, surface security, and SEO; emit structured JSON. Use for URL audits or website-cloner input. Don't use for penetration tests, full SEO audits, or App Store ASO."
 license: MIT
 effort: high
 metadata:
-  version: 1.0.2
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.1
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Website Analyzer
@@ -20,6 +20,13 @@ Trigger when the user asks to:
 - Understand a website's structure, style, or category
 
 Do **not** use for full penetration testing, deep security audits, or App Store ASO.
+
+## Prerequisites
+
+1. Require a valid `http://` or `https://` URL and an output path or stdout destination.
+2. Confirm page-fetch access is available; never bypass authentication, paywalls, or bot protections.
+3. When an output path is supplied, validate that its directory exists and is writable; skip this check for stdout.
+4. If any prerequisite fails, return a descriptive error with the failing input and corrective action.
 
 ## Workflow
 
@@ -162,7 +169,7 @@ When a sub-score cannot be computed (e.g. `robots.txt` unreachable), record the 
 - **Category**: `saas-landing` | `portfolio` | `e-commerce` | `blog` | `docs` | `dashboard` | `marketing-site` | `web-app` | `other`
 - **Style**: Typography, color palette, spacing density, motion indicators, aesthetic vibe
 
-## Error Handling
+## Edge Cases and Error Handling
 
 | Failure | Behavior |
 |---|---|
@@ -171,4 +178,30 @@ When a sub-score cannot be computed (e.g. `robots.txt` unreachable), record the 
 | Paywall / login | `{"error": "paywall"}` — stop |
 | Redirect loop | `{"error": "redirect-loop"}` — stop |
 | Empty page | `{"error": "empty"}` — stop |
+
+## Acceptance Criteria
+
+Verify the expected output before reporting success:
+
+- JSON parses and contains `url`, `timestamp`, `ui_ux`, `category`, `style`, `performance`, `security`, and `seo`.
+- `seo.score` is an integer from 0 through 100 and matches the weighted, null-adjusted dimension calculation.
+- Performance estimates include units or `_kb` suffixes and an explicit static-analysis limitation.
+- Every unavailable measurement is `null` or an error field, never an invented value.
+- The output is written to the requested destination; assert the file exists and can be parsed when a path is supplied.
+
+## Step Completion Report
+
+Emit this after analysis:
+
+```text
+◆ Analyze Website
+··································································
+  Input fetched:        √ pass | × fail ([reason])
+  Six dimensions:      √ pass | × partial ([missing])
+  SEO calculation:     √ pass | × partial ([null dimensions])
+  Output JSON:         √ pass ([path or stdout])
+  Result:              PASS | PARTIAL | FAIL
+```
+
+Report `PASS` only when the JSON is valid and all six top-level dimensions are present; use `PARTIAL` for explicitly labeled crawlability gaps.
 

--- a/skills/website-cloner/website-builder/SKILL.md
+++ b/skills/website-cloner/website-builder/SKILL.md
@@ -4,7 +4,7 @@ description: "Build an approved Vite/React/Tailwind plan, collect assets, verify
 license: MIT
 effort: high
 metadata:
-  version: 1.2.0
+  version: 1.3.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -27,6 +27,7 @@ Do **not** use for design review or planning — those are upstream phases.
 - `prd.md` (Phase 3 proposal) exists for alignment reference
 - Node.js and npm are available
 - Git is available for repository management
+- `website-analyzer` is installed for the comparable post-deployment audit
 
 ## Tech Stack
 
@@ -47,7 +48,8 @@ Do **not** use for design review or planning — those are upstream phases.
 5. Create new assets as specified
 6. Build and verify
 7. Deploy to GitHub Pages
-8. Emit builder metadata
+8. Re-audit the deployed URL for comparable after metrics
+9. Emit builder metadata
 ```
 
 ## Repo Sync Before Edits (mandatory)
@@ -181,9 +183,24 @@ Configure GitHub Pages:
 
 Report the GitHub Pages URL.
 
-## Step 7: Emit Builder Metadata
+## Step 7: Re-audit the Deployed Site
 
-Write a JSON metadata file for the final report phase:
+After the GitHub Pages URL responds successfully, run the same analyzer used for the baseline:
+
+```text
+/website-analyzer "https://<user>.github.io/<repo>/" --output "$PROJECT_DIR/after-analysis.json"
+```
+
+Require the analyzer's structured `performance`, `seo`, and `security` objects. The comparable
+performance fields are `lcp_estimate_seconds`, unitless `cls_estimate`,
+`ttfb_estimate_seconds`, `total_page_weight_kb`, and `request_count`. Preserve analyzer `null`
+values and caveats; do not turn estimates into measured values. If deployment or the re-audit
+fails, record the error and return `PARTIAL` rather than inventing an after snapshot.
+
+## Step 8: Emit Builder Metadata
+
+Write a JSON metadata file for the final report phase. Copy the post-deployment analyzer objects
+without changing their field names or units:
 
 ```json
 {
@@ -195,6 +212,40 @@ Write a JSON metadata file for the final report phase:
   "assets_created": ["cta-copy.txt", "hero-icon.svg", ...],
   "deviations": [],
   "build_output_size_kb": 450,
+  "after_snapshot_source": "after-analysis.json",
+  "after_snapshot_status": "complete | partial | unavailable",
+  "performance": {
+    "lcp_estimate_seconds": 1.8,
+    "cls_estimate": 0.03,
+    "ttfb_estimate_seconds": 0.2,
+    "total_page_weight_kb": 650,
+    "request_count": 32,
+    "notes": "estimated from static analysis"
+  },
+  "security": {
+    "https": true,
+    "mixed_content": false,
+    "security_headers": ["strict-transport-security"],
+    "exposed_metadata": [],
+    "note": "Surface-level check only. Not a full security audit."
+  },
+  "seo": {
+    "score": 94,
+    "title_tag": "present",
+    "meta_description": "present",
+    "heading_structure": "h1:1 h2:4",
+    "alt_text_coverage": 1.0,
+    "structured_data": "present",
+    "canonical_url": "present",
+    "robots_sitemap": "robots=ok | sitemap=found",
+    "dimension_scores": {
+      "meta_tags": 95,
+      "heading_structure": 85,
+      "image_alt_text": 100,
+      "structured_data": 100,
+      "crawlability": 90
+    }
+  },
   "tech_stack": {
     "bundler": "vite",
     "framework": "react",
@@ -204,7 +255,8 @@ Write a JSON metadata file for the final report phase:
 }
 ```
 
-Write to: `$PROJECT_DIR/builder-metadata.json`
+`build_output_size_kb` is the complete build artifact size, not page weight; never use it as
+`performance.total_page_weight_kb`. Write metadata to `$PROJECT_DIR/builder-metadata.json`.
 
 ## Acceptance Criteria
 
@@ -213,15 +265,17 @@ Verify the expected output before deployment is marked complete:
 - `npm run build` exits 0 and the configured static output directory exists.
 - Every approved task is represented in `tasks_completed` or named in `deviations`; assert `tasks_completed <= tasks_total`.
 - Internal routes and collected asset paths resolve under the GitHub Pages base path.
-- `builder-metadata.json` parses and contains the URL, task counts, asset lists, deviations, output size, and exact tech stack.
-- The reported Pages URL responds successfully after deployment, or the report is `PARTIAL` with the deployment error.
+- `builder-metadata.json` parses and contains the URL, task counts, asset lists, deviations, output size, exact tech stack, after-snapshot status, and structured performance/SEO/security objects.
+- A `PASS` result requires a responsive Pages URL and a complete comparable after snapshot with every required performance field, SEO overall/dimension score, and security check non-null.
+- Deployment, analyzer, or required after-value gaps are recorded and force `PARTIAL`; a metadata write failure is `FAIL`.
 - No credentials, local paths, or secret environment values appear in generated assets or metadata.
 
 ## Edge Cases
 
 - Existing repository or remote: inspect `git status` and `git remote -v`; confirm the target before changing either.
 - Dirty working tree: preserve user changes and follow the mandatory sync guardrail; never discard them.
-- Build succeeds but deployment fails: keep the verified local build, record the error, and return `PARTIAL`.
+- Build succeeds but deployment fails: keep the verified local build, record the error, set the after snapshot unavailable, and return `PARTIAL`.
+- Deployment succeeds but the re-audit is incomplete: preserve nulls and analyzer caveats, set `after_snapshot_status` to `partial`, and return `PARTIAL`.
 - A task conflicts with the approved PRD: stop that task and ask; do not silently reinterpret the plan.
 
 ## Step Completion Reports
@@ -255,7 +309,8 @@ Verify the expected output before deployment is marked complete:
 ······································································
   Repository created:     √ pass
   GitHub Pages configured: √ pass (<url>)
+  After snapshot:         √ complete | × partial ([missing])
   Metadata emitted:       √ pass
   ____________________________
-  Result:                 PASS
+  Result:                 PASS | PARTIAL | FAIL
 ```

--- a/skills/website-cloner/website-builder/SKILL.md
+++ b/skills/website-cloner/website-builder/SKILL.md
@@ -4,7 +4,7 @@ description: "Build an approved Vite/React/Tailwind plan, collect assets, verify
 license: MIT
 effort: high
 metadata:
-  version: 1.3.0
+  version: 1.3.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -102,7 +102,19 @@ npm install tailwindcss @tailwindcss/vite
 npm install class-variance-authority clsx tailwind-merge lucide-react
 ```
 
-Configure Tailwind and shadcn/ui. Set up the GitHub Pages deployment target.
+Configure Tailwind and shadcn/ui. Set up the GitHub Pages deployment target. In `vite.config.js` (or `.ts`), make the build base explicit so the workflow can select `/` for a user/organization Pages repository and `/<repo>/` for a project Pages repository:
+
+```js
+import { defineConfig } from "vite"
+import react from "@vitejs/plugin-react"
+
+export default defineConfig({
+  base: process.env.VITE_BASE_PATH || "/",
+  plugins: [react()],
+})
+```
+
+Use `import.meta.env.BASE_URL` for public asset URLs. For a client-routed SPA, prefer `HashRouter`; if the approved plan requires `BrowserRouter`, set its `basename` from `import.meta.env.BASE_URL` and provide a tested Pages 404 fallback. Do not leave root-relative asset or route URLs that bypass the configured base.
 
 ## Step 3: Execute Tasks Phase by Phase
 
@@ -168,20 +180,67 @@ Verify:
 
 ## Step 6: Deploy to GitHub Pages
 
-Create or update a GitHub repository for the site:
+Create `.github/workflows/deploy-pages.yml`. Pages must deploy the verified Vite `dist/` artifact through GitHub Actions—not the repository root or a branch folder:
 
-```bash
-git init
-git remote add origin git@github.com:<user>/<repo>.git
-git add .
-git commit -m "chore: initial site build"
-git push -u origin main
+```yaml
+name: Deploy Vite site to Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/configure-pages@v5
+      - run: npm ci
+      - name: Configure Vite base path
+        shell: bash
+        run: |
+          repo_name="${GITHUB_REPOSITORY#*/}"
+          if [[ "$repo_name" == *.github.io ]]; then
+            echo "VITE_BASE_PATH=/" >> "$GITHUB_ENV"
+          else
+            echo "VITE_BASE_PATH=/$repo_name/" >> "$GITHUB_ENV"
+          fi
+      - run: npm run build
+      - name: Verify static artifact
+        run: test -f dist/index.html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v4
 ```
 
-Configure GitHub Pages:
-- Repository Settings → Pages → Source: `main` branch, `/ (root)`
+Create or update the GitHub repository for the site, run the repository's required secret scan, then commit and push the project including `package-lock.json`, `vite.config.*`, and the workflow. In Repository Settings → Pages, select **GitHub Actions** as the source; never select `main / (root)` or `/docs` for this Vite build.
 
-Report the GitHub Pages URL.
+Verify the completed workflow uploaded `dist/`, the deploy job succeeded, and its `page_url` responds. Confirm project Pages uses `https://<user>.github.io/<repo>/`, while `<user>.github.io` repositories use the root URL. Report the deployed URL from the workflow output.
 
 ## Step 7: Re-audit the Deployed Site
 
@@ -262,9 +321,11 @@ without changing their field names or units:
 
 Verify the expected output before deployment is marked complete:
 
-- `npm run build` exits 0 and the configured static output directory exists.
+- `npm run build` exits 0 and `dist/index.html` exists.
+- `.github/workflows/deploy-pages.yml` runs `npm ci` and `npm run build`, uploads exactly `dist/` as a Pages artifact, and deploys it with the required Pages permissions and environment.
+- The workflow-derived `VITE_BASE_PATH` is `/` for user/organization Pages and `/<repo>/` for project Pages; Vite, internal routes, and asset URLs use that base consistently.
 - Every approved task is represented in `tasks_completed` or named in `deviations`; assert `tasks_completed <= tasks_total`.
-- Internal routes and collected asset paths resolve under the GitHub Pages base path.
+- Internal routes and collected asset paths resolve under the GitHub Pages base path, including a direct-refresh check for every supported route strategy.
 - `builder-metadata.json` parses and contains the URL, task counts, asset lists, deviations, output size, exact tech stack, after-snapshot status, and structured performance/SEO/security objects.
 - A `PASS` result requires a responsive Pages URL and a complete comparable after snapshot with every required performance field, SEO overall/dimension score, and security check non-null.
 - Deployment, analyzer, or required after-value gaps are recorded and force `PARTIAL`; a metadata write failure is `FAIL`.

--- a/skills/website-cloner/website-builder/SKILL.md
+++ b/skills/website-cloner/website-builder/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: website-builder
-description: "Execute the approved tasks.md to build a Vite + React + shadcn/ui + Tailwind CSS website deployable to GitHub Pages. Collects assets from the original site and creates new assets per plan. Emits builder metadata for the final report. Use when asked to build, implement, or code a website from a plan. Don't use for design review or planning — those are upstream phases."
+description: "Build an approved Vite/React/Tailwind plan, collect assets, verify static output, deploy to GitHub Pages, and emit metadata. Use for implementing tasks.md. Don't use for design review, planning, backend services, or unapproved specs."
 license: MIT
 effort: high
 metadata:
-  version: 1.0.2
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Website Builder
@@ -52,7 +52,13 @@ Do **not** use for design review or planning — those are upstream phases.
 
 ## Repo Sync Before Edits (mandatory)
 
-Before modifying any project files:
+Choose the repository branch before modifying project files:
+
+1. **Existing git worktree with `origin`:** preserve dirty changes, then sync before edits.
+2. **New project with no git repository or remote:** skip fetch/pull, initialize the project, and add the approved remote only during deployment.
+3. **Existing repository with an unexpectedly missing `origin`:** stop and ask; do not assume it is a new project.
+
+For the existing-worktree branch, run:
 
 ```bash
 branch="$(git rev-parse --abbrev-ref HEAD)"
@@ -69,7 +75,7 @@ git fetch origin && git pull --rebase origin "$branch"
 git stash pop
 ```
 
-If origin is missing or rebase fails, stop and ask.
+If rebase or stash restoration fails, stop and ask. Never discard user changes.
 
 ## Step 1: Read the Plan
 
@@ -199,6 +205,24 @@ Write a JSON metadata file for the final report phase:
 ```
 
 Write to: `$PROJECT_DIR/builder-metadata.json`
+
+## Acceptance Criteria
+
+Verify the expected output before deployment is marked complete:
+
+- `npm run build` exits 0 and the configured static output directory exists.
+- Every approved task is represented in `tasks_completed` or named in `deviations`; assert `tasks_completed <= tasks_total`.
+- Internal routes and collected asset paths resolve under the GitHub Pages base path.
+- `builder-metadata.json` parses and contains the URL, task counts, asset lists, deviations, output size, and exact tech stack.
+- The reported Pages URL responds successfully after deployment, or the report is `PARTIAL` with the deployment error.
+- No credentials, local paths, or secret environment values appear in generated assets or metadata.
+
+## Edge Cases
+
+- Existing repository or remote: inspect `git status` and `git remote -v`; confirm the target before changing either.
+- Dirty working tree: preserve user changes and follow the mandatory sync guardrail; never discard them.
+- Build succeeds but deployment fails: keep the verified local build, record the error, and return `PARTIAL`.
+- A task conflicts with the approved PRD: stop that task and ask; do not silently reinterpret the plan.
 
 ## Step Completion Reports
 

--- a/skills/website-cloner/website-clone-final-report/SKILL.md
+++ b/skills/website-cloner/website-clone-final-report/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: website-clone-final-report
-description: "Produce a before/after comparison report of a website clone project. Uses Phase 1 analysis as baseline and builder metadata as 'after' snapshot. Covers performance, SEO, security, UI/UX deltas, deviations, and GitHub Pages URL. Use when asked for a final report, before-after comparison, or project closure summary of a website clone. Don't use for ongoing monitoring or live site audits."
+description: "Generate a website-clone closure report comparing baseline analysis, builder metadata, planned tasks, and implemented results. Use after a completed rebuild. Don't use for live audits, ongoing monitoring, implementation, or speculative metrics."
 license: MIT
 effort: high
 metadata:
-  version: 1.0.1
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.3
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Website Clone Final Report
@@ -34,6 +34,8 @@ Do **not** use for ongoing monitoring or live site audits — those are separate
 ```
 
 ## Output: final-report.md Structure
+
+Use the report template below as the only output template. Read only the source sections needed for each comparison to preserve the context budget.
 
 ```markdown
 # Final Report: <site name> Clone
@@ -192,7 +194,32 @@ Final report saved to: <absolute-path>
 GitHub Pages URL: <url>
 ```
 
-## Error Handling
+## Acceptance Criteria and Expected Output
+
+Verify the report before saving:
+
+- Every source file is named as present or missing; no absent input is silently treated as evidence.
+- For each metric with both before and after values, show the formula, unit, and correctly rounded delta; mark unavailable after-values explicitly and never invent them.
+- Each qualitative claim cites an implemented task, builder deviation, or baseline observation.
+- `final-report.md` contains implementation summary, performance, SEO, security, UI/UX, deviations, caveats, and Pages URL sections.
+- The expected result is `PASS` when the saved markdown is non-empty and every available comparison is supported; unavailable metrics are explained rather than treated as failures.
+
+## Step Completion Report
+
+```text
+◆ Final Comparison Report
+··································································
+  Inputs accounted for: √ pass | × partial ([missing])
+  Deltas verified:      √ pass | × partial ([unavailable])
+  Deviations compared:  √ pass
+  Report saved:         √ pass ([absolute path])
+  Pages URL:            √ pass | × unavailable
+  Result:               PASS | PARTIAL | FAIL
+```
+
+Use `PASS` only when every required input is accounted for and each available comparison is supported. Missing required inputs force `PARTIAL`; unavailable optional metrics are labeled, and a write failure is `FAIL`.
+
+## Edge Cases and Error Handling
 
 | Failure | Behavior |
 |---|---|

--- a/skills/website-cloner/website-clone-final-report/SKILL.md
+++ b/skills/website-cloner/website-clone-final-report/SKILL.md
@@ -4,13 +4,13 @@ description: "Generate a website-clone closure report comparing baseline analysi
 license: MIT
 effort: high
 metadata:
-  version: 1.2.3
+  version: 1.3.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Website Clone Final Report
 
-Produces a before/after comparison report closing the loop on a website clone project. Uses Phase 1 analysis as baseline and builder metadata as the "after" snapshot.
+Produces a before/after comparison report closing the loop on a website clone project. Uses Phase 1 analysis as the baseline and the builder's post-deployment re-audit as the comparable "after" snapshot.
 
 ## When to Use
 
@@ -24,7 +24,7 @@ Do **not** use for ongoing monitoring or live site audits — those are separate
 ## Workflow
 
 ```
-1. Read Phase 1 analysis (baseline) and builder metadata (after)
+1. Read Phase 1 analysis (baseline) and validate builder metadata's post-deployment after snapshot
 2. Read tasks.md for what was implemented
 3. Read prd.md for what was planned
 4. Compute before/after deltas per dimension
@@ -62,11 +62,11 @@ A plain-language summary of what was built, drawn from tasks.md:
 
 | Metric | Before | After | Delta |
 |--------|--------|-------|-------|
-| LCP | 4.3s | 1.8s | -58% |
-| CLS | 0.18 | 0.03 | -83% |
-| TTFB | 0.8s | 0.2s | -75% |
-| Page Weight | 2.1 MB | 650 KB | -69% |
-| Requests | 87 | 32 | -63% |
+| LCP estimate (seconds) | 4.3 | 1.8 | -58% |
+| CLS estimate (unitless) | 0.18 | 0.03 | -83% |
+| TTFB estimate (seconds) | 0.8 | 0.2 | -75% |
+| Page Weight (KB) | 2100 | 650 | -69% |
+| Requests (count) | 87 | 32 | -63% |
 
 ### SEO
 
@@ -75,16 +75,18 @@ A plain-language summary of what was built, drawn from tasks.md:
 | Overall Score | 62/100 | 94/100 | +52% |
 | Meta Tags | 60 | 95 | +58% |
 | Heading Structure | 50 | 85 | +70% |
-| Alt Text Coverage | 30% | 100% | +233% |
-| Structured Data | 0 | 100 | +100% |
+| Alt Text Score | 30/100 | 100/100 | +233% |
+| Structured Data | 20/100 | 100/100 | +400% |
+| Crawlability | 60/100 | 90/100 | +50% |
 
 ### Security
 
 | Check | Before | After |
 |-------|--------|-------|
 | HTTPS | Yes | Yes |
-| Security Headers | Partial | Strong |
-| Mixed Content | 2 issues | 0 issues |
+| Mixed Content | Detected | Not detected |
+| Security Headers Detected | 2 | 4 |
+| Exposed Metadata Findings | 2 | 0 |
 
 ### UI/UX Changes
 
@@ -126,8 +128,8 @@ the URL above."
 
 ---
 
-*This report was generated from the Phase 1 analysis baseline and builder metadata.*
-*All metrics are based on automated analysis and may not reflect actual user experience.*
+*This report was generated from the Phase 1 analysis baseline and the builder's post-deployment re-audit.*
+*LCP, CLS, TTFB, page weight, and request values are static-analysis estimates, not field measurements.*
 ```
 
 ## Step 1: Read Inputs
@@ -146,19 +148,28 @@ Read file <path-to-tasks.md>
 Read file <path-to-prd.md>
 ```
 
-If any input is missing, note it and proceed with what's available.
+Validate `builder-metadata.json` has `after_snapshot_source`, `after_snapshot_status`, and the
+embedded `performance`, `seo`, and `security` objects copied from the post-deployment analyzer run.
+If any input is missing, note it and proceed only to produce a clearly `PARTIAL` report.
 
 ## Step 2: Compute Deltas
 
-Compare baseline metrics against builder metadata:
+Compare matching baseline and after-snapshot fields:
 
-| Metric | Source | Delta |
-|--------|--------|-------|
-| LCP, CLS, TTFB, page weight, requests | Phase 1 analysis vs. builder metadata | after - before |
-| SEO score, dimension scores | Phase 1 analysis vs. builder metadata | after - before |
-| Security checks | Phase 1 analysis vs. builder metadata | qualitative comparison |
+| Metric | Baseline source | After source |
+|--------|-----------------|--------------|
+| LCP estimate (seconds) | `analysis.performance.lcp_estimate_seconds` | `builder.performance.lcp_estimate_seconds` |
+| CLS estimate (unitless) | `analysis.performance.cls_estimate` | `builder.performance.cls_estimate` |
+| TTFB estimate (seconds) | `analysis.performance.ttfb_estimate_seconds` | `builder.performance.ttfb_estimate_seconds` |
+| Page weight (KB), requests (count) | `analysis.performance.*` | `builder.performance.*` |
+| SEO score and five dimension scores | `analysis.seo.*` | `builder.seo.*` |
+| HTTPS, mixed content, header list, exposed metadata | `analysis.security.*` | `builder.security.*` |
 
-For UI/UX, describe changes based on the tasks.md implementation vs. the Phase 1 analysis.
+For numeric metrics, normalize to the displayed unit and calculate percentage delta as
+`((after - before) / before) × 100`, rounded to the nearest whole percent. If the baseline is zero,
+show the absolute `after - before` change and label percentage delta `N/A (zero baseline)`. Compare
+security booleans directly and arrays by reproducible counts; do not invent qualitative ratings.
+For UI/UX, describe changes based on tasks.md versus the Phase 1 analysis.
 
 ## Step 3: Identify Deviations
 
@@ -199,10 +210,12 @@ GitHub Pages URL: <url>
 Verify the report before saving:
 
 - Every source file is named as present or missing; no absent input is silently treated as evidence.
-- For each metric with both before and after values, show the formula, unit, and correctly rounded delta; mark unavailable after-values explicitly and never invent them.
+- Required comparison data comprises all five performance fields, SEO overall score plus all five dimension scores, and the four security fields (`https`, `mixed_content`, `security_headers`, `exposed_metadata`) in both snapshots.
+- For each numeric metric, show the formula, deterministic unit, and correctly rounded delta; label estimates and never invent unavailable values.
 - Each qualitative claim cites an implemented task, builder deviation, or baseline observation.
 - `final-report.md` contains implementation summary, performance, SEO, security, UI/UX, deviations, caveats, and Pages URL sections.
-- The expected result is `PASS` when the saved markdown is non-empty and every available comparison is supported; unavailable metrics are explained rather than treated as failures.
+- `PASS` requires valid baseline, builder metadata, tasks, and PRD inputs; a responsive Pages URL; `after_snapshot_status: complete`; every required comparison supported; and a non-empty saved report.
+- `PARTIAL` is mandatory when the report is saved but any required input, URL, snapshot, metric, or comparison is missing, null, invalid, or unavailable. A report write failure or inability to produce a valid report is `FAIL`.
 
 ## Step Completion Report
 
@@ -217,12 +230,13 @@ Verify the report before saving:
   Result:               PASS | PARTIAL | FAIL
 ```
 
-Use `PASS` only when every required input is accounted for and each available comparison is supported. Missing required inputs force `PARTIAL`; unavailable optional metrics are labeled, and a write failure is `FAIL`.
+Use `PASS` only when every required comparison above is supported. Any unavailable required before/after value forces `PARTIAL`, even when the report can explain the gap; never promote unavailable comparisons to `PASS`.
 
 ## Edge Cases and Error Handling
 
 | Failure | Behavior |
 |---|---|
-| No analysis input | Note missing baseline, proceed with qualitative comparison |
-| No builder metadata | Note missing after data, request builder metadata from orchestrator |
-| No tasks.md | Describe what was implemented based on available data only |
+| No analysis input | Produce a qualitative report only if useful; result is `PARTIAL` |
+| No builder metadata | Request builder metadata from the orchestrator; any saved report is `PARTIAL` |
+| Missing/incomplete after snapshot | Preserve unavailable values and analyzer errors; result is `PARTIAL` |
+| No tasks.md or prd.md | Describe only supported implementation/deviation facts; result is `PARTIAL` |

--- a/skills/website-cloner/website-clone-report/SKILL.md
+++ b/skills/website-cloner/website-clone-report/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: website-clone-report
-description: "Convert website analyzer output into a comprehensive plain-language report for non-technical users. Prompts for validation before persisting. Use when asked to report on a website analysis, create an end-user report, or translate technical metrics into plain language. Don't use for technical audit reports targeting developers, raw SEO audits, or penetration testing. Approval gate: never saves without explicit user approval."
+description: "Generate a plain-language report from website-analyzer JSON and save it only after explicit approval. Use for non-technical summaries. Don't use for developer audits, raw SEO analysis, penetration testing, or unapproved persistence."
 license: MIT
 effort: high
 metadata:
-  version: 1.0.2
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.1
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Website Clone Report
@@ -20,6 +20,13 @@ Trigger when the user asks to:
 - Produce an end-user summary of a site assessment
 
 Do **not** use for technical audit reports targeting developers — those belong to the analyzer skill.
+
+## Prerequisites
+
+1. Require valid website-analyzer JSON and a proposed output path.
+2. Read `references/api_reference.md` when validating fields or translating metrics; use only the needed reference mappings to protect the context budget.
+3. Confirm the user can review the draft and explicitly approve persistence.
+4. Stop with a descriptive error when the JSON is invalid or contains an analyzer `error` variant.
 
 ## Workflow
 
@@ -171,11 +178,38 @@ After the `Write` call returns, confirm to the user:
 Report saved to: <absolute-path>
 ```
 
-## Error Handling
+## Acceptance Criteria and Expected Output
+
+Verify the approved report before saving:
+
+- It covers UI/UX, category, style, performance, surface security, SEO, and next steps, or names each unavailable dimension.
+- Every metric and observation traces to the analyzer JSON; assert that no unsupported benchmark or claim was invented.
+- Language is understandable without developer terminology, while the security and single-page-crawl caveats remain explicit.
+- The expected result is a non-empty approved markdown file at the resolved path, written only after explicit approval such as `Approve`.
+- Re-read the saved file state or Write result and report its absolute path.
+
+## Edge Cases and Error Handling
 
 | Failure | Behavior |
 |---|---|
 | No analyzer input provided | Ask for the analysis JSON file path |
 | Invalid JSON | Report error and ask for valid input |
+| Analyzer error variant | Surface its `error` and `detail`; do not draft a health report |
+| Missing or null dimension | Omit unsupported specifics and identify the gap in next steps |
 | User never approves | Keep the loop going; do not auto-save |
+
+## Step Completion Report
+
+```text
+◆ Website Clone Report
+··································································
+  Analyzer JSON:        √ pass | × fail ([reason])
+  Six dimensions:      √ translated | × partial ([missing])
+  Draft reviewed:      √ pass
+  User approved:       √ pass | × pending
+  Report saved:        √ pass ([absolute path]) | — not approved
+  Result:              PASS | BLOCKED | FAIL
+```
+
+Never report `PASS` before both explicit approval and a successful Write result.
 

--- a/skills/website-cloner/website-clone-report/SKILL.md
+++ b/skills/website-cloner/website-clone-report/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate a plain-language report from website-analyzer JSON and sa
 license: MIT
 effort: high
 metadata:
-  version: 1.2.1
+  version: 1.2.2
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -86,6 +86,7 @@ Translate metrics to plain language:
   For comparison, sites that load in under 2 seconds tend to keep visitors engaged."
 - **Visual stability:** "The page layout is mostly stable while loading.
   You're unlikely to notice elements jumping around."
+- **How quickly the server responds:** "The estimated server response delay is X seconds."
 - **How much data it uses:** "The page weighs about X KB, roughly equivalent to
   loading Y average-sized images."
 - **Number of resources:** "The page makes about X requests to load."
@@ -136,8 +137,9 @@ For each dimension:
 - **Category**: Explain what kind of site it is in plain terms.
 - **Style**: Describe the feel and look without needing CSS knowledge.
 - **Performance**: Translate numbers to relatable comparisons:
-  - LCP: "how fast the main content appears"
-  - CLS: "how stable the page feels while loading"
+  - `lcp_estimate_seconds`: "how fast the main content appears" (estimated seconds)
+  - `cls_estimate`: "how stable the page feels while loading" (unitless)
+  - `ttfb_estimate_seconds`: "how quickly the server responds" (estimated seconds)
   - Page weight: "how much data the page uses"
   - Request count: "how many pieces the page needs to load"
 - **Security**: Surface-level observations only, no technical headers jargon.

--- a/skills/website-cloner/website-clone-report/references/api_reference.md
+++ b/skills/website-cloner/website-clone-report/references/api_reference.md
@@ -27,9 +27,9 @@ The skill expects JSON in this shape (see `skills/website-cloner/website-analyze
     "aesthetic": "vibe description"
   },
   "performance": {
-    "lcp_estimate": 2.5,
+    "lcp_estimate_seconds": 2.5,
     "cls_estimate": 0.05,
-    "ttfb_estimate": 0.3,
+    "ttfb_estimate_seconds": 0.3,
     "total_page_weight_kb": 1200,
     "request_count": 45,
     "notes": "estimated from static analysis"
@@ -80,8 +80,9 @@ Error variant (skill should report and stop, not produce a report):
 | `style.palette` | Design and Style | Translate hex to color families: "cool blues and grays with orange accents". |
 | `style.spacing` | Design and Style | "compact" → "densely packed"; "spacious" → "lots of breathing room". |
 | `style.motion` | Design and Style | "heavy" → "lots of animation"; "minimal" → "very little movement". |
-| `performance.lcp_estimate` | Performance | "How fast content appears". Benchmarks: < 2.5s good, 2.5–4s fair, > 4s slow. |
-| `performance.cls_estimate` | Performance | "How stable the page feels while loading". < 0.1 stable, ≥ 0.25 jumpy. |
+| `performance.lcp_estimate_seconds` | Performance | "How fast content appears". This is an estimate in seconds; benchmarks: < 2.5s good, 2.5–4s fair, > 4s slow. |
+| `performance.cls_estimate` | Performance | "How stable the page feels while loading". This estimate is unitless; < 0.1 stable, ≥ 0.25 jumpy. |
+| `performance.ttfb_estimate_seconds` | Performance | "How quickly the server responds". This is an estimate in seconds; label it as estimated. |
 | `performance.total_page_weight_kb` | Performance | "How much data the page uses". Compare to images: "≈ N average photos worth". |
 | `performance.request_count` | Performance | "Number of pieces the page needs to load". |
 | `security.https` / `mixed_content` | Security Overview | HTTPS + no mixed content → "encrypted from end to end". |

--- a/skills/website-cloner/website-implementation-plan/SKILL.md
+++ b/skills/website-cloner/website-implementation-plan/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: website-implementation-plan
-description: "Turn approved prd.md into a phased implementation plan with landing page first, asset collection vs creation, individual tasks. Writes tasks.md after user approval. Use when asked to plan website implementation, create an implementation plan, or break down a PRD into tasks. Don't use for building or coding — that's a separate phase."
+description: "Generate phased tasks.md from an approved website PRD, with landing page first, measurable tasks, and collect/create asset tracking. Use for implementation planning. Don't use for coding, design review, unapproved PRDs, or direct deployment."
 license: MIT
 effort: high
 metadata:
-  version: 1.1.0
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.3.1
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Website Implementation Plan
@@ -35,6 +35,8 @@ Do **not** use for building or coding — that is Phase 5 (website-builder).
 ```
 
 ## Output: tasks.md Structure
+
+Use the tasks.md template below as the only output template. Read only the PRD sections needed for the current phase to preserve the context budget.
 
 ```markdown
 # Implementation Plan: <site name>
@@ -236,10 +238,38 @@ The orchestrator MUST NOT advance to Phase 5 unless the outcome is `approved`.
 A standalone invocation may ignore the status line, but the file-existence rule
 still holds: no approval, no `tasks.md`.
 
-## Error Handling
+## Acceptance Criteria and Expected Output
+
+Verify the complete plan before requesting approval:
+
+- Every in-scope PRD requirement maps to at least one numbered task or an explicitly justified exclusion.
+- Phase 1 produces an independently usable landing page; later phases preserve dependency order.
+- Every task has bounded scope, concrete outputs, measurable acceptance criteria, and all required assets classified as `[Collect]` or `[Create]`.
+- Asset Summary contains every asset named by a task exactly once with a source and action.
+- The expected result is valid markdown at the approved path plus exactly one final `STATUS: approved`; pending or aborted outcomes write no file.
+
+## Step Completion Report
+
+```text
+◆ Implementation Plan
+··································································
+  Approved PRD:         √ pass | × fail ([reason])
+  Landing page first:  √ pass
+  Tasks measurable:    √ pass ([count])
+  Assets classified:   √ pass ([collect]/[create])
+  User approved:       √ pass | × pending
+  tasks.md saved:      √ pass ([absolute path]) | — not approved
+  Result:              PASS | BLOCKED | FAIL
+```
+
+Report `PASS` only when the return contract's file and final status-line conditions both hold.
+
+## Edge Cases and Error Handling
 
 | Failure | Behavior |
 |---|---|
 | No prd.md provided | Ask for the PRD file path |
 | Invalid PRD format | Report error and ask for valid file |
+| Conflicting PRD requirements | Surface the conflict and ask before task decomposition |
+| No assets required | Include an empty Asset Summary and state that no collection or creation is needed |
 | User never approves | Keep looping; do not auto-save |

--- a/skills/website-cloner/website-implementation-plan/SKILL.md
+++ b/skills/website-cloner/website-implementation-plan/SKILL.md
@@ -4,7 +4,7 @@ description: "Generate phased tasks.md from an approved website PRD, with landin
 license: MIT
 effort: high
 metadata:
-  version: 1.3.1
+  version: 1.3.2
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -55,14 +55,17 @@ The landing/home page is built first so it can be shown to potential users early
 
 ### Task 1.1: Project Setup
 
-**Scope:** Initialize Vite + React + shadcn/ui + Tailwind CSS project. Configure build, routing, and deployment to GitHub Pages.
+**Scope:** Initialize Vite + React + shadcn/ui + Tailwind CSS project. Configure build, base-aware routing/assets, and deterministic GitHub Actions Pages artifact deployment.
 
-**Outputs:** Working project scaffold with build pipeline.
+**Outputs:** Working project scaffold, base-aware Vite configuration, and `.github/workflows/deploy-pages.yml`.
 
 **Acceptance Criteria:**
 - `npm run dev` starts a local dev server
-- `npm run build` produces static assets in dist/
-- GitHub Pages deployment configured
+- `npm run build` produces `dist/index.html`
+- `vite.config.*` consumes `VITE_BASE_PATH`; the workflow sets `/` for user/organization Pages and `/<repo>/` for project Pages
+- Internal routes and public assets resolve under the configured base; the selected SPA route strategy has a direct-refresh check
+- The Pages workflow runs `npm ci` and `npm run build`, uploads exactly `dist/` with `actions/upload-pages-artifact`, and deploys it with `actions/deploy-pages`
+- Pages source is GitHub Actions, never repository-root, `/docs`, or branch-folder publishing
 
 **Assets Needed:**
 - [Collect] Logo, brand colors, brand name from original site
@@ -143,9 +146,10 @@ Performance, SEO, and security improvements from the PRD.
 
 ## Deployment
 
-1. Push to GitHub repository
-2. Configure GitHub Pages (settings → Pages → source: main /docs or /)
-3. Verify deployment at `https://<user>.github.io/<repo>/`
+1. Include `package-lock.json`, base-aware `vite.config.*`, and `.github/workflows/deploy-pages.yml` in the implementation tasks.
+2. Push the approved project to the default branch and configure Repository Settings → Pages → Source as **GitHub Actions**.
+3. Require the workflow to build and verify `dist/index.html`, upload exactly `dist/` as the Pages artifact, and deploy that artifact.
+4. Verify project Pages at `https://<user>.github.io/<repo>/`; for a `<user>.github.io` repository, verify the root URL instead.
 
 ---
 
@@ -245,6 +249,7 @@ Verify the complete plan before requesting approval:
 - Every in-scope PRD requirement maps to at least one numbered task or an explicitly justified exclusion.
 - Phase 1 produces an independently usable landing page; later phases preserve dependency order.
 - Every task has bounded scope, concrete outputs, measurable acceptance criteria, and all required assets classified as `[Collect]` or `[Create]`.
+- Project setup includes the artifact-based Pages workflow, deterministic Vite base-path behavior, and route/asset checks; no plan publishes Vite output from repository root or `/docs`.
 - Asset Summary contains every asset named by a task exactly once with a source and action.
 - The expected result is valid markdown at the approved path plus exactly one final `STATUS: approved`; pending or aborted outcomes write no file.
 

--- a/skills/website-cloner/website-improvement-prd/SKILL.md
+++ b/skills/website-cloner/website-improvement-prd/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: website-improvement-prd
-description: "Turn approved end-user report into a full improvement proposal with what/why/value for each change. Writes prd.md after user approval. Use when asked to propose website improvements, create a PRD for a site rebuild, or plan improvements with measurable impact. Don't use for implementation planning or coding — those are separate phases."
+description: "Generate an approval-gated improvement PRD from a report and baseline, with evidence-backed what/why/value changes and measurable targets. Use for rebuild proposals. Don't use for task breakdown, coding, implementation, or unapproved persistence."
 license: MIT
 effort: high
 metadata:
-  version: 1.1.1
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.3.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Website Improvement PRD
@@ -189,11 +189,38 @@ The orchestrator MUST NOT advance to Phase 4 unless the outcome is `approved`.
 A standalone invocation may ignore the status line, but the file-existence rule
 still holds: no approval, no `prd.md`.
 
-## Error Handling
+## Acceptance Criteria and Expected Output
+
+Verify the complete proposal before requesting approval:
+
+- Every proposed change contains a specific What, evidence-backed Why, and measurable Expected Value.
+- Every baseline issue from the approved report or analysis maps to a proposal change or an explicit out-of-scope rationale.
+- Metric targets include units, current values, realistic target logic, and correctly computed deltas; label estimates rather than presenting them as guarantees.
+- `prd.md` contains executive summary, current state, grouped improvements, metrics summary, next steps, and source-data caveat.
+- The expected result is an approved non-empty markdown file plus exactly one final `STATUS: approved`; pending or aborted outcomes write no file.
+
+## Step Completion Report
+
+```text
+◆ Website Improvement PRD
+··································································
+  Inputs validated:     √ pass | × fail ([reason])
+  Changes evidenced:   √ pass ([count])
+  Targets measurable:  √ pass
+  User approved:       √ pass | × pending
+  prd.md saved:        √ pass ([absolute path]) | — not approved
+  Result:              PASS | BLOCKED | FAIL
+```
+
+Report `PASS` only when the return contract's file and final status-line conditions both hold.
+
+## Edge Cases and Error Handling
 
 | Failure | Behavior |
 |---|---|
 | No input files provided | Ask for report.md and analysis.json paths |
 | Invalid input format | Report error and ask for valid files |
+| Report and analysis conflict | Cite both values and ask which approved baseline governs |
+| Missing baseline metric | Propose a qualitative change or mark the target unavailable; never invent a number |
 | User never approves | Keep looping; do not auto-save |
 


### PR DESCRIPTION
Type: chore

## Summary
- improve skill instructions, gates, and predictable output contracts
- strengthen error handling in bundled Python utilities
- add focused fork-sync command validation guidance
- improve website-cloner child-skill workflows

## Validation
- quick_validate.py passed for all 40 skills
- python3 -m py_compile passed for all changed Python scripts
- git diff --check passed
- focused screenshot probes passed for existing and missing paths
- README catalog versions match all 40 current SKILL.md versions

## Decision Record
- Root cause: Review cycle 2 exposed path and routing ambiguity, invalid list metadata in screenshot collection, and a Vite build/deployment source mismatch.
- Options considered: Preserve combined/default behavior with stronger warnings, or make each destructive/routing/deployment transition explicit and independently verifiable.
- Options rejected: A combined Path B+C command sequence for conflict-only repairs, implicit draw.io selection after no answer, metadata attached to a built-in list, and Pages publishing from the repository root.
- Selected option:
  - Keep format-specific diagram requests strict; fallback requires approval only when format/aesthetic is ambiguous.
  - Use unit-bearing website performance fields and the same analyzer for baseline and post-deployment snapshots.
  - Propagate PARTIAL whenever a required before/after comparison is unavailable.
  - Isolate fork-sync paths, return typed screenshot collection results, and deploy base-aware Vite `dist/` through a GitHub Actions Pages artifact.
- Residual risk: Pages availability and post-deployment analyzer reachability remain external dependencies; failures are surfaced as PARTIAL rather than hidden.

## Acceptance Criteria Verification
| Finding | Verification |
|---|---|
| Fork fetch syntax | Upstream and origin are fetched separately. |
| Diagram fallback | Explicit unavailable engines stop with install guidance; ambiguous fallback requires approval. |
| SEO `--max-files` | Missing, option-like, non-integer, zero, and negative values exit nonzero with stderr guidance. |
| Website metric units | LCP/TTFB use deterministic seconds fields across producer and consumers. |
| Final comparisons | Builder re-audits after deployment; missing required comparisons force PARTIAL/FAIL. |
| Fork path isolation | Path B-only stops after feature-branch push and PR verification; default-branch reset/push is limited to approved Path C, B+C, or D. |
| Screenshot missing paths | Typed collection results reach actionable missing-path stderr guidance without crashing. |
| Pages deployment | GitHub Actions builds base-aware Vite output and deploys the verified `dist/` artifact. |
| Catalog versions | README catalog entries match all 40 current SKILL.md metadata versions. |
