### PR TITLE
feat(skills): add orchestrator context gate with HANDOFF succession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 | Skill | Version |
 |-------|---------|
 | fork-upstream-sync | 1.0.3 |
-| herdr-agent-comms | 1.21.0 |
+| herdr-agent-comms | 1.23.0 |
 | issue-work-loop | 1.1.5 |
 | diagram-generator | 1.0.0 (umbrella routing draw.io + Excalidraw) |
 
@@ -25,7 +25,7 @@
 | Skill | Version Change |
 |-------|----------------|
 | docs-generator → doc-manager | 1.2.5 → 2.0.1 |
-| tmux-agent-comms | 1.3.0 → 1.9.0 (observability + app terminal tabs by default) |
+| tmux-agent-comms | 1.3.0 → 2.2.0 (observability, app terminal tabs by default, orchestrator context handoff) |
 | landing-page-generator | 1.1.4 → 1.2.0 (absorbs README-to-landing as Mode B) |
 | code-review | 1.2.0 → 2.0.1 (merge code-optimizer + clean-code + slop-cleanup as modes) |
 | drawio-generator | 1.2.2 → 1.2.3 (nested under diagram-generator umbrella) |
@@ -52,6 +52,8 @@
 | tad-generator | → 1.4.0 |
 | tasks-generator | → 1.3.0 |
 | website-cloner | → 1.1.6 |
+
+**Orchestrator context handoff (herdr-agent-comms 1.23.0, tmux-agent-comms 2.2.0):** the main agent now gates its own context window instead of only its workers'. It self-checks usage at three named points — before a spawn wave, before a broadcast, and after each relayed reply — and at or above a 50% threshold (overridable in conversation) performs a **HANDOFF**: it spawns a successor orchestrator with the skill's own guarded spawn path (`main-g<N>` pane in Herdr, `<folder>-main-g<N>` session in tmux), delivers a compact fleet brief through the normal baseline/marker/preflight cycle, waits for an explicit `HANDOFF ACCEPTED` ack, then goes read-only and announces the successor. Orchestrator is now a **role, not a pane** — the outgoing pane/session is retired, never closed without confirmation — and exactly one orchestrator holds write access at a time. When usage is unreportable, a countable fallback (20 relayed reads or 4 spawn waves) drives the same decision. See `references/context-succession.md` in either skill.
 
 **Breaking (doc-manager):** `docs-generator` renamed to `doc-manager`; the `/docs-generator` invocation and `--skill docs-generator` install path are removed — use `/doc-manager`. Reoriented from "restructure docs into a hierarchy" to "generate missing or update existing docs so every page matches the code." New behavior: every non-obvious claim is cited to `path:line`, ambiguities are resolved by asking and logged to `docs/DECISIONS.md`, nothing is invented. Runbook (deploy/setup/process) docs additionally get a check-only `validate.sh` and a maintained `docs/troubleshooting.md`. **2.0.1:** runbook acceptance no longer hard-requires live `--check` exit 0 for operator env/network prereqs; validate script template parses all flags (`--check` + `--run-destructive`).
 

--- a/README.md
+++ b/README.md
@@ -241,9 +241,9 @@ Adjacent skills: **test-coverage** (generate tests for untested branches) · **d
 | [**ollama-optimizer**](skills/ollama-optimizer/) | 1.1.1 | medium | Hardware-aware Ollama tuning |
 | [**install-script-generator**](skills/install-script-generator/) | 2.2.1 | high | Cross-platform install.sh with env detection |
 | [**opencode-runner**](skills/opencode-runner/) | 1.4.1 | medium | Delegate work to opencode free cloud models |
-| [**herdr-agent-comms**](skills/herdr-agent-comms/) | 1.22.2 | medium | Manage Herdr agent fleets: tile panes, message/wait/read, steer |
+| [**herdr-agent-comms**](skills/herdr-agent-comms/) | 1.23.0 | medium | Manage Herdr agent fleets: tile panes, message/wait/read, steer |
 | [**issue-work-loop**](skills/issue-work-loop/) | 1.3.1 | max | Resolve one GitHub issue via a Herdr implementer→reviewer loop until CLEAN |
-| [**tmux-agent-comms**](skills/tmux-agent-comms/) | 2.1.0 | medium | Spawn, message, read CLI agents in tmux |
+| [**tmux-agent-comms**](skills/tmux-agent-comms/) | 2.2.0 | medium | Spawn, message, read CLI agents in tmux |
 
 ---
 

--- a/skills/herdr-agent-comms/SKILL.md
+++ b/skills/herdr-agent-comms/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires `herdr` on PATH and a running Herdr server (`herdr status`)."
 effort: medium
 metadata:
