### PR TITLE
fix(docs): correct skill count to 42 and assert it mechanically (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Docs
 - Reconcile root README skill catalog to on-disk `metadata.version` for all installable skills; add `fork-upstream-sync`, `herdr-agent-comms`, Google Antigravity install path, Project docs index, install validation link
-- Reconcile `docs/index.html` GitHub Pages copy to current catalog state: v1.15.0 baseline, 40 installable skills, Google Antigravity support, and no removed `clean-code` catalog card
+- Reconcile `docs/index.html` GitHub Pages copy to current catalog state: v1.15.0 baseline, Google Antigravity support, and no removed `clean-code` catalog card
 - Correct the `docs/index.html` skill count to 42 at every site, state the counting rule (every tracked `SKILL.md` under `skills/`, nested suite sub-skills included) beside the literal, and assert it from `scripts/validate-contribute.sh` so the next skill added cannot silently re-break it
 - Fix CONTRIBUTING setup commands to external skill-creator paths (`~/.claude/skills/skill-creator/scripts/`); align frontmatter example with `metadata.version`
 - Add `scripts/validate-install.sh`, `scripts/validate-contribute.sh` (check-only), `docs/DECISIONS.md`, `docs/troubleshooting.md`, `docs/archive/README.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Docs
 - Reconcile root README skill catalog to on-disk `metadata.version` for all installable skills; add `fork-upstream-sync`, `herdr-agent-comms`, Google Antigravity install path, Project docs index, install validation link
 - Reconcile `docs/index.html` GitHub Pages copy to current catalog state: v1.15.0 baseline, 40 installable skills, Google Antigravity support, and no removed `clean-code` catalog card
+- Correct the `docs/index.html` skill count to 42 at every site, state the counting rule (every tracked `SKILL.md` under `skills/`, nested suite sub-skills included) beside the literal, and assert it from `scripts/validate-contribute.sh` so the next skill added cannot silently re-break it
 - Fix CONTRIBUTING setup commands to external skill-creator paths (`~/.claude/skills/skill-creator/scripts/`); align frontmatter example with `metadata.version`
 - Add `scripts/validate-install.sh`, `scripts/validate-contribute.sh` (check-only), `docs/DECISIONS.md`, `docs/troubleshooting.md`, `docs/archive/README.md`
 - Move former root documentation drafts into `docs/archive/` and explicitly unignore archived copies while keeping future root drafts ignored

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,33 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Agent Skills — Ready-made skills for AI coding agents</title>
-  <meta name="description" content="Agent Skills v1.15.0 — 40 installable workflows for AI coding agents. Browse the GitHub Pages catalog, install with one command. Claude Code, Cursor, Copilot, Codex, OpenCode, and Google Antigravity. MIT licensed.">
+  <!--
+    SKILL COUNT — counting rule (do not guess it; it is asserted mechanically).
+
+      Rule:    every installable SKILL.md anywhere under skills/, including the
+               nested sub-skills of umbrella suites (diagram-generator/,
+               website-cloner/). install.sh and remote-install.sh install those
+               children independently, so each one is a separately installable
+               skill. Directories without a SKILL.md (e.g. *-workspace/) never
+               count.
+      Command: git ls-files skills | grep -c '/SKILL\.md$'
+               (equivalently, on a clean tree: find skills -name SKILL.md | wc -l)
+      Value:   42 skills
+
+    The number appears in five page-visible places: this meta description, the
+    hero badge, the "Current catalog docs" card, the "N skills" social-proof
+    card, and the footer line under it — plus the Value line above, which is
+    written in the same "<n> skills" form on purpose so that it is checked too.
+    Change all six together.
+
+    scripts/validate-contribute.sh re-derives the count and fails when any of
+    the six disagrees with it, and also when fewer than six still match the
+    "<n> skills" / "<n> installable" shape it looks for — so a site reworded out
+    of that shape cannot quietly stop being checked. If you deliberately add or
+    remove a site, update expected_sites in that script. Run it after adding or
+    removing a skill.
+  -->
+  <meta name="description" content="Agent Skills v1.15.0 — 42 installable workflows for AI coding agents. Browse the GitHub Pages catalog, install with one command. Claude Code, Cursor, Copilot, Codex, OpenCode, and Google Antigravity. MIT licensed.">
   <link rel="icon" href="assets/logo/favicon.svg" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -553,7 +579,7 @@
   <!-- HERO (PAS opener) -->
   <header class="hero">
     <div class="container">
-      <div class="badge"><strong>v1.15.0</strong> · <strong>40 skills</strong> · <a href="https://luongnv89.github.io/skills/" style="color: inherit; text-decoration: underline;">Live on GitHub Pages</a> · MIT</div>
+      <div class="badge"><strong>v1.15.0</strong> · <strong>42 skills</strong> · <a href="https://luongnv89.github.io/skills/" style="color: inherit; text-decoration: underline;">Live on GitHub Pages</a> · MIT</div>
       <h1>Stop Rebuilding Agent Skills</h1>
       <p class="hero-sub">
         Your AI coding agent restarts from zero every session. Agent Skills gives you a browsable catalog of standalone, versioned workflows — including this site from <code class="mono">docs/</code>. Install only what you need with one command. Your agent follows the same process every time.
@@ -693,7 +719,7 @@
       <div class="grid-3">
         <div class="card">
           <h3>Current catalog docs</h3>
-          <p>README and this GitHub Pages home now reflect the 40 installable <code class="mono">SKILL.md</code> entries in <code class="mono">skills/</code>.</p>
+          <p>README and this GitHub Pages home now reflect the 42 installable <code class="mono">SKILL.md</code> entries in <code class="mono">skills/</code>.</p>
         </div>
         <div class="card">
           <h3>New &amp; expanded skills</h3>
@@ -718,7 +744,7 @@
       </p>
       <div class="grid-3">
         <div class="card">
-          <h3>40 skills</h3>
+          <h3>42 skills</h3>
           <p>Code review, security-setup, release automation, website-cloner suite, PRDs, Herdr/tmux agent comms — each installs on its own.</p>
         </div>
         <div class="card">
@@ -731,7 +757,7 @@
         </div>
       </div>
       <p style="margin-top: 2rem; color: var(--muted); font-size: 0.9rem;">
-        Catalog <strong>v1.15.0</strong> plus Unreleased docs — 40 installable workflows, suite-aware installers, and current README parity.
+        Catalog <strong>v1.15.0</strong> plus Unreleased docs — 42 installable workflows, suite-aware installers, and current README parity.
       </p>
     </div>
   </section>

--- a/scripts/validate-contribute.sh
+++ b/scripts/validate-contribute.sh
@@ -51,6 +51,35 @@ if [ -f "$SC/quick_validate.py" ] && [ -f skills/doc-manager/SKILL.md ]; then
   fi
 fi
 
+# --- Skill count parity: docs/index.html vs the catalog on disk ---
+# Counting rule (stated in full in the docs/index.html <head> comment): every
+# tracked SKILL.md anywhere under skills/, nested suite sub-skills included,
+# because install.sh installs those children independently. Directories with no
+# SKILL.md (e.g. *-workspace/) never count.
+if [ -f docs/index.html ]; then
+  on_disk="$(git ls-files skills | grep -c '/SKILL\.md$' | tr -d '[:space:]')"
+  # Every site that advertises the count matches "<n> skills" or "<n> installable".
+  # The <head> comment enumerates them; a site reworded out of that shape would
+  # otherwise go unchecked, so the number of matches is asserted as well.
+  expected_sites=6
+  sites="$(grep -oE '[0-9]+ (skills|installable)' docs/index.html | grep -oE '^[0-9]+')"
+  n_sites="$(printf '%s\n' "$sites" | grep -c '[0-9]' | tr -d '[:space:]')"
+  bad_sites="$(printf '%s\n' "$sites" | grep '[0-9]' | grep -vx "$on_disk" | sort -u | tr '\n' ' ')"
+  if [ -z "$on_disk" ] || [ "$on_disk" = "0" ]; then
+    bad "docs/index.html skill count" "could not derive the count from git ls-files"
+  elif [ "$n_sites" -eq 0 ]; then
+    bad "docs/index.html skill count" "no '<n> skills'/'<n> installable' literal found — update this check if the copy was reworded"
+  elif [ "$n_sites" -lt "$expected_sites" ]; then
+    bad "docs/index.html skill count" "only $n_sites of the $expected_sites documented sites still match '<n> skills'/'<n> installable' — a reworded site would go unchecked"
+  elif [ -n "$bad_sites" ]; then
+    bad "docs/index.html skill count" "advertises ${bad_sites}but ${on_disk} SKILL.md files are tracked under skills/"
+  else
+    ok "docs/index.html skill count ($on_disk in $n_sites places)"
+  fi
+else
+  bad "docs/index.html present" "missing"
+fi
+
 # --- Destructive scaffold — gated ---
 if [ "$MODE" = "destructive" ]; then
   man "init_skill.py my-skill --path skills/ (creates files)"


### PR DESCRIPTION
Closes #89

## Summary

`docs/index.html` advertised **40 skills** in five places while the catalog on disk holds 42. The issue suspected the counting rule was unknown and that correcting the number "would be guesswork" — it isn't. `40` was the exact value of the unbounded `SKILL.md` count at commit `b4f78f0` (PR #80), the commit that introduced the literal (`git ls-tree -r b4f78f0 --name-only | grep -c 'SKILL\.md$'` = 40, while the top-level-only count there was 32 — only the unbounded rule matches). The page already stated that rule in prose. Two skills have landed since (#82 `issue-work-loop`, #87 `codebase-modernizer`), so the literal is simply stale by +2. This PR corrects it to **42**, writes the rule and its deriving command next to the literal, and makes `scripts/validate-contribute.sh` assert it so the next skill added cannot silently re-break it.

## Approach

Option 2 — *Correct the literal plus add a mechanical check*. The advertised figure keeps the page's own long-standing rule (every installable `SKILL.md` under `skills/`, nested suite sub-skills included — `install.sh` and `remote-install.sh` install those children independently, so they are genuinely installable). The count is now documented and enforced rather than hand-maintained.

Why 42 and not 34: eight `SKILL.md` files are nested sub-skills — 2 under `diagram-generator/`, 6 under `website-cloner/`. 34 top-level + 8 nested = 42. The rule also excludes `skills/tmux-agent-comms-workspace/` for free, since it carries no `SKILL.md`, so no workspace special-casing is needed.

**On `CHANGELOG.md`:** line 8 under `## Unreleased` still reads "40 installable skills". That entry is a dated record of what #80 reconciled the docs to at that time, and it was accurate then; rewriting it would retroactively falsify the log. A fresh `Unreleased` → `Docs` entry records this correction instead. The distinction is deliberate: `docs/index.html` makes present-tense claims on a live page ("now reflect", "42 skills") and must be current; the changelog is a record of what happened.

## Decision Record

- **Root cause:** A hand-maintained literal drifted. `40` was the correct value of the unbounded `SKILL.md` count at commit `b4f78f0` (#80) — verified by `git ls-tree` at that commit — and two top-level skills have been added since (#82 `issue-work-loop`, #87 `codebase-modernizer`), making the true value 42. The rule was never unknown; the page states it on the "Current catalog docs" card.
- **Options considered:** Option 1 — Correct the literal and document the rule beside it; Option 2 — Correct the literal plus add a mechanical check in `scripts/validate-contribute.sh`; Option 3 — Switch the advertised rule to the top-level skill count (34).
- **Options rejected:** Option 1 — still hand-maintained; it re-breaks the moment #46 or any new skill lands. Option 3 — contradicts the rule the page has stated since #80 and would read as a 6-skill reduction; changing what the number *means* is a maintainer product decision, not a drift fix. Also rejected: deferring as "guesswork" (the rule is stated in the file and confirmed by git history), and trusting the issue body's 36/38 figures (both predate #90 and are each one too high — now 35 and 37).
- **Selected option:** Option 2 — Correct the literal plus add a mechanical check.
- **Residual risk:** The check keys on the copy patterns `<n> skills` / `<n> installable`, and on `expected_sites=6`. Rewording a site out of that shape fails loudly (`only 5 of the 6 documented sites still match …`) rather than passing silently, but a deliberate copy change that adds or removes a site needs `expected_sites` updated with it — the `<head>` note says so. Separately, `scripts/validate-contribute.sh` is a manual runbook script and is not wired into either GitHub Actions workflow (pre-existing), so the guarantee holds for anyone who runs the repo's validators; wiring it into CI is a reasonable follow-up. If the maintainer later prefers to advertise the top-level figure (34), that is a deliberate rule change and should update the `<head>` note and this check together.
- **Reproduction:** `grep -oE '[0-9]+ (skills|installable)' docs/index.html` returned `40` at 5 sites while `git ls-files skills | grep -c '/SKILL\.md$'` returned `42` — confirmed red → regression check added to `scripts/validate-contribute.sh`, itself proven red by perturbing one literal to `41` (exit 1) and by stripping every literal (exit 1).

Analyzed at: `main @ 102a7d0` (2026-08-17)

## Changes

| File | Change |
|------|--------|
| `docs/index.html` | `40` → `42` at all five page-visible count sites (meta description, hero badge, "Current catalog docs" card, social-proof card, footer line); new `<head>` comment stating the counting rule, the deriving command, the current value, where the sites are, and that `scripts/validate-contribute.sh` enforces it. The comment's own `Value:` line is written as `42 skills` so the check covers it too — 6 checked sites in total |
| `scripts/validate-contribute.sh` | New check: re-derives the count from `git ls-files skills \| grep -c '/SKILL\.md$'` and fails when any advertised literal disagrees, when fewer than the six documented sites still match the pattern it looks for (so a reworded site cannot quietly stop being checked), when no literal is found at all, or when the count cannot be derived |
| `CHANGELOG.md` | New `Unreleased` → `Docs` entry for this correction |

No `SKILL.md` was touched, so no `metadata.version` bump is owed.

## Test Results

- Unit tests: n/a — this repo has no unit test runner (no npm/pnpm/make/pytest)
- Integration tests: n/a
- E2e tests: n/a
- Repo validators: `scripts/validate-contribute.sh` passes (12 checks OK, exit 0); `scripts/validate-install.sh` passes
- Red-path verification of the new check (done by hand, deliberately not committed — this repo has no test suite to hold them): a literal perturbed to `41` → FAIL, exit 1; the `<head>` `Value:` line perturbed to `43` → FAIL, exit 1; one site reworded out of the pattern while keeping a stale number (`42 ready-made workflows`) → FAIL, exit 1; every count literal reworded away → FAIL, exit 1 with the "copy was reworded" hint. The tree was restored and re-verified green after each.
- Build: n/a (static site, no build step)
- QA cycles: 1 (code reviewer returned PASS, 0 blocking issues; its one non-blocking note was adopted anyway — see below)

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| The skill count shown in `docs/index.html` matches the catalog on disk | pass | Verified red: `grep -oE '[0-9]+ (skills\|installable)' docs/index.html` → `40` ×5 vs `git ls-files skills \| grep -c '/SKILL\.md$'` → `42` → fixed → regression check in `scripts/validate-contribute.sh` (`docs/index.html skill count (42 in 6 places) OK`) |
| The counting rule is stated next to the literal, with the exact command that derives it | pass | `docs/index.html` `<head>` comment (immediately above the `<meta name="description">` site) names the rule, the command, the value, and every site |
| The rule is asserted mechanically so the next skill added cannot silently re-break it | pass | `scripts/validate-contribute.sh` — proven red by perturbing a literal to `41`, by perturbing the `<head>` `Value:` line to `43`, and by removing every literal (exit 1 each time); green on the corrected tree |

<!-- gitissue:qa v1 head=2d743d28cad2c91d0ec17bd9bdd0c1d2d2c350c6 profile=full cycles=1 review=clean ui=none -->