-  version: 1.22.2
+  version: 1.23.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -25,11 +25,13 @@ Use Herdr concepts, not tmux assumptions. Prefer status-aware helpers and relay 
 | Broadcast to a fleet | Phases 3 and 6 |
 | Focus/steer a pane | Phase 3, then Phase 6 |
 | Close workers | Phase 6 teardown |
+| Main agent's own context is filling up | Phase 7 HANDOFF |
 
 Read only the reference needed by that branch:
 
 - See `references/herdr-recipes.md` for guarded grid spawning, equalization semantics, multi-line sends, focus, and troubleshooting.
 - See `references/delivery-and-waiting.md` for preflight, completion markers, delivery verification, wait outcomes, and concurrent waits.
+- See `references/context-succession.md` for the main agent's context gate, HANDOFF procedure, and handoff brief template.
 
 ## Check Prerequisites
 
@@ -40,13 +42,15 @@ Read only the reference needed by that branch:
 
 ## Follow Non-Negotiable Rules
 
-1. **Keep root.** Never replace or close the root pane during fleet work.
-2. **Parse IDs.** Read opaque workspace/tab/pane IDs from JSON; never infer them from display order.
-3. **Use one equal-width row.** Split the current rightmost pane `right`, keep every worker in the root tab, then run the equalizer. Create separate tabs only when the user explicitly requests isolation.
-4. **Fail closed before writes.** Reject missing, ambiguous, `working`, `blocked`, malformed, or off-enum targets. Only a verified safe status may receive input.
-5. **Wait before follow-ups.** Never send while an agent is working. Every follow-up gets a fresh baseline and completion marker.
-6. **Surface blockers.** A trust, auth, or permission prompt needs a human; do not type a task or recovery Enter into it.
-7. **Confirm destruction.** Closing panes, tabs, workspaces, or the server can lose work. Obtain explicit approval and preserve root unless the user says otherwise.
+1. **Keep root as a role.** Never replace or close the root pane during fleet work. The one exception is a Phase 7 HANDOFF, where the orchestrator role migrates to a ready successor pane; even then the outgoing pane is retired to read-only, never closed without Rule 8 confirmation.
+2. **Run exactly one orchestrator.** Only the current main agent writes to fleet panes. After a HANDOFF ack, the outgoing agent issues no further sends, splits, or closes — two orchestrators writing the same panes corrupt each other's baselines.
+3. **Parse IDs.** Read opaque workspace/tab/pane IDs from JSON; never infer them from display order.
+4. **Use one equal-width row.** Split the current rightmost pane `right`, keep every worker in the root tab, then run the equalizer. Create separate tabs only when the user explicitly requests isolation.
+5. **Fail closed before writes.** Reject missing, ambiguous, `working`, `blocked`, malformed, or off-enum targets. Only a verified safe status may receive input.
+6. **Wait before follow-ups.** Never send while an agent is working. Every follow-up gets a fresh baseline and completion marker.
+7. **Surface blockers.** A trust, auth, or permission prompt needs a human; do not type a task or recovery Enter into it.
+8. **Confirm destruction.** Closing panes, tabs, workspaces, or the server can lose work. Obtain explicit approval and preserve the orchestrator pane unless the user says otherwise.
+9. **Gate your own context.** Self-check at every Phase 7 gate point; at or above the threshold, HANDOFF instead of continuing to fill this window.
 
 ## Phase 1 — Resolve Root Context
 
@@ -113,6 +117,22 @@ Accept `idle` or `done` after observed work. Read a capped `recent-unwrapped` tr
 
 **Done when:** every requested target has a recorded outcome and destructive actions match the user's confirmed scope.
 
+## Phase 7 — Hand Off the Orchestrator Role
+
+Long fleet runs outlive one context window. Self-check your own usage at three gate points — before a spawn wave, before a broadcast, and after each relayed reply — never mid-cycle between a dispatch and its wait.
+
+| Self-reported usage | Action |
+|---|---|
+| `P >= threshold` (default 50, overridable in conversation) | HANDOFF |
+| `P < threshold` | Continue as main |
+| UNKNOWN or unavailable | Count relayed reads and spawn waves; HANDOFF at 20 reads or 4 spawn waves |
+
+HANDOFF spawns a successor with the same Phase 2 machinery — `main-g<N>` in the root tab, equalized, readiness-gated — then delivers a compact handoff brief through the Phase 4 cycle and waits for the ack `HANDOFF ACCEPTED gen=<N> fleet=<k>`. After the ack, that pane is the orchestrator; this pane goes read-only and announces the new one with `herdr agent focus main-g<N>`. A successor that fails readiness or never acks means the HANDOFF failed: stay main, report the orphan pane, and ask before closing it.
+
+Read `references/context-succession.md` for the gate-point table, UNKNOWN fallback logging, full procedure, and the brief template. Never paste transcripts or diffs into a brief.
+
+**Done when:** the gate decision is recorded with a percentage or an explicit UNKNOWN fallback, and any HANDOFF has a ready successor pane, a delivered brief, a received ack, and no write from the outgoing pane afterward.
+
 ## Verify Expected Output
 
 Expected output for a successful fleet operation:
@@ -133,6 +153,7 @@ Acceptance criteria:
 - Every send passes preflight and every completed reply has delivery evidence.
 - Every agent ends as completed, blocked, timed out, or failed—none disappear from the report.
 - Errors and destructive confirmations are surfaced explicitly.
+- The context gate is evaluated at each gate point, and any HANDOFF ends with exactly one acked orchestrator.
 
 ## Handle Edge Cases
 
@@ -142,6 +163,7 @@ Acceptance criteria:
 - More than four panes: warn that columns become cramped; change layout only with user approval.
 - Unequal grid: rerun the equalizer and abort worker launch if it still fails.
 - Wrong workspace or accidental tab: stop, preserve work, and ask before moving or closing panes.
+- Successor never acks: HANDOFF failed—stay main, keep the fleet, and report the orphan pane before asking to close it.
 
 ## Emit the Step Completion Report
 
@@ -154,6 +176,7 @@ Acceptance criteria:
   Layout/readiness:    √ pass (if spawning; otherwise — n/a)
   Delivery:            √ pass (if sending; otherwise — n/a)
   Replies:             √ pass (done|idle · blocked/timeouts reported)
+  Context gate:        √ pass (P% or UNKNOWN · continue | HANDOFF → main-gN)
   Destructive action:  — none (or confirmed scope)
   Result:              PASS | FAIL | PARTIAL
 ```

--- a/skills/herdr-agent-comms/docs/README.md
+++ b/skills/herdr-agent-comms/docs/README.md
@@ -12,7 +12,8 @@
 ## Highlights
 
 - **Root + sub-agents grid** — every column, including root, is resized to equal width as sub-agents are added.
-- **Root never replaced** — orchestrator pane stays; only close worker panes on teardown.
+- **Root never replaced by accident** — the orchestrator pane stays put; only worker panes are closed on teardown.
+- **Context handoff** — when the main agent's own window passes 50%, it spawns a successor orchestrator pane, hands over a compact fleet brief, and goes read-only so a long run never dies of a full context.
 - **Fleet spawn** — agent CLI + model + thinking + optional skills, then assign tasks in parallel.
 - **Message & steer** — `pane run` / `agent send`, wait on `working` → `done`/`idle`, read transcripts.
 - **Broadcast** — fan one instruction to many agents; concurrent waits.
@@ -26,6 +27,7 @@
 | "Ask the reviewer agent what it found" | Resolve target, send, wait on status, relay reply |
 | "Broadcast 'pull main' to all fleet agents" | Fan-out send + concurrent collect |
 | "Focus the tests pane so I can steer" | `herdr agent focus tests` |
+| "Keep this fleet running even when you run out of context" | Hand the orchestrator role to a fresh `main-g2` pane with a compact brief |
 
 ## How It Works
 

--- a/skills/herdr-agent-comms/evals/evals.json
+++ b/skills/herdr-agent-comms/evals/evals.json
@@ -36,6 +36,12 @@
       "prompt": "My SSH session died — can you reattach my tmux coding agents?",
       "expected_output": "Should NOT trigger herdr-agent-comms as the primary skill (tmux domain). Negative trigger: redirect to tmux-agent-comms or plain tmux help.",
       "files": []
+    },
+    {
+      "id": 7,
+      "prompt": "Keep driving this Herdr fleet through the whole refactor — I don't want the run to fall over when you fill up your own context.",
+      "expected_output": "Treats the main agent's context as a gated resource: self-checks usage at the named gate points (before a spawn wave, before a broadcast, after each relayed reply) rather than continuously, and continues as main below the 50% threshold. At or above it — or on the UNKNOWN fallback counters (20 relayed reads / 4 spawn waves) — performs a HANDOFF: spawns a successor pane named main-g2 through the same guarded split + equalize + readiness path, sends a compact handoff brief (objective, fleet roster with pane ids and statuses, delivered vs outstanding, constraints) through the normal baseline/marker/preflight cycle, waits for the exact ack 'HANDOFF ACCEPTED gen=2 fleet=<k>', then goes read-only, announces the new orchestrator with herdr agent focus main-g2, and never closes the outgoing root pane without confirmation. Does not paste transcripts or diffs into the brief, and never leaves two orchestrators writing to the fleet.",
+      "files": []
     }
   ]
 }

--- a/skills/herdr-agent-comms/references/context-succession.md
+++ b/skills/herdr-agent-comms/references/context-succession.md
@@ -1,0 +1,92 @@
+# Context succession (HANDOFF) — herdr-agent-comms
+
+Read this when the main agent's own context gate fires, or before starting a fleet run expected to outlast one context window.
+
+**HANDOFF** = the orchestrator role migrates from this pane to a fresh successor pane. Root is a **role, not a pane**: after a HANDOFF the successor is `root_pane` for every later operation, the outgoing pane is retired to read-only, and it is closed only under Rule 8 confirmation.
+
+HANDOFF is not a worker restart. Workers are respawned through Phase 2; HANDOFF replaces the orchestrator itself, so exactly one agent keeps write access to the fleet.
+
+## Gate points
+
+Self-check at these checkpoints only — not on every tool call.
+
+| Checkpoint | When |
+|---|---|
+| Before a spawn wave | Phase 2, before the first `herdr pane split` |
+| Before a broadcast | Phase 6, before `broadcast.sh` |
+| After a reply relay | Phase 5, once the delta has been relayed |
+
+Never gate mid-cycle. If a send has dispatched and its wait has not resolved, finish Phase 5 first, then gate.
+
+## Probe and decision
+
+Read your own usage the way this harness surfaces it — status line, a context command, or a remaining-context warning — and resolve it to an integer percentage of the window consumed, or to UNKNOWN. Do not read transcripts or session files to derive it.
+
+| Result | Action |
+|---|---|
+| Integer `P >= threshold` | HANDOFF |
+| Integer `P < threshold` | Continue as main |
+| UNKNOWN or unavailable | Apply the fallback below |
+
+Threshold defaults to **50** and is overridable in conversation ("handoff at 65"). Values outside 1–99 use 50 and print one warning.
+
+## UNKNOWN fallback
+
+Count from the moment this generation became main:
+
+| Counter | HANDOFF at |
+|---|---|
+| Relayed reads (Phase 5 deltas) | 20 |
+| Spawn waves (Phase 2 runs) | 4 |
+
+Whichever count trips first. HANDOFF immediately, regardless of counters, on a harness compaction/summarization notice, on your own truncated output, or after losing tracked pane ids twice.
+
+Anti-thrash: a generation may not HANDOFF until it has completed at least one full operation (spawn wave, send cycle, or broadcast). Log every UNKNOWN decision:
+
+```text
+⚠ Context UNKNOWN for main — fallback: {continue|handoff} ({reads}/20 reads · {waves}/4 waves)
+```
+
+## HANDOFF procedure
+
+1. **Record the brief** from the template below. Compact state only — never transcripts, full diffs, or pasted worker output.
+2. **Spawn the successor** with the canonical `spawn_sub` workflow in `herdr-recipes.md`: plan the rightmost split, split `--direction right --no-focus` in `project_dir`, parse the pane id, equalize as a hard gate. Name it `main-g<N>` for generation `N` (the original main is `g1`); on collision, suffix an epoch. Launch the **same agent CLI the outgoing main is running**, bare, unless the user named a different one — a successor on an unfamiliar CLI cannot honor the brief. If the grid already holds more than four panes, warn that columns are cramped and ask before adding the successor column.
+3. **Ready-gate it** with `wait_for_idle.py --ready`. On non-zero, abort the HANDOFF: stay main, report the orphan pane id, and ask before closing it. A failed HANDOFF never leaves the fleet without an orchestrator.
+4. **Send the brief** through the full Phase 4 cycle — baseline, fresh `HERDR_DONE_` marker, preflight, `herdr pane run`, delivery check. Multi-line payload: use the guarded multi-line recipe in `herdr-recipes.md`.
+5. **Wait for the ack** `HANDOFF ACCEPTED gen=<N> fleet=<k>` via `wait_for_idle.py`. No ack (timeout or blocked) means the HANDOFF failed — stay main and report.
+6. **Retire this pane.** After the ack, issue no further writes to any fleet pane: no sends, no splits, no closes. Remain available for read-only reporting so the human is not stranded.
+7. **Announce the successor** to the human by pane id and name, with `herdr agent focus main-g<N>` so they can steer it directly.
+
+## Handoff brief template
+
+```text
+You are now the MAIN AGENT (orchestrator) for this Herdr fleet. Load the
+`herdr-agent-comms` skill and continue the run from the state below.
+
+generation: {N}   (previous main: {old_pane} — retired, read-only)
+handoff threshold: {T}%   — keep gating your own context at this number
+workspace: {ws}   tab: {root_tab}   project_dir: {project_dir}
+your pane: {new_pane}   — use it as root_pane for every later operation
+
+objective: {one-paragraph restatement of the user's ask}
+
+fleet roster:
+  {name} = {pane_id} · role {role} · status {status} · last verified: {deliverable}
+
+delivered (do NOT redo): {bullets}
+outstanding (in order): {bullets}
+constraints: {confirmations granted or withheld · destructive scope · layout limits}
+
+Rules:
+1. Mint fresh baselines and completion markers. Never inherit mine.
+2. Never write to {old_pane}. Never close panes, tabs, or the server without
+   explicit user confirmation.
+3. Re-verify every worker's status before your first send.
+4. Reply exactly `HANDOFF ACCEPTED gen={N} fleet={k}` before doing any work.
+
+Do not read my transcript. Everything you need is above.
+```
+
+## Done when
+
+The report records a parsed percentage or an explicit UNKNOWN fallback; any HANDOFF has a ready successor pane id, a delivered brief, a received ack, and an announced focus command; and the outgoing pane has made no write since the ack.

--- a/skills/tmux-agent-comms/SKILL.md
+++ b/skills/tmux-agent-comms/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires `tmux` on PATH. Optional Python 3 for wait/preflight/broadcast helpers."
 effort: medium
 metadata:
-  version: 2.1.0
+  version: 2.2.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -28,6 +28,7 @@ Route directly to the required mode; do not read unrelated references.
 | Read a pane, show status, or inspect | Phase 5 |
 | Broadcast to a fleet | Phase 6 |
 | Shut down an agent | Phase 6 |
+| Main agent's own context is filling up | Phase 7 HANDOFF |
 
 ## Prerequisites
 
@@ -44,10 +45,12 @@ Route directly to the required mode; do not read unrelated references.
 5. **Bound waiting.** Use a wall-clock cap or at most 2–3 re-waits. Surface a stall instead of polling forever.
 6. **Keep reads bounded.** Start with `capture-pane -S -40` and widen only when the reply is truncated.
 7. **Escalate blocked panes.** A trust/auth/permission dialog requires a human; do not type task text into it.
+8. **Run exactly one orchestrator.** Only the current main agent writes to fleet sessions. Orchestrator is a role, not a session: after a Phase 7 HANDOFF ack, the outgoing agent goes read-only and issues no further `send-keys`, spawns, or kills.
+9. **Gate your own context.** Self-check at every Phase 7 gate point; at or above the threshold, HANDOFF instead of continuing to fill this window.
 
 ## Workflow
 
-Run the six phases in order for a send. A read-only status/inspect operation may jump to Phase 5.
+Run Phases 1–6 in order for a send. A read-only status/inspect operation may jump to Phase 5. Phase 7 is the orchestrator's own context gate, evaluated at its named gate points rather than in sequence.
 
 ### Phase 1 — Create or Discover
 
@@ -134,12 +137,29 @@ Read `references/tmux-recipes.md` for classification commands, periodic fleet st
 
 **Complete when:** every follow-up has an independent proof cycle, broadcast failures are reported per target, or confirmed teardown affects only named sessions.
 
+### Phase 7 — Hand Off the Orchestrator Role
+
+Long fleet runs outlive one context window. Self-check your own usage at three gate points — before a spawn wave, before a broadcast, and after each relayed capture — never mid-cycle between a send and its wait.
+
+| Self-reported usage | Action |
+|---|---|
+| `P >= threshold` (default 50, overridable in conversation) | HANDOFF |
+| `P < threshold` | Continue as main |
+| UNKNOWN or unavailable | Count relayed reads and spawn waves; HANDOFF at 20 reads or 4 spawn waves |
+
+HANDOFF spawns a successor with the same Phase 1 machinery — `<folder>-main-g<N>`, app terminal tab by default, ready-gated — then delivers a compact handoff brief through the Phase 3 cycle (paste-buffer, since it is multi-line) and waits for the ack `HANDOFF ACCEPTED gen=<N> fleet=<k>`. After the ack, that session is the orchestrator; this agent goes read-only and prints the successor's `tmux attach-session` command for the human. A successor that fails readiness or never acks means the HANDOFF failed: stay main, report the unused session, and ask before killing it.
+
+Read `references/context-succession.md` for the gate-point table, UNKNOWN fallback logging, full procedure, and the brief template. Never paste transcripts or diffs into a brief.
+
+**Complete when:** the gate decision is recorded with a percentage or an explicit UNKNOWN fallback, and any HANDOFF has a ready successor session, a delivered brief, a received ack, and no write from the outgoing agent afterward.
+
 ## Acceptance Criteria
 
 - Every write targets a confirmed session and immediately follows a successful preflight.
 - Every message has a fresh baseline, split marker, delivery check, bounded wait, and independent capped-tail verification.
 - No blocked dialog receives task text; no destructive command runs without confirmation.
 - Fleet sends and readiness checks run concurrently, with partial failures identified by session.
+- The context gate is evaluated at each gate point, and any HANDOFF ends with exactly one acked orchestrator.
 - The expected output is the requested reply/status plus the adapted Step Completion Report below—not raw unbounded scrollback.
 
 ## Example
@@ -162,10 +182,12 @@ Expected result: the agent's new reply is relayed, the joined marker proves this
 - Follow-up: never reuse a deleted baseline or marker already present in transcript.
 - Truncated capture: widen `-S` stepwise.
 - Human attached manually: detach with `Ctrl-b d`; never kill merely to return control.
+- Successor never acks: HANDOFF failed—stay main, keep the fleet, and report the unused session before asking to kill it.
 
 ## References
 
 - `references/delivery-and-waiting.md` — read for any send/wait cycle, recovery, marker contract, or timeout.
+- `references/context-succession.md` — read at the context gate for the HANDOFF procedure and brief template.
 - `references/tmux-recipes.md` — read only for script resolution, spawn modes, fleets, status/inspect, multiline sends, attach, scrollback, or troubleshooting.
 - `scripts/preflight_send.py` — fail-closed check before every send or recovery Enter.
 - `scripts/wait_for_idle.py` — readiness and settled-reply waiter.
@@ -184,6 +206,7 @@ After each operation, emit only applicable rows:
   Message delivered:   √ pass (activity vs baseline)
   Completion marker:   √ pass (fresh and joined)
   Reply verified:      √ pass (bounded independent read)
+  Context gate:        √ pass (P% or UNKNOWN · continue | HANDOFF → <folder>-main-gN)
   Destructive action:  — none (or: √ confirmed)
   Result:              PASS | FAIL | PARTIAL
 ```

--- a/skills/tmux-agent-comms/docs/README.md
+++ b/skills/tmux-agent-comms/docs/README.md
@@ -18,6 +18,7 @@
 - **Broadcast & collect** — preflight + baselines + split markers + concurrent waits; periodic fleet status during long-running work.
 - **Status & inspect** — list every managed agent in a table, inspect one agent, and get the exact attach command for a human terminal.
 - **Keep agents visible** — new sessions attach to a fresh terminal tab in the current app by default; detached mode remains available for background fleets or environments without a terminal-tab facility.
+- **Context handoff** — when the main agent's own window passes 50%, it spawns a successor orchestrator session (`<folder>-main-g2`), hands over a compact fleet brief, and goes read-only so a long run never dies of a full context.
 - **Safe teardown** — kill individual sessions (or the whole server) behind explicit user confirmation, so no agent's work is lost by accident.
 
 ## When to Use
@@ -30,6 +31,7 @@
 | "Show status for my tmux agents" | Print a table with state, progress, start time, and working directory |
 | "Inspect the reviewer agent" | Show details for that agent and the exact `tmux attach-session` command |
 | "Shut down the tests agent" | Confirm, then `kill-session` that target |
+| "Keep this fleet running even when you run out of context" | Hand the orchestrator role to a fresh `<folder>-main-g2` session with a compact brief |
 
 ## How It Works
 
@@ -133,6 +135,7 @@ The skill confirms the target with you, then `kill-session`. (A full reset of ev
 
 | Path | Description |
 |---|---|
+| `references/context-succession.md` | The main agent's own context gate (default 50%), HANDOFF procedure, successor naming, and the compact handoff brief template |
 | `references/tmux-recipes.md` | Broadcast patterns, periodic fleet status, status/inspect behavior, multi-line/code message sending, pane splitting, scrollback, chrome-stripping, and a troubleshooting table |
 | `scripts/wait_for_idle.py` | Polls a pane until idle; prints just the reply delta (token-lean) and reports idle / blocked-on-prompt / timeout via exit codes 0/3/2 |
 | `scripts/broadcast.sh` | Sends one message to a fleet and collects every reply concurrently, one labeled block per agent |

--- a/skills/tmux-agent-comms/evals/evals.json
+++ b/skills/tmux-agent-comms/evals/evals.json
@@ -54,6 +54,12 @@
       "prompt": "My Herdr workspace died — can you reattach my Herdr coding agents?",
       "expected_output": "Should NOT trigger tmux-agent-comms as the primary skill (Herdr domain). Negative trigger: redirect to herdr-agent-comms or plain herdr help.",
       "files": []
+    },
+    {
+      "id": 10,
+      "prompt": "You're managing my tmux agents for a long job. Watch your own context and don't let the whole thing stall when you get close to full.",
+      "expected_output": "Treats the main agent's context as a gated resource: self-checks usage at the named gate points (before a spawn wave, before a broadcast, after each relayed capture) rather than continuously, and continues as main below the 50% threshold. At or above it — or on the UNKNOWN fallback counters (20 relayed reads / 4 spawn waves) — performs a HANDOFF: creates a successor session named <folder>-main-g2 through the normal Phase 1 path (app terminal tab by default, collision check, --ready gate), sends a compact handoff brief (objective, fleet roster with sessions and states, delivered vs outstanding, constraints) via paste-buffer through the normal baseline/marker/preflight cycle, waits for the exact ack 'HANDOFF ACCEPTED gen=2 fleet=<k>', then goes read-only, prints (does not run) the successor's tmux attach-session command, and never kills the outgoing session without confirmation. Does not paste transcripts or diffs into the brief, and never leaves two orchestrators writing to the fleet.",
+      "files": []
     }
   ]
 }

--- a/skills/tmux-agent-comms/references/context-succession.md
+++ b/skills/tmux-agent-comms/references/context-succession.md
@@ -1,0 +1,92 @@
+# Context succession (HANDOFF) — tmux-agent-comms
+
+Read this when the main agent's own context gate fires, or before starting a fleet run expected to outlast one context window.
+
+**HANDOFF** = the orchestrator role migrates from this agent to a fresh successor session. Orchestrator is a **role, not a session**: after a HANDOFF the successor drives every later operation, the outgoing agent is retired to read-only, and its session is killed only under Critical Rule 1 confirmation.
+
+HANDOFF is not a worker restart. Workers are respawned through Phase 1; HANDOFF replaces the orchestrator itself, so exactly one agent keeps write access to the fleet.
+
+## Gate points
+
+Self-check at these checkpoints only — not on every tool call.
+
+| Checkpoint | When |
+|---|---|
+| Before a spawn wave | Phase 1, before the first `new-session` |
+| Before a broadcast | Phase 6, before `broadcast.sh` |
+| After a reply relay | Phase 5, once the capture has been relayed |
+
+Never gate mid-cycle. If a message has been sent and its wait has not resolved, finish Phase 4 first, then gate.
+
+## Probe and decision
+
+Read your own usage the way this harness surfaces it — status line, a context command, or a remaining-context warning — and resolve it to an integer percentage of the window consumed, or to UNKNOWN. Do not read transcripts or session files to derive it.
+
+| Result | Action |
+|---|---|
+| Integer `P >= threshold` | HANDOFF |
+| Integer `P < threshold` | Continue as main |
+| UNKNOWN or unavailable | Apply the fallback below |
+
+Threshold defaults to **50** and is overridable in conversation ("handoff at 65"). Values outside 1–99 use 50 and print one warning.
+
+## UNKNOWN fallback
+
+Count from the moment this generation became main:
+
+| Counter | HANDOFF at |
+|---|---|
+| Relayed reads (Phase 5 captures) | 20 |
+| Spawn waves (Phase 1 runs) | 4 |
+
+Whichever count trips first. HANDOFF immediately, regardless of counters, on a harness compaction/summarization notice, on your own truncated output, or after losing tracked session names twice.
+
+Anti-thrash: a generation may not HANDOFF until it has completed at least one full operation (spawn wave, send cycle, or broadcast). Log every UNKNOWN decision:
+
+```text
+⚠ Context UNKNOWN for main — fallback: {continue|handoff} ({reads}/20 reads · {waves}/4 waves)
+```
+
+## HANDOFF procedure
+
+1. **Record the brief** from the template below. Compact state only — never transcripts, full diffs, or pasted worker output.
+2. **Spawn the successor** through Phase 1: name it `<folder>-main-g<N>` for generation `N` (the original main is `g1`), collision-check with `tmux has-session`, open it in an app terminal tab when available, and otherwise create it detached and print the attach command. Launch the **same agent CLI the outgoing main is running** unless the user named a different one — a successor on an unfamiliar CLI cannot honor the brief.
+3. **Ready-gate it** with `wait_for_idle.py --ready --timeout 60`. On non-zero, abort the HANDOFF: stay main, report the unused session, and ask before killing it. A failed HANDOFF never leaves the fleet without an orchestrator.
+4. **Send the brief** through the full Phase 3 cycle — baseline, fresh `TAC_DONE_` marker, preflight, text then a separate `Enter`, delivery check. The brief is multi-line, so load it with paste-buffer per Critical Rule 4 rather than shell escaping.
+5. **Wait for the ack** `HANDOFF ACCEPTED gen=<N> fleet=<k>` with `wait_for_idle.py`. No ack (timeout or blocked) means the HANDOFF failed — stay main and report.
+6. **Retire this agent.** After the ack, issue no further writes to any fleet session: no `send-keys`, no new sessions, no kills. Remain available for read-only reporting so the human is not stranded.
+7. **Announce the successor** to the human by exact session name, and print — do not run — `tmux attach-session -t <folder>-main-g<N>` so they can steer it directly.
+
+## Handoff brief template
+
+```text
+You are now the MAIN AGENT (orchestrator) for this tmux fleet. Load the
+`tmux-agent-comms` skill and continue the run from the state below.
+
+generation: {N}   (previous main: {old_target} — retired, read-only)
+handoff threshold: {T}%   — keep gating your own context at this number
+workdir: {project_dir}   your session: {new_session}
+
+objective: {one-paragraph restatement of the user's ask}
+
+fleet roster:
+  {session} · role {role} · state {in-progress|done|blocked|unknown} · last verified: {deliverable}
+
+delivered (do NOT redo): {bullets}
+outstanding (in order): {bullets}
+constraints: {confirmations granted or withheld · destructive scope}
+
+Rules:
+1. Mint fresh baselines and completion markers. Never inherit mine.
+2. Never write to {old_target}. Never kill a session or the server without
+   explicit user confirmation.
+3. Re-verify every session with `has-session` and a bounded capture before
+   your first send.
+4. Reply exactly `HANDOFF ACCEPTED gen={N} fleet={k}` before doing any work.
+
+Do not read my transcript. Everything you need is above.
+```
+
+## Done when
+
+The report records a parsed percentage or an explicit UNKNOWN fallback; any HANDOFF has a ready successor session, a delivered brief, a received ack, and an announced attach command; and the outgoing agent has made no write since the ack.


### PR DESCRIPTION
Closes #86

## Problem

`herdr-agent-comms` and `tmux-agent-comms` gate their **workers'** context but never the **main agent's own**. A long fleet run dies when the orchestrator fills its window — the fleet is left with no one driving it.

## What changed

Both skills now self-check their own usage at three named gate points — before a spawn wave, before a broadcast, and after each relayed reply — never mid-cycle between a dispatch and its wait.

| Self-reported usage | Action |
|---|---|
| `P >= threshold` (default 50, overridable in conversation) | HANDOFF |
| `P < threshold` | Continue as main |
| UNKNOWN | Count relayed reads / spawn waves; HANDOFF at 20 reads or 4 waves |

**HANDOFF** spawns a successor through the skill's *own* guarded spawn path (`main-g<N>` pane in Herdr, `<folder>-main-g<N>` session in tmux), ready-gates it, delivers a compact fleet brief through the normal baseline/marker/preflight cycle, and waits for the exact ack `HANDOFF ACCEPTED gen=<N> fleet=<k>`. After the ack the outgoing agent goes read-only and announces the successor (`herdr agent focus` / a printed `tmux attach-session`). No ack or a failed readiness gate means the handoff failed: stay main, report the orphan, ask before closing it — the fleet is never left without an orchestrator.

### The load-bearing edit

herdr Rule 1 read *"Never replace or close the root pane during fleet work"* — a flat contradiction of any handoff. **Root is now a role, not a pane:** it migrates to the successor, while the outgoing pane is retired read-only and closed only under confirmation. Both skills also gained **"run exactly one orchestrator"** so two agents never write the same panes and corrupt each other's baselines.

## Design note

Follows the house pattern in `issue-work-loop/references/context-gate.md` (same 50% threshold, same UNKNOWN-fallback shape): **self-report + countable fallback, no transcript parsing.** A JSONL/usage parser would hardcode Claude Code internals inside skills whose job is launching `pi`, `claude`, *and* `opencode` — wrong shape, and it would owe new test suites in both `tests/` dirs.

## Files

- `references/context-succession.md` (new, per skill) — gate points, UNKNOWN fallback logging, procedure, handoff brief template
- `SKILL.md` (both) — Phase 7, routing-table row, rule amendments, acceptance criterion, report row
- herdr rules renumbered 2–7 → 3–8; all cross-references re-checked (`broadcast.sh:129`'s "Critical Rule 7" now correctly resolves to *Surface blockers*)
- one eval case per skill, both `docs/README.md`, root `README.md` versions, CHANGELOG under `## Unreleased`

## Versions

| Skill | Change |
|---|---|
| herdr-agent-comms | 1.22.2 → 1.23.0 |
| tmux-agent-comms | 2.1.0 → 2.2.0 |

## Validation

`quick_validate.py` clean on both. SKILL.md line counts 182 / 214 (cap 500). No eval run — Path B retrofit doesn't require one.

## Open question

The outgoing agent **announces** the handoff rather than **asking** first. That was my judgment call: handoff isn't destructive, and stopping to ask defeats the point during an unattended run. Easy to flip to a confirmation gate if you'd rather.
