### PR TITLE
feat(codebase-modernizer): add agent-env plan pre-step (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@
 
 **codebase-modernizer (1.1.0):** read-only whole-repo audit that produces `MODERNIZATION_REPORT.md` and `MODERNIZATION_PLAN.md` for a codebase gone stale or messy. Phase 0 records a **baseline-green** verdict (build, test pass rate, coverage, CI) that every planned task's acceptance criteria then reference — which is what makes the plan testable rather than aspirational. Ten dimensions: dependency and runtime currency is the skill's own (`scripts/dep_scan.sh` probes 14 ecosystems fail-soft). A delegate is invoked during the audit **only if it writes nothing** — `code-review` modes `review`/`perf` and `dont-make-me-think` run; the six that write (`code-review` modes `clean`/`cleanup`, `test-coverage`, `devops-pipeline`, `security-setup`, `doc-manager`) are scanned inline and instead named as the invocation in the plan task that does the work. Findings cite `path:line` or are marked **Not Assessed** — never guessed. Dependencies are never upgraded in place: they are classified into **upgrade waves** (security patches → patch/minor batch → one major per task with a named migration source, via Context7 when available). The plan uses a fixed P0–P4 skeleton with sprints, milestones, a dependency DAG, and a stated critical path, in `tasks-generator`'s task format. A future gated apply-upgrades mode is the intended v2 extension.
 
+**codebase-modernizer (1.2.0):** every emitted plan now opens with an unconditional **Pre — Agent environment** step before P0 Stabilize (P0–P4 keep their numbers). Pre schedules a runnable agent environment and create-or-improve of `CLAUDE.md` / `AGENTS.md` via `/agent-config create|update` — planned only; the audit still never writes those files.
+
 **issue-work-loop (1.1.5):** resolves a single GitHub issue through a Herdr-pane implementer→reviewer loop until the PR review is CLEAN. Implementer runs `/issue-resolver`, reviewer runs `/issue-pr-review --review-only` in a separate pane; every FINDING counts, including notes (no soft-pass). Reviewer is FRESHENed at ROUND start and implementer before each fix when context crosses 50%; `--no-cleanup` skips SWEEP for debug; worker panes and loop worktrees are swept at the end by default; merging is always left to the human.
 
 ### Skills Updated
 | Skill | Version Change |
 |-------|----------------|
+| codebase-modernizer | 1.1.0 → 1.2.0 |
 | docs-generator → doc-manager | 1.2.5 → 2.0.1 |
 | tmux-agent-comms | 1.3.0 → 2.2.0 (observability, app terminal tabs by default, orchestrator context handoff) |
 | landing-page-generator | 1.1.4 → 1.2.0 (absorbs README-to-landing as Mode B) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,14 @@
 
 **codebase-modernizer (1.2.0):** every emitted plan now opens with an unconditional **Pre — Agent environment** step before P0 Stabilize (P0–P4 keep their numbers). Pre schedules a runnable agent environment and create-or-improve of `CLAUDE.md` / `AGENTS.md` via `/agent-config create|update` — planned only; the audit still never writes those files.
 
+**codebase-modernizer (1.2.1):** Pre is exempt from the still-green suite AC when the baseline is RED. Pre.3 / `AGENTS.md` is create-or-update against agent-config checklists only; recorded build/test commands live on Pre.1 notes and Pre.2 / `CLAUDE.md`.
+
 **issue-work-loop (1.1.5):** resolves a single GitHub issue through a Herdr-pane implementer→reviewer loop until the PR review is CLEAN. Implementer runs `/issue-resolver`, reviewer runs `/issue-pr-review --review-only` in a separate pane; every FINDING counts, including notes (no soft-pass). Reviewer is FRESHENed at ROUND start and implementer before each fix when context crosses 50%; `--no-cleanup` skips SWEEP for debug; worker panes and loop worktrees are swept at the end by default; merging is always left to the human.
 
 ### Skills Updated
 | Skill | Version Change |
 |-------|----------------|
-| codebase-modernizer | 1.1.0 → 1.2.0 |
+| codebase-modernizer | 1.1.0 → 1.2.1 |
 | docs-generator → doc-manager | 1.2.5 → 2.0.1 |
 | tmux-agent-comms | 1.3.0 → 2.2.0 (observability, app terminal tabs by default, orchestrator context handoff) |
 | landing-page-generator | 1.1.4 → 1.2.0 (absorbs README-to-landing as Mode B) |

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ npx skills add https://github.com/luongnv89/skills --skill <name>
 | Skill | Version | Effort | What it does |
 |---|---|---|---|
 | [**code-review**](skills/code-review/) | 2.1.0 | high | Review or improve code — 4 modes: bugs/security, performance, clean-code audit, slop cleanup |
-| [**codebase-modernizer**](skills/codebase-modernizer/) | 1.1.0 | max | Whole-repo audit + phased, testable plan to modernize a stale or messy codebase |
+| [**codebase-modernizer**](skills/codebase-modernizer/) | 1.2.0 | max | Whole-repo audit + phased, testable plan to modernize a stale or messy codebase |
 | [**test-coverage**](skills/test-coverage/) | 1.3.0 | low | Target untested branches and edge cases |
 | [**dont-make-me-think**](skills/dont-make-me-think/) | 1.3.2 | medium | Usability review using Krug's principles |
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ npx skills add https://github.com/luongnv89/skills --skill <name>
 | Skill | Version | Effort | What it does |
 |---|---|---|---|
 | [**code-review**](skills/code-review/) | 2.1.0 | high | Review or improve code — 4 modes: bugs/security, performance, clean-code audit, slop cleanup |
-| [**codebase-modernizer**](skills/codebase-modernizer/) | 1.2.0 | max | Whole-repo audit + phased, testable plan to modernize a stale or messy codebase |
+| [**codebase-modernizer**](skills/codebase-modernizer/) | 1.2.1 | max | Whole-repo audit + phased, testable plan to modernize a stale or messy codebase |
 | [**test-coverage**](skills/test-coverage/) | 1.3.0 | low | Target untested branches and edge cases |
 | [**dont-make-me-think**](skills/dont-make-me-think/) | 1.3.2 | medium | Usability review using Krug's principles |
 

--- a/skills/codebase-modernizer/SKILL.md
+++ b/skills/codebase-modernizer/SKILL.md
@@ -4,7 +4,7 @@ description: "Audit a stale, inherited, or messy codebase — deps, bugs, securi
 license: MIT
 effort: max
 metadata:
-  version: 1.1.0
+  version: 1.2.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
   architecture: "orchestrator (baseline gate → parallel dimension audits → evidence report → phased sprint plan → validation)"
 ---
@@ -36,6 +36,8 @@ such as `obj/`, `.dart_tool/`, `target/`, `.gradle/`). Nothing else.
   broken build and an unreviewable diff, which is exactly what the plan exists to prevent.
 - Refactors, dead-code removal, and test generation are **planned**, not applied. Applying them is
   the delegate skills' job, run later against the plan.
+- Agent environment files (`CLAUDE.md`, `AGENTS.md`) are **planned** via `/agent-config create` or
+  `/agent-config update` in the plan's Pre step — never created or rewritten during the audit.
 - If the user asks mid-run to start fixing, finish the report and plan first, then hand off to the
   delegate skill named in that task.
 
@@ -121,7 +123,8 @@ currency**, the **baseline gate**, and the **audit → plan bridge**. Everything
   one during an audit would break the read-only contract. Never do it. Audit the dimension with its
   checklist in `references/dimension-map.md`, record `Path: inline`, and name that skill as the
   invocation in the plan task that does the work. Here `inline` is the expected path, not a
-  degradation — do not report it as a limitation.
+  degradation — do not report it as a limitation. The plan's Pre step likewise names
+  `/agent-config create|update` and never runs it.
 
 Read `references/delegation-policy.md` before Phase 2 for exact invocation args, artifact handling,
 and the Skill-tool-unavailable fallback (which *is* reduced depth).
@@ -204,10 +207,11 @@ table.
 
 Spawn `agents/plan-architect.md` with the report path (or run it inline when the Agent tool is
 unavailable). It writes `MODERNIZATION_PLAN.md` from `references/plan-template.md`, using the fixed
-five-phase skeleton:
+skeleton (unconditional **Pre**, then **P0–P4** — do not rename or renumber P0–P4):
 
 | Phase | Goal | Milestone |
 |---|---|---|
+| **Pre Agent environment** | env an AI agent can use autonomously; `CLAUDE.md` / `AGENTS.md` created or improved | `ME` — both files exist (create or update via planned `/agent-config`); recorded commands documented |
 | **P0 Stabilize** | build green, tests runnable, lockfile committed, CI running | `M0` — baseline-green reproducible in CI |
 | **P1 Secure & Patch** | vulnerabilities closed, security patch + patch/minor **upgrade waves** | `M1` — zero known High/Critical vulns; patch/minor current |
 | **P2 Modernize** | each major dependency bump and runtime/toolchain upgrade, one task each | `M2` — every major current or deferred with written rationale |
@@ -217,10 +221,12 @@ five-phase skeleton:
 Phases split into sprints. Every task uses the `tasks-generator` task format so the plan interoperates
 with that skill, plus a `Closes:` line naming finding IDs.
 
-**Completion criteria:** every `Critical` and `High` finding is closed by ≥ 1 task; every task has
-≥ 2 testable acceptance criteria, one of which asserts baseline-green still holds; task IDs follow
+**Completion criteria:** Pre — Agent environment is present and ordered before P0, with create vs
+update of `CLAUDE.md` and `AGENTS.md` matching file presence and `/agent-config` named not run;
+every `Critical` and `High` finding is closed by ≥ 1 task; every task has ≥ 2 testable acceptance
+criteria, one of which asserts baseline-green still holds; task IDs follow `Task Pre.<index>` then
 `Task <sprint>.<index>`; the dependency table references only task IDs that exist; no circular
-dependencies; the critical path is stated explicitly; each of P0–P4 has a milestone with a
+dependencies; the critical path is stated explicitly; Pre and each of P0–P4 have a milestone with a
 measurable exit condition.
 
 ### Phase 5 — Validation pass
@@ -277,7 +283,9 @@ The run is successful only if **all** hold:
 - [ ] Every finding record has a unique `F-<DIM>-<NNN>` ID, a severity, and `path:line` evidence
       (or manifest+version for `DEP`).
 - [ ] Every `Critical` and `High` finding is closed by at least one task in the plan.
-- [ ] The plan contains phases P0–P4, each with ≥ 1 sprint and a measurable milestone.
+- [ ] The plan starts with the Agent-environment pre-step, then P0–P4, each with ≥ 1 sprint and a
+      measurable milestone. Pre is present whether `CLAUDE.md` / `AGENTS.md` already exist (update)
+      or not (create). `/agent-config` is named, never invoked.
 - [ ] Every task has ≥ 2 testable acceptance criteria including a baseline-green assertion, explicit
       `Dependencies`, an effort estimate, and a `Closes:` line.
 - [ ] The dependency table has no broken task IDs and no cycles; the critical path is stated.
@@ -295,7 +303,7 @@ Baseline: AMBER — builds; 41/58 tests pass; no coverage tool; CI absent
 Dimensions: 8 audited, 2 Not Assessed (UX — no UI detected; PERF — out of requested scope)
 Findings: 3 critical, 11 high, 24 medium, 9 low
 Outputs: MODERNIZATION_REPORT.md, MODERNIZATION_PLAN.md
-Plan: 5 phases, 9 sprints, 47 tasks — critical path P0→P1→P2 (Sprint 0.1 → 2.4)
+Plan: Pre + P0–P4, 10 sprints, 50 tasks — critical path Pre.1 → 0.1 → 2.4
 Validation: plan-validator PASS, 0 must-fix
 Source files changed: 0
 ```

--- a/skills/codebase-modernizer/SKILL.md
+++ b/skills/codebase-modernizer/SKILL.md
@@ -4,7 +4,7 @@ description: "Audit a stale, inherited, or messy codebase — deps, bugs, securi
 license: MIT
 effort: max
 metadata:
-  version: 1.2.0
+  version: 1.2.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
   architecture: "orchestrator (baseline gate → parallel dimension audits → evidence report → phased sprint plan → validation)"
 ---
@@ -46,7 +46,8 @@ such as `obj/`, `.dart_tool/`, `target/`, `.gradle/`). Nothing else.
 Used throughout this skill and its references with these exact meanings:
 
 - **baseline-green** — the recorded state where the project builds and its test suite runs to a known
-  pass rate. Established in Phase 0; every planned task's acceptance criteria require it to hold.
+  pass rate. Established in Phase 0; every P0–P4 task's acceptance criteria require it to hold. Pre
+  is exempt when the baseline is RED — restore-green stays on P0 / Sprint 0.
 - **finding record** — one normalized issue row with a stable **finding ID** (`F-<DIM>-<NNN>`, e.g.
   `F-DEP-003`). The report lists them; the plan's tasks close them by ID.
 - **Not Assessed** — an explicit report verdict for a dimension that could not be checked (no tool,
@@ -147,9 +148,9 @@ Build and test commands can legitimately create build output, but any *tracked* 
 report it and note that the probe was not reproducible. `references/baseline.md` gives the
 non-mutating form of each command.
 
-**When there is no test command**, the baseline-green assertion every plan task carries falls back to
-the build: tasks before the P0 suite-creation task assert `<build command>` succeeds; every later
-task asserts the suite that task established.
+**When there is no test command**, the baseline-green assertion every **P0–P4** task carries falls
+back to the build: P0–P4 tasks before the P0 suite-creation task assert `<build command>` succeeds;
+every later P0–P4 task asserts the suite that task established. Do not apply this fallback to Pre.
 
 **Completion criteria:** every row of the baseline table in `references/baseline.md` holds a recorded
 value or an explicit **Not Assessed** with a reason; the overall verdict is `GREEN`, `AMBER`, or
@@ -224,7 +225,8 @@ with that skill, plus a `Closes:` line naming finding IDs.
 **Completion criteria:** Pre — Agent environment is present and ordered before P0, with create vs
 update of `CLAUDE.md` and `AGENTS.md` matching file presence and `/agent-config` named not run;
 every `Critical` and `High` finding is closed by ≥ 1 task; every task has ≥ 2 testable acceptance
-criteria, one of which asserts baseline-green still holds; task IDs follow `Task Pre.<index>` then
+criteria; every P0–P4 task asserts baseline-green still holds (Pre is exempt when the baseline is
+RED — Pre ACs are install/run notes plus create-or-update of `CLAUDE.md`/`AGENTS.md`); task IDs follow `Task Pre.<index>` then
 `Task <sprint>.<index>`; the dependency table references only task IDs that exist; no circular
 dependencies; the critical path is stated explicitly; Pre and each of P0–P4 have a milestone with a
 measurable exit condition.
@@ -286,8 +288,9 @@ The run is successful only if **all** hold:
 - [ ] The plan starts with the Agent-environment pre-step, then P0–P4, each with ≥ 1 sprint and a
       measurable milestone. Pre is present whether `CLAUDE.md` / `AGENTS.md` already exist (update)
       or not (create). `/agent-config` is named, never invoked.
-- [ ] Every task has ≥ 2 testable acceptance criteria including a baseline-green assertion, explicit
-      `Dependencies`, an effort estimate, and a `Closes:` line.
+- [ ] Every task has ≥ 2 testable acceptance criteria, explicit `Dependencies`, an effort estimate,
+      and a `Closes:` line. P0–P4 tasks include a baseline-green assertion. Pre is exempt when the
+      baseline is RED (install/run notes plus create-or-update of `CLAUDE.md`/`AGENTS.md`).
 - [ ] The dependency table has no broken task IDs and no cycles; the critical path is stated.
 - [ ] Major dependency bumps are one task each, never batched, each naming its migration source.
 - [ ] Limitations section lists every **Not Assessed** dimension, missing tool, and degraded pass.
@@ -303,7 +306,7 @@ Baseline: AMBER — builds; 41/58 tests pass; no coverage tool; CI absent
 Dimensions: 8 audited, 2 Not Assessed (UX — no UI detected; PERF — out of requested scope)
 Findings: 3 critical, 11 high, 24 medium, 9 low
 Outputs: MODERNIZATION_REPORT.md, MODERNIZATION_PLAN.md
-Plan: Pre + P0–P4, 10 sprints, 50 tasks — critical path Pre.1 → 0.1 → 2.4
+Plan: Pre + P0–P4, 10 sprints, 50 tasks — critical path Pre.1 → Pre.2 → 0.1 → 2.4
 Validation: plan-validator PASS, 0 must-fix
 Source files changed: 0
 ```

--- a/skills/codebase-modernizer/agents/plan-architect.md
+++ b/skills/codebase-modernizer/agents/plan-architect.md
@@ -53,9 +53,10 @@ Convert an evidence report into an executable plan. You read the report, you wri
    A P0–P4 phase with no findings gets a one-line note; it is never renumbered or dropped. Pre is
    never omitted.
 3. **Split by effort.** Every `L` finding becomes ≥ 2 tasks. Every task is 1–3 days.
-4. **Write tasks** in the template's format: Description, `Closes:`, ≥ 2 acceptance criteria (one
-   asserting baseline-green holds against the recorded pass rate), `Dependencies`, `Effort`,
-   `Verify:` with the exact command a reviewer runs.
+4. **Write tasks** in the template's format: Description, `Closes:`, ≥ 2 acceptance criteria,
+   `Dependencies`, `Effort`, `Verify:` with the exact command a reviewer runs. P0–P4 tasks include
+   one AC asserting baseline-green holds against the recorded pass rate. Pre ACs are install/run
+   notes plus create-or-update of `CLAUDE.md`/`AGENTS.md` — not a green/pass-rate assertion.
 5. **Sequence.**
    - Pre is first; no P0–P4 task starts before `ME`.
    - Nothing outside P0 starts before `M0` when the baseline is RED, except Pre.
@@ -76,7 +77,9 @@ Return `FAIL` with the specific gap rather than a plan that misses any of these:
 
 - [ ] Every `Critical` and `High` finding appears in a task's `Closes:` or in Deferred.
 - [ ] No task exists without `Closes:` or a named milestone it enables.
-- [ ] Every task has ≥ 2 acceptance criteria; ≥ 1 asserts baseline-green.
+- [ ] Every task has ≥ 2 acceptance criteria. P0–P4 include ≥ 1 that asserts baseline-green; Pre
+      ACs are install/run notes plus create-or-update of `CLAUDE.md`/`AGENTS.md` (no green/pass-rate
+      AC).
 - [ ] Every acceptance criterion is checkable by a command, file state, or count.
 - [ ] Task IDs follow `Task <sprint>.<index>`, unique across the plan.
 - [ ] Dependency table references only existing task IDs; no cycles.
@@ -99,7 +102,7 @@ Write the file, then return JSON:
   "tasks": 50,
   "closed": {"critical": 3, "high": 11, "medium": 24, "low": 9},
   "deferred": ["F-PERF-02"],
-  "critical_path": {"tasks": ["Pre.1","0.1","0.3","1.2","2.1","2.4"], "days": 36},
+  "critical_path": {"tasks": ["Pre.1","Pre.2","0.1","0.3","1.2","2.1","2.4"], "days": 36},
   "self_check": "PASS",
   "gaps": []
 }

--- a/skills/codebase-modernizer/agents/plan-architect.md
+++ b/skills/codebase-modernizer/agents/plan-architect.md
@@ -36,8 +36,8 @@ Convert an evidence report into an executable plan. You read the report, you wri
 ## Process
 
 1. **Read the report end to end.** Build the finding inventory: ID, dimension, severity, effort,
-   evidence. Note the baseline verdict, the test command of record, and the pass rate — every task's
-   acceptance criteria reference them.
+   evidence. Note the baseline verdict, the test command of record, and the pass rate — every P0–P4
+   task's acceptance criteria reference them. Pre ACs do not.
 2. **Emit Pre, then bucket findings into the fixed P0–P4 skeleton** from
    `references/plan-template.md`. Do not rename or renumber P0–P4.
    - **Pre — Agent environment** is unconditional and comes first, even when `CLAUDE.md` and

--- a/skills/codebase-modernizer/agents/plan-architect.md
+++ b/skills/codebase-modernizer/agents/plan-architect.md
@@ -1,8 +1,8 @@
 ---
 name: plan-architect
-description: Turn MODERNIZATION_REPORT.md into MODERNIZATION_PLAN.md — five phases, sprints, testable tasks closing named findings, milestones, and a critical path
+description: Turn MODERNIZATION_REPORT.md into MODERNIZATION_PLAN.md — agent-environment pre-step then P0-P4, sprints, testable tasks closing named findings, milestones, and a critical path
 role: Modernization Plan Architect
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Plan Architect Agent
@@ -30,27 +30,35 @@ Convert an evidence report into an executable plan. You read the report, you wri
   serves. If you want a task the report does not support, you are missing a finding — say so in the
   plan's Risks section rather than inventing one.
 - **Never schedule this skill to run anything.** Tasks are for the user; where a delegate skill does
-  the work, name it (`code-review mode:cleanup`, `test-coverage`, `devops-pipeline`).
+  the work, name it (`/agent-config create|update`, `code-review mode:cleanup`, `test-coverage`,
+  `devops-pipeline`). Never invoke `/agent-config` while writing the plan.
 
 ## Process
 
 1. **Read the report end to end.** Build the finding inventory: ID, dimension, severity, effort,
    evidence. Note the baseline verdict, the test command of record, and the pass rate — every task's
    acceptance criteria reference them.
-2. **Bucket findings into the fixed P0–P4 skeleton** from `references/plan-template.md`. The
-   assignment is by *what unblocks what*, not by dimension:
-   - anything preventing verification (broken build, no suite, no lockfile, no CI) → **P0**
-   - vulnerabilities and waves W1–W2 → **P1**
-   - runtime/toolchain (W3) and each major (W4+) → **P2**
-   - dead code, duplication, weak types, coverage → **P3**
-   - UX, performance, docs → **P4**
-   A phase with no findings gets a one-line note; it is never renumbered or dropped.
+2. **Emit Pre, then bucket findings into the fixed P0–P4 skeleton** from
+   `references/plan-template.md`. Do not rename or renumber P0–P4.
+   - **Pre — Agent environment** is unconditional and comes first, even when `CLAUDE.md` and
+     `AGENTS.md` already exist. File absent → `/agent-config create` for that file. File present →
+     `/agent-config update`. Cover both files. Also schedule install/env/run notes an agent cannot
+     infer. Pre tasks serve milestone `ME`; they do not invent findings. Never run `/agent-config`.
+   - Assignment of report findings is by *what unblocks what*, not by dimension:
+     - anything preventing verification (broken build, no suite, no lockfile, no CI) → **P0**
+     - vulnerabilities and waves W1–W2 → **P1**
+     - runtime/toolchain (W3) and each major (W4+) → **P2**
+     - dead code, duplication, weak types, coverage → **P3**
+     - UX, performance, docs → **P4**
+   A P0–P4 phase with no findings gets a one-line note; it is never renumbered or dropped. Pre is
+   never omitted.
 3. **Split by effort.** Every `L` finding becomes ≥ 2 tasks. Every task is 1–3 days.
 4. **Write tasks** in the template's format: Description, `Closes:`, ≥ 2 acceptance criteria (one
    asserting baseline-green holds against the recorded pass rate), `Dependencies`, `Effort`,
    `Verify:` with the exact command a reviewer runs.
 5. **Sequence.**
-   - Nothing outside P0 starts before `M0` when the baseline is RED.
+   - Pre is first; no P0–P4 task starts before `ME`.
+   - Nothing outside P0 starts before `M0` when the baseline is RED, except Pre.
    - One major per task, ordered by blast radius ascending; dependents after their dependencies;
      the runtime upgrade before framework majors that require it.
    - A refactor task depends on the tests covering the code it touches.
@@ -73,7 +81,10 @@ Return `FAIL` with the specific gap rather than a plan that misses any of these:
 - [ ] Task IDs follow `Task <sprint>.<index>`, unique across the plan.
 - [ ] Dependency table references only existing task IDs; no cycles.
 - [ ] Critical path stated with its task chain and duration.
-- [ ] P0–P4 all present, each with ≥ 1 sprint and a measurable milestone.
+- [ ] Pre — Agent environment is present, ordered before P0, with measurable milestone `ME`.
+- [ ] `CLAUDE.md` and `AGENTS.md` each have a create or update task matching whether the file exists.
+- [ ] `/agent-config` is named on those tasks and is not described as already run.
+- [ ] P0–P4 all present and unrenumbered, each with ≥ 1 sprint and a measurable milestone.
 - [ ] Majors are one per task, each naming a migration source or flagged as a spike.
 
 ## Output
@@ -83,12 +94,12 @@ Write the file, then return JSON:
 ```json
 {
   "plan_path": "/abs/path/to/repo/MODERNIZATION_PLAN.md",
-  "phases": 5,
-  "sprints": 9,
-  "tasks": 47,
+  "phases": 6,
+  "sprints": 10,
+  "tasks": 50,
   "closed": {"critical": 3, "high": 11, "medium": 24, "low": 9},
   "deferred": ["F-PERF-02"],
-  "critical_path": {"tasks": ["0.1","0.3","1.2","2.1","2.4"], "days": 34},
+  "critical_path": {"tasks": ["Pre.1","0.1","0.3","1.2","2.1","2.4"], "days": 36},
   "self_check": "PASS",
   "gaps": []
 }

--- a/skills/codebase-modernizer/agents/plan-validator.md
+++ b/skills/codebase-modernizer/agents/plan-validator.md
@@ -1,8 +1,8 @@
 ---
 name: plan-validator
-description: Fresh-context validation of MODERNIZATION_REPORT.md and MODERNIZATION_PLAN.md — verify every citation resolves, severities are defensible, and no finding is orphaned
+description: Fresh-context validation of MODERNIZATION_REPORT.md and MODERNIZATION_PLAN.md — verify every citation resolves, the agent-environment pre-step precedes P0, severities are defensible, and no finding is orphaned
 role: Modernization Validator
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Plan Validator Agent
@@ -39,8 +39,13 @@ The failure modes of an audit-and-plan run, in the order they cost the most:
 6. **Unverifiable criteria** — "code is cleaner", "improve performance", "refactor the module". A
    criterion that no command, file state, or count can settle is a failed criterion.
 7. **Sequencing errors** — a refactor scheduled before the tests covering it; a framework major before
-   the runtime upgrade it requires; anything outside P0 starting before `M0` on a RED baseline;
-   batched majors in one task.
+   the runtime upgrade it requires; anything other than Pre starting outside P0 before `M0` on a RED
+   baseline; Pre missing, placed after P0, or used as a reason to rename/renumber P0–P4; batched
+   majors in one task.
+7b. **Applied `/agent-config`** — `CLAUDE.md` or `AGENTS.md` written or rewritten during the audit,
+    or a Pre task that treats those files as already done because they exist. Pre must name
+    `/agent-config create` (file absent) or `/agent-config update` (file present). Those tasks are
+    planned, not applied.
 8. **Graph defects** — dependency table referencing a task ID that does not exist; a cycle; a stated
    critical path that is not actually the longest chain. **Recompute it yourself from the dependency
    table** — a plan that merely *states* a critical path passes every other check while being wrong.
@@ -58,7 +63,9 @@ The failure modes of an audit-and-plan run, in the order they cost the most:
    `resolves` / `wrong-line` / `missing`.
 3. Cross-check report ↔ plan: every Critical/High ID appears in a `Closes:` or in Deferred; every
    `Closes:` ID exists in the report.
-4. Walk the dependency graph for cycles and dangling IDs; recompute the critical path.
+4. Confirm Pre — Agent environment exists, is ordered before P0 / `M0`, covers both `CLAUDE.md` and
+   `AGENTS.md` with create-vs-update matching file presence, and did not run `/agent-config`. Then
+   walk the dependency graph for cycles and dangling IDs; recompute the critical path.
 5. Re-add the severity counts.
 6. Read the Limitations section last, then re-examine every claim it undercuts.
 

--- a/skills/codebase-modernizer/docs/README.md
+++ b/skills/codebase-modernizer/docs/README.md
@@ -79,9 +79,9 @@ the same pattern for the plan's Pre step: named, never run during the audit.
 ## The three ideas that make the output useful
 
 **Baseline first.** Before anything else it records whether the project builds and what fraction of
-tests pass. Every task in the plan then carries "and the suite is still green" as an acceptance
-criterion. That's what makes the plan *testable* instead of aspirational — and if the baseline is
-RED, restoring it becomes Sprint 0 and everything else waits.
+tests pass. Every P0–P4 task in the plan then carries "and the suite is still green" as an
+acceptance criterion. Pre is exempt when the baseline is RED — restoring green is P0 / Sprint 0.
+That's what makes the plan *testable* instead of aspirational.
 
 **No bulk upgrades.** Running `npm update` across a stale tree gives you a broken build and a diff
 nobody can review. Instead every dependency is classified (patch / minor / major / vulnerable /
@@ -97,7 +97,7 @@ filled in with a plausible guess. The Limitations section lists every one of the
 
 | Phase | Goal | Milestone |
 |---|---|---|
-| **Pre Agent environment** | env an agent can use autonomously; create or improve `CLAUDE.md` / `AGENTS.md` | both files exist and document how to run the project |
+| **Pre Agent environment** | env an agent can use autonomously; create or improve `CLAUDE.md` / `AGENTS.md` | both files exist (create or update); commands documented in `CLAUDE.md` and Pre.1 notes |
 | **P0 Stabilize** | build green, tests runnable, CI running | baseline reproducible in CI |
 | **P1 Secure & Patch** | vulnerabilities closed, waves W1–W2 shipped | zero High/Critical advisories |
 | **P2 Modernize** | runtime upgrade, then majors one at a time | every major current or deferred with a reason |

--- a/skills/codebase-modernizer/docs/README.md
+++ b/skills/codebase-modernizer/docs/README.md
@@ -20,7 +20,7 @@ review, that skill's own `CODE_REVIEW.md` — and every file it created is liste
 | File | Contents |
 |---|---|
 | `MODERNIZATION_REPORT.md` | Baseline health + every finding, severity-ranked, each citing `file:line` |
-| `MODERNIZATION_PLAN.md` | 5 phases → sprints → tasks → milestones, every task closing named findings |
+| `MODERNIZATION_PLAN.md` | Pre + P0–P4 → sprints → tasks → milestones, every task closing named findings |
 
 ## When to Use
 
@@ -67,12 +67,14 @@ but only three of them actually run during the audit.
 | CI / pipelines | checklist scan | `devops-pipeline` |
 | Secrets / vulnerabilities | checklist scan | `security-setup` |
 | Docs drift | checklist scan | `doc-manager` |
+| Agent environment (`CLAUDE.md`, `AGENTS.md`) | not written | `/agent-config create` or `update` (plan Pre step) |
 
-**Why the split:** six of those skills *write* — they install pre-commit hooks, generate workflow
-files, create test files, rewrite docs, or refactor source. Running one during an audit would break
-the read-only promise. So the audit scans those dimensions itself, and the plan names the exact skill
-to run for each task — which is more useful anyway: "Task 3.2: run `/test-coverage` on
-`src/payments`" beats a finding that says coverage is low.
+**Why the split:** those skills *write* — they install pre-commit hooks, generate workflow files,
+create test files, rewrite docs, refactor source, or write `CLAUDE.md` / `AGENTS.md`. Running one
+during an audit would break the read-only promise. So the audit scans those dimensions itself, and
+the plan names the exact skill to run for each task — which is more useful anyway: "Task 3.2: run
+`/test-coverage` on `src/payments`" beats a finding that says coverage is low. `/agent-config` is
+the same pattern for the plan's Pre step: named, never run during the audit.
 
 ## The three ideas that make the output useful
 
@@ -95,6 +97,7 @@ filled in with a plausible guess. The Limitations section lists every one of the
 
 | Phase | Goal | Milestone |
 |---|---|---|
+| **Pre Agent environment** | env an agent can use autonomously; create or improve `CLAUDE.md` / `AGENTS.md` | both files exist and document how to run the project |
 | **P0 Stabilize** | build green, tests runnable, CI running | baseline reproducible in CI |
 | **P1 Secure & Patch** | vulnerabilities closed, waves W1–W2 shipped | zero High/Critical advisories |
 | **P2 Modernize** | runtime upgrade, then majors one at a time | every major current or deferred with a reason |

--- a/skills/codebase-modernizer/evals/evals.json
+++ b/skills/codebase-modernizer/evals/evals.json
@@ -5,17 +5,17 @@
       "id": 1,
       "kind": "happy-path",
       "prompt": "I haven't touched this project in about a year. Can you do a full review of the codebase — dependencies, logic, UI, UX — and give me a step-by-step plan with sprints and milestones to bring it up to date?",
-      "expected_output": "MODERNIZATION_REPORT.md and MODERNIZATION_PLAN.md written at the repo root; baseline recorded with a GREEN/AMBER/RED verdict; all 10 dimensions dispositioned; a 5-phase plan with sprints, tasks, and milestones.",
+      "expected_output": "MODERNIZATION_REPORT.md and MODERNIZATION_PLAN.md written at the repo root; baseline recorded with a GREEN/AMBER/RED verdict; all 10 dimensions dispositioned; a plan with the Agent-environment pre-step then P0-P4, sprints, tasks, and milestones.",
       "files": [],
       "expectations": [
         "The run establishes the Phase 0 baseline (build, tests, pass rate) BEFORE auditing any dimension",
         "Both MODERNIZATION_REPORT.md and MODERNIZATION_PLAN.md exist at the target repo root",
         "The report's dimension coverage table lists all 10 dimensions with Audited or Not Assessed + reason",
         "Every finding cites path:line, or is marked repo-wide only for absence-of-thing findings",
-        "The plan contains phases P0 through P4, each with at least one sprint and a measurable milestone",
+        "The plan starts with Pre / Agent environment, then phases P0 through P4 unrenumbered, each with at least one sprint and a measurable milestone",
         "Every task has at least 2 acceptance criteria, one asserting the test suite is still green",
         "Every task carries a Closes: line naming finding IDs, or names the milestone it enables",
-        "No repo-writing delegate is invoked during the audit — test-coverage, devops-pipeline, security-setup, doc-manager, code-review mode clean, and code-review mode cleanup are each named in a plan task instead",
+        "No repo-writing delegate is invoked during the audit — agent-config, test-coverage, devops-pipeline, security-setup, doc-manager, code-review mode clean, and code-review mode cleanup are each named in a plan task instead",
         "git diff --stat is empty — no tracked file's content was modified",
         "Any new file is one of the two reports, the declared CODE_REVIEW.md artifact, or a probe byproduct, and all of them are enumerated in the report's Artifacts section",
         "dont-make-me-think is invoked in review mode only — its Redesign Mode never runs and no UI source file is edited"
@@ -59,6 +59,7 @@
         "The baseline verdict is RED and the audit continues rather than aborting",
         "The UX dimension is marked 'Not Assessed — no UI detected' and no UX findings are invented",
         "The absent test suite is reported as a Critical finding and lands in phase P0",
+        "The plan starts with Pre / Agent environment before P0; missing CLAUDE.md and AGENTS.md are scheduled as /agent-config create, not written during the audit",
         "The plan's Sprint 0 restores baseline-green and later phases depend on milestone M0",
         "The Limitations section names every Not Assessed dimension and every missing tool"
       ]
@@ -73,7 +74,7 @@
         "Exactly the DEP and TEST dimensions are audited",
         "The other eight dimensions appear in the coverage table marked Not Assessed with the out-of-scope reason",
         "No findings are produced for dimensions that were not audited",
-        "The plan still uses the fixed P0-P4 skeleton, with empty phases collapsed to a one-line note rather than renumbered"
+        "The plan starts with Pre / Agent environment, then the fixed P0-P4 skeleton, with empty P0-P4 phases collapsed to a one-line note rather than dropped or renumbered"
       ]
     },
     {
@@ -85,7 +86,7 @@
       "expectations": [
         "codebase-modernizer does not trigger; the request routes to code-review",
         "No MODERNIZATION_REPORT.md or MODERNIZATION_PLAN.md is written",
-        "No 5-phase sprint plan is produced for a single-diff review"
+        "No Pre + P0-P4 sprint plan is produced for a single-diff review"
       ]
     },
     {
@@ -114,6 +115,7 @@
         "No CLEAN_CODE_AUDIT.md is produced (code-review mode clean is not invoked)",
         "dont-make-me-think runs in review mode only — no UI source file is edited",
         "Each of the six writing skills is named as the invocation in at least one plan task",
+        "The plan's Pre step names /agent-config create or /agent-config update and agent-config is not invoked during the audit",
         "git diff --stat is empty at the end of the run"
       ]
     },
@@ -134,7 +136,7 @@
       "id": 10,
       "kind": "happy-path",
       "prompt": "I inherited this Rails app from a contractor who left 8 months ago. Give me a refactoring and upgrade plan I can actually work through sprint by sprint.",
-      "expected_output": "Full audit plus a P0-P4 plan sized into sprints, with the Ruby/Rails dependency and runtime currency assessed and majors split one per task.",
+      "expected_output": "Full audit plus a Pre then P0-P4 plan sized into sprints, with the Ruby/Rails dependency and runtime currency assessed and majors split one per task.",
       "files": [],
       "expectations": [
         "The skill triggers on the inherited/neglected-codebase framing without the user saying 'modernize' or 'stale'",
@@ -142,7 +144,23 @@
         "The Ruby ecosystem is detected and its runtime version checked against current stable for EOL",
         "Any Rails major-version bump is its own task naming a migration source, never batched with other upgrades",
         "Sprints are sized to 5-10 tasks each and every task carries an effort estimate",
+        "The plan starts with Pre / Agent environment before unrenumbered P0-P4",
         "Both MODERNIZATION_REPORT.md and MODERNIZATION_PLAN.md are written; git diff --stat is empty"
+      ]
+    },
+    {
+      "id": 11,
+      "kind": "edge",
+      "prompt": "Audit this repo and give me the modernization plan. (Target: CLAUDE.md and AGENTS.md already exist at the repo root.)",
+      "expected_output": "Plan still opens with Pre / Agent environment. Existing agent config files are scheduled as /agent-config update (improve), never skipped, and never rewritten during the audit.",
+      "files": [],
+      "expectations": [
+        "The plan contains Pre / Agent environment ordered before P0 Stabilize even though CLAUDE.md and AGENTS.md already exist",
+        "Pre tasks name /agent-config update for the existing files, not create, and do not treat file presence as done",
+        "If either file had been missing the matching task would have named /agent-config create instead",
+        "agent-config is not invoked during the audit; CLAUDE.md and AGENTS.md content is unchanged",
+        "P0 through P4 remain present and are not renamed or renumbered",
+        "git diff --stat is empty — no tracked file's content was modified"
       ]
     }
   ]

--- a/skills/codebase-modernizer/evals/evals.json
+++ b/skills/codebase-modernizer/evals/evals.json
@@ -13,7 +13,7 @@
         "The report's dimension coverage table lists all 10 dimensions with Audited or Not Assessed + reason",
         "Every finding cites path:line, or is marked repo-wide only for absence-of-thing findings",
         "The plan starts with Pre / Agent environment, then phases P0 through P4 unrenumbered, each with at least one sprint and a measurable milestone",
-        "Every task has at least 2 acceptance criteria, one asserting the test suite is still green",
+        "Every P0-P4 task has at least 2 acceptance criteria, one asserting the test suite is still green; Pre is exempt from the green assertion when the baseline is RED",
         "Every task carries a Closes: line naming finding IDs, or names the milestone it enables",
         "No repo-writing delegate is invoked during the audit — agent-config, test-coverage, devops-pipeline, security-setup, doc-manager, code-review mode clean, and code-review mode cleanup are each named in a plan task instead",
         "git diff --stat is empty — no tracked file's content was modified",
@@ -60,6 +60,7 @@
         "The UX dimension is marked 'Not Assessed — no UI detected' and no UX findings are invented",
         "The absent test suite is reported as a Critical finding and lands in phase P0",
         "The plan starts with Pre / Agent environment before P0; missing CLAUDE.md and AGENTS.md are scheduled as /agent-config create, not written during the audit",
+        "Pre has no green-build/suite acceptance criterion; restore-green stays on Sprint 0",
         "The plan's Sprint 0 restores baseline-green and later phases depend on milestone M0",
         "The Limitations section names every Not Assessed dimension and every missing tool"
       ]

--- a/skills/codebase-modernizer/references/baseline.md
+++ b/skills/codebase-modernizer/references/baseline.md
@@ -110,7 +110,7 @@ Do not launch servers, open browsers, or run migrations. This skill is read-only
 A completed baseline table plus the verdict, written into the report's Baseline section by Phase 3.
 Carry forward to later phases:
 
-- the exact **test command** (every planned task's acceptance criteria reference it),
-- the **pass rate** at audit time (the "still green" bar tasks must not regress below),
+- the exact **test command** (every P0–P4 task's acceptance criteria reference it; Pre does not),
+- the **pass rate** at audit time (the "still green" bar P0–P4 tasks must not regress below),
 - the list of rows marked **Not Assessed** (they become P0 tasks: add coverage tooling, add CI, and
   so on).

--- a/skills/codebase-modernizer/references/delegation-policy.md
+++ b/skills/codebase-modernizer/references/delegation-policy.md
@@ -59,3 +59,18 @@ dimensions fall back to inline as well. That *is* reduced depth, unlike the six 
 
 Never guess whether a delegate exists. An unverified assumption that a skill is present produces a
 `Path: delegated` row backed by nothing.
+
+## Planned later — `/agent-config` (not a dimension)
+
+`/agent-config` **writes** `CLAUDE.md` and `AGENTS.md`. It is not an audit dimension and it is never
+invoked during the audit — not `create`, not `update`, not `audit`.
+
+Name it only in the plan's **Pre — Agent environment** tasks, which the user runs later:
+
+| File state at audit time | Planned invocation |
+|---|---|
+| `CLAUDE.md` or `AGENTS.md` absent | `/agent-config create` targeting that file |
+| file already present | `/agent-config update` targeting that file |
+
+Presence of either file is not a reason to skip Pre. Do not treat "the file exists" as the
+milestone. The audit records which variant to schedule; it does not draft or patch the files.

--- a/skills/codebase-modernizer/references/plan-template.md
+++ b/skills/codebase-modernizer/references/plan-template.md
@@ -6,18 +6,35 @@ format matches `tasks-generator` so the plan interoperates with that skill; the 
 
 ## The fixed phase skeleton
 
-Phases are always P0–P4 in this order. A phase with no findings collapses to a one-line "nothing
-found in this phase" note — it is never renumbered or dropped, because the ordering is the argument:
-you cannot verify an upgrade without a baseline, and you should not modernize on top of a known
-vulnerability.
+Every plan starts with an unconditional **Pre — Agent environment** step, then phases **P0–P4** in
+this order. Do not rename, drop, or renumber P0–P4 to make room for Pre. A P0–P4 phase with no
+findings collapses to a one-line "nothing found in this phase" note — it is never renumbered or
+dropped, because the ordering is the argument: you cannot verify an upgrade without a baseline, and
+you should not modernize on top of a known vulnerability. Pre is never collapsed away.
 
 | Phase | Goal | Exit milestone |
 |---|---|---|
+| **Pre Agent environment** | project env an AI agent can use autonomously; `CLAUDE.md` and `AGENTS.md` created or improved | `ME` — both files exist at the repo root, document the recorded build/test commands, and are scheduled via `/agent-config` (not written during the audit) |
 | **P0 Stabilize** | build green, tests runnable, lockfile committed, CI running the suite | `M0` — baseline-green reproducible in CI from a clean checkout |
 | **P1 Secure & Patch** | close vulnerabilities, ship waves W1–W2 | `M1` — zero known High/Critical advisories; patch/minor current |
 | **P2 Modernize** | runtime/toolchain upgrade (W3), then one major per task (W4+) | `M2` — every major current or deferred with written rationale |
 | **P3 Clean & Harden** | dead code, duplication, weak types, coverage to target | `M3` — coverage ≥ target; duplication below threshold; zero `any` in the named scope |
 | **P4 Polish** | UI/UX, performance, docs alignment | `M4` — UX findings closed; perf budget met; docs match code |
+
+### Pre — Agent environment — required, not optional
+
+Pre is planned work, never applied by this skill. It exists so a later agent can execute P0–P4
+without unwritten human context. Put the detailed tasks here; do not invent `F-*` findings for it —
+Pre tasks are milestone-enabling and serve `ME`.
+
+| Rule | How to fill it |
+|---|---|
+| Always present | Emit Pre even when `CLAUDE.md` and `AGENTS.md` already exist. Presence is not done. |
+| Create vs improve | File **absent** → task names `/agent-config create` for that file. File **present** → task names `/agent-config update` (improve against agent-config's checklists). Cover **both** files, independently. |
+| Broader env | Also schedule whatever an agent needs to install, configure, and run the repo: toolchain install, required env vars / `.env.example`, the recorded build and test commands, non-obvious repo etiquette. Fold these into Pre tasks; do not push them into P0. |
+| Never invoke | Do **not** run `/agent-config` (or write `CLAUDE.md` / `AGENTS.md`) during the audit. Name the exact invocation on the task's `Verify:` line. |
+| IDs | Sprint **Pre**, tasks `Task Pre.<index>` so P0 keeps Sprint 0 / `Task 0.<index>`. |
+| Order | `ME` precedes every P0–P4 task. On a RED baseline, Pre is the only work allowed before `M0`. |
 
 ### Binding M3 and M4 — required, not optional
 
@@ -52,13 +69,68 @@ what makes this plan testable rather than aspirational.
 
 | Phase | Sprints | Tasks | Closes | Milestone |
 |---|---|---|---|---|
+| Pre Agent environment | 1 | 3 | — (enables ME) | ME |
 | P0 Stabilize | 1 | 6 | 4 Critical | M0 |
 | P1 Secure & Patch | 2 | 11 | 3 Critical, 8 High | M1 |
 | P2 Modernize | 3 | 14 | 6 High | M2 |
 | P3 Clean & Harden | 2 | 12 | 18 Medium | M3 |
 | P4 Polish | 1 | 8 | 9 Low | M4 |
 
-**Critical path:** Task 0.1 → 0.3 → 1.2 → 2.1 → 2.4 (<N> days). Nothing in P2 starts before M0.
+**Critical path:** Task Pre.1 → 0.1 → 0.3 → 1.2 → 2.1 → 2.4 (<N> days). Nothing in P0 starts before ME. Nothing in P2 starts before M0.
+
+## Phase Pre — Agent environment
+
+**Goal:** <one line> · **Milestone ME:** <CLAUDE.md and AGENTS.md created or improved; recorded build/test commands documented>
+
+### Sprint Pre — Agent-runnable environment
+
+#### Task Pre.1: <Make the project environment agent-runnable>
+
+**Description**: Install/configure notes, env vars, and the recorded build/test commands so an agent can proceed without unwritten context. Serves milestone ME.
+
+**Closes**: — (milestone-enabling: ME)
+
+**Acceptance Criteria**:
+- [ ] A later agent can install deps and run the recorded build/test commands from written project files alone
+- [ ] `<test command>` passes at ≥ 41/58 (baseline-green holds)
+
+**Dependencies**: None
+
+**Effort**: S | M | L (1–3 days)
+
+**Verify**: `<the exact command a reviewer runs to confirm this task is done>`
+
+#### Task Pre.2: <Create or improve CLAUDE.md>
+
+**Description**: File absent → `/agent-config create` targeting `CLAUDE.md`. File present → `/agent-config update`. Serves milestone ME. Do not run the skill while planning.
+
+**Closes**: — (milestone-enabling: ME)
+
+**Acceptance Criteria**:
+- [ ] `CLAUDE.md` exists at the repo root and names the recorded build/test commands
+- [ ] `<test command>` passes at ≥ 41/58 (baseline-green holds)
+
+**Dependencies**: Pre.1
+
+**Effort**: S
+
+**Verify**: run `/agent-config create` (or `update` if the file exists) targeting `CLAUDE.md`
+
+#### Task Pre.3: <Create or improve AGENTS.md>
+
+**Description**: File absent → `/agent-config create` targeting `AGENTS.md`. File present → `/agent-config update`. Serves milestone ME. Do not run the skill while planning.
+
+**Closes**: — (milestone-enabling: ME)
+
+**Acceptance Criteria**:
+- [ ] `AGENTS.md` exists at the repo root (create) or is improved against agent-config checklists (update)
+- [ ] `<test command>` passes at ≥ 41/58 (baseline-green holds)
+
+**Dependencies**: Pre.1
+
+**Effort**: S
+
+**Verify**: run `/agent-config create` (or `update` if the file exists) targeting `AGENTS.md`
 
 ## Phase P0 — Stabilize
 
@@ -93,8 +165,9 @@ what makes this plan testable rather than aspirational.
 
 | Task | Depends on | Blocks | Wave |
 |---|---|---|---|
-| 0.1 | — | 0.3, 1.1 | W0 |
-| 1.1 | 0.1 | 2.1 | W1 |
+| Pre.1 | — | Pre.2, Pre.3, 0.1 | W0 |
+| 0.1 | Pre.1 | 0.3, 1.1 | W1 |
+| 1.1 | 0.1 | 2.1 | W2 |
 
 ## Execution waves
 
@@ -103,13 +176,15 @@ run in parallel.
 
 | Wave | Tasks |
 |---|---|
-| 1 | 0.1, 0.2, 0.4 |
-| 2 | 0.3, 0.5 |
+| 1 | Pre.1 |
+| 2 | Pre.2, Pre.3, 0.1, 0.2, 0.4 |
+| 3 | 0.3, 0.5 |
 
 ## Milestones
 
 | ID | Phase | Exit condition (measurable) | Verify with |
 |---|---|---|---|
+| ME | Pre | `CLAUDE.md` and `AGENTS.md` exist (created or improved); recorded build/test commands documented | `test -f CLAUDE.md && test -f AGENTS.md` |
 | M0 | P0 | clean checkout → build + suite green in CI | CI run link / `<command>` |
 | M1 | P1 | `npm audit --json` reports 0 high+ advisories | `<command>` |
 
@@ -153,21 +228,24 @@ oversight — this section is what makes the plan reviewable.
 - Runtime/toolchain upgrade (W3) precedes framework majors that require it.
 
 **Delegate tasks**
-- The audit deliberately did not run the six skills that write (`code-review` modes `clean` and
-  `cleanup`, `test-coverage`, `devops-pipeline`, `security-setup`, `doc-manager`). Where one of them
-  does a task's work, the task names it and its exact invocation — e.g.
+- The audit deliberately did not run the skills that write (`/agent-config create|update`,
+  `code-review` modes `clean` and `cleanup`, `test-coverage`, `devops-pipeline`, `security-setup`,
+  `doc-manager`). Where one of them does a task's work, the task names it and its exact invocation —
+  e.g. `Verify: run /agent-config update targeting CLAUDE.md` or
   `Verify: run /test-coverage on src/payments, then npm test`.
 - The task still carries its own acceptance criteria. "Ran the skill" is not a criterion; what the
   skill was supposed to achieve is.
 
 **Structure**
-- Task IDs are `Task <sprint>.<index>`; sprint numbering runs continuously across phases (Sprint 0 in
-  P0, Sprint 1–2 in P1, …) so IDs stay unique.
+- Pre uses `Task Pre.<index>` in Sprint Pre. After that, task IDs are `Task <sprint>.<index>`; sprint
+  numbering runs continuously across P0–P4 (Sprint 0 in P0, Sprint 1–2 in P1, …) so IDs stay unique.
 - The dependency table references only task IDs that exist, and contains no cycles.
 - The critical path is stated explicitly with its task chain and duration.
 - Every phase has a milestone whose exit condition is measurable by a stated command or artifact.
 
 **Sequencing that must hold**
-- Nothing outside P0 starts before `M0` when the baseline is RED.
+- Pre is first. No P0–P4 task starts before `ME`.
+- Nothing outside P0 starts before `M0` when the baseline is RED, except Pre (which precedes P0).
 - Refactor tasks in P3 depend on the tests that cover the code they touch.
 - `code-review` mode `cleanup` appears as a P3 task the user runs — this skill never runs it.
+- `/agent-config create|update` appears as Pre tasks the user runs — this skill never runs it.

--- a/skills/codebase-modernizer/references/plan-template.md
+++ b/skills/codebase-modernizer/references/plan-template.md
@@ -79,7 +79,7 @@ finish first. Pre ACs only require documented install/run notes and create-or-up
 | P3 Clean & Harden | 2 | 12 | 18 Medium | M3 |
 | P4 Polish | 1 | 8 | 9 Low | M4 |
 
-**Critical path:** Task Pre.1 → 0.1 → 0.3 → 1.2 → 2.1 → 2.4 (<N> days). Nothing in P0 starts before ME. Nothing in P2 starts before M0.
+**Critical path:** Task Pre.1 → Pre.2 → 0.1 → 0.3 → 1.2 → 2.1 → 2.4 (<N> days). Nothing in P0 starts before ME. Nothing in P2 starts before M0.
 
 ## Phase Pre — Agent environment
 

--- a/skills/codebase-modernizer/references/plan-template.md
+++ b/skills/codebase-modernizer/references/plan-template.md
@@ -14,7 +14,7 @@ you should not modernize on top of a known vulnerability. Pre is never collapsed
 
 | Phase | Goal | Exit milestone |
 |---|---|---|
-| **Pre Agent environment** | project env an AI agent can use autonomously; `CLAUDE.md` and `AGENTS.md` created or improved | `ME` — both files exist at the repo root, document the recorded build/test commands, and are scheduled via `/agent-config` (not written during the audit) |
+| **Pre Agent environment** | project env an AI agent can use autonomously; `CLAUDE.md` and `AGENTS.md` created or improved | `ME` — both files exist (create or update via planned `/agent-config`); recorded build/test commands documented in `CLAUDE.md` and Pre.1 notes |
 | **P0 Stabilize** | build green, tests runnable, lockfile committed, CI running the suite | `M0` — baseline-green reproducible in CI from a clean checkout |
 | **P1 Secure & Patch** | close vulnerabilities, ship waves W1–W2 | `M1` — zero known High/Critical advisories; patch/minor current |
 | **P2 Modernize** | runtime/toolchain upgrade (W3), then one major per task (W4+) | `M2` — every major current or deferred with written rationale |
@@ -83,7 +83,7 @@ finish first. Pre ACs only require documented install/run notes and create-or-up
 
 ## Phase Pre — Agent environment
 
-**Goal:** <one line> · **Milestone ME:** <CLAUDE.md and AGENTS.md created or improved; recorded build/test commands documented>
+**Goal:** <one line> · **Milestone ME:** <CLAUDE.md and AGENTS.md created or improved; recorded build/test commands documented in CLAUDE.md and Pre.1 notes>
 
 ### Sprint Pre — Agent-runnable environment
 
@@ -126,8 +126,8 @@ finish first. Pre ACs only require documented install/run notes and create-or-up
 **Closes**: — (milestone-enabling: ME)
 
 **Acceptance Criteria**:
-- [ ] `AGENTS.md` exists at the repo root (create) or is improved against agent-config checklists (update)
-- [ ] `AGENTS.md` names the recorded build/test commands
+- [ ] `AGENTS.md` exists at the repo root (create via `/agent-config` if absent)
+- [ ] `AGENTS.md` is improved against agent-config checklists only (subagent definitions; update if already present). Recorded build/test commands stay on Pre.1 notes and `CLAUDE.md`
 
 **Dependencies**: Pre.1
 
@@ -188,7 +188,7 @@ run in parallel.
 
 | ID | Phase | Exit condition (measurable) | Verify with |
 |---|---|---|---|
-| ME | Pre | `CLAUDE.md` and `AGENTS.md` exist (created or improved); recorded build/test commands documented | `test -f CLAUDE.md && test -f AGENTS.md` |
+| ME | Pre | `CLAUDE.md` and `AGENTS.md` exist (create or update); recorded build/test commands documented in `CLAUDE.md` and Pre.1 notes | `test -f CLAUDE.md && test -f AGENTS.md` |
 | M0 | P0 | clean checkout → build + suite green in CI | CI run link / `<command>` |
 | M1 | P1 | `npm audit --json` reports 0 high+ advisories | `<command>` |
 

--- a/skills/codebase-modernizer/references/plan-template.md
+++ b/skills/codebase-modernizer/references/plan-template.md
@@ -35,6 +35,7 @@ Pre tasks are milestone-enabling and serve `ME`.
 | Never invoke | Do **not** run `/agent-config` (or write `CLAUDE.md` / `AGENTS.md`) during the audit. Name the exact invocation on the task's `Verify:` line. |
 | IDs | Sprint **Pre**, tasks `Task Pre.<index>` so P0 keeps Sprint 0 / `Task 0.<index>`. |
 | Order | `ME` precedes every P0–P4 task. On a RED baseline, Pre is the only work allowed before `M0`. |
+| RED baseline | Pre does **not** assert a green build or suite. Restore-green stays on P0 / Sprint 0. Pre ACs only require documented install/run notes and create-or-update of `CLAUDE.md` / `AGENTS.md`. |
 
 ### Binding M3 and M4 — required, not optional
 
@@ -62,8 +63,10 @@ multiple sprints when it exceeds that; a phase always has at least one sprint.
 Derived from [`MODERNIZATION_REPORT.md`](./MODERNIZATION_REPORT.md) · **Baseline at audit:** <verdict>
 **Test command of record:** `<command>` · **Pass rate at audit:** `<41/58>`
 
-Every task's acceptance criteria include *"`<test command>` passes at ≥ the recorded rate"*. That is
-what makes this plan testable rather than aspirational.
+Every P0–P4 task's acceptance criteria include *"`<test command>` passes at ≥ the recorded rate"*.
+On a RED baseline, Pre omits that assertion — restoring green is P0 / Sprint 0, and Pre must
+finish first. Pre ACs only require documented install/run notes and create-or-update of
+`CLAUDE.md` / `AGENTS.md`.
 
 ## At a glance
 
@@ -91,8 +94,8 @@ what makes this plan testable rather than aspirational.
 **Closes**: — (milestone-enabling: ME)
 
 **Acceptance Criteria**:
-- [ ] A later agent can install deps and run the recorded build/test commands from written project files alone
-- [ ] `<test command>` passes at ≥ 41/58 (baseline-green holds)
+- [ ] Written notes cover toolchain install, required env vars / `.env.example`, and the recorded build/test commands
+- [ ] A later agent can follow those notes from project files alone (commands may still be RED; restoring green is P0)
 
 **Dependencies**: None
 
@@ -107,8 +110,8 @@ what makes this plan testable rather than aspirational.
 **Closes**: — (milestone-enabling: ME)
 
 **Acceptance Criteria**:
-- [ ] `CLAUDE.md` exists at the repo root and names the recorded build/test commands
-- [ ] `<test command>` passes at ≥ 41/58 (baseline-green holds)
+- [ ] `CLAUDE.md` exists at the repo root (create via `/agent-config` if absent)
+- [ ] `CLAUDE.md` names the recorded build/test commands (improve via `/agent-config update` if already present)
 
 **Dependencies**: Pre.1
 
@@ -124,7 +127,7 @@ what makes this plan testable rather than aspirational.
 
 **Acceptance Criteria**:
 - [ ] `AGENTS.md` exists at the repo root (create) or is improved against agent-config checklists (update)
-- [ ] `<test command>` passes at ≥ 41/58 (baseline-green holds)
+- [ ] `AGENTS.md` names the recorded build/test commands
 
 **Dependencies**: Pre.1
 
@@ -148,7 +151,7 @@ what makes this plan testable rather than aspirational.
 - [ ] <specific, checkable condition — a command, a file state, or a count>
 - [ ] `<test command>` passes at ≥ 41/58 (baseline-green holds)
 
-**Dependencies**: None
+**Dependencies**: Pre.2, Pre.3
 
 **Effort**: S | M | L (1–3 days)
 
@@ -166,7 +169,7 @@ what makes this plan testable rather than aspirational.
 | Task | Depends on | Blocks | Wave |
 |---|---|---|---|
 | Pre.1 | — | Pre.2, Pre.3, 0.1 | W0 |
-| 0.1 | Pre.1 | 0.3, 1.1 | W1 |
+| 0.1 | Pre.2, Pre.3 | 0.3, 1.1 | W1 |
 | 1.1 | 0.1 | 2.1 | W2 |
 
 ## Execution waves
@@ -177,8 +180,9 @@ run in parallel.
 | Wave | Tasks |
 |---|---|
 | 1 | Pre.1 |
-| 2 | Pre.2, Pre.3, 0.1, 0.2, 0.4 |
-| 3 | 0.3, 0.5 |
+| 2 | Pre.2, Pre.3 |
+| 3 | 0.1, 0.2, 0.4 |
+| 4 | 0.3, 0.5 |
 
 ## Milestones
 
@@ -212,11 +216,15 @@ oversight — this section is what makes the plan reviewable.
 - No task invents work absent from the report.
 
 **Testability**
-- ≥ 2 acceptance criteria per task; at least one asserts baseline-green still holds.
+- ≥ 2 acceptance criteria per task. P0–P4 tasks include one that asserts baseline-green still holds.
+  **Pre is exempt from the green-build/suite AC when the baseline is RED** — restoring that is P0 /
+  Sprint 0, and no P0 work may start before `ME`. Pre ACs only require documented install/run notes
+  and create-or-update of `CLAUDE.md` / `AGENTS.md`.
 - **When there is no test command at audit time** (RED baseline, no suite — a supported case), the
-  baseline assertion falls back to the build: tasks scheduled *before* the P0 suite-creation task
-  assert "`<build command>` succeeds"; every task *after* it asserts the suite that task established.
-  State this substitution once at the top of the plan so the criteria are not silently weaker.
+  baseline assertion falls back to the build: **P0–P4** tasks scheduled *before* the P0 suite-creation
+  task assert "`<build command>` succeeds"; every task *after* it asserts the suite that task
+  established. Do not apply this fallback to Pre. State the substitution once at the top of the
+  plan so the criteria are not silently weaker.
 - Each criterion is checkable by a command, a file state, or a count — never "code is cleaner".
 - The `Verify:` line gives the exact command a reviewer runs.
 

--- a/skills/codebase-modernizer/references/report-template.md
+++ b/skills/codebase-modernizer/references/report-template.md
@@ -39,7 +39,7 @@ the plan does about them. No hedging, no filler.>
 | Last commit | <date>, N commits in 12 months | `git log -1` |
 
 **Verdict:** GREEN | AMBER | RED
-**Test command of record:** `<command>` — every plan task's acceptance criteria reference this.
+**Test command of record:** `<command>` — every P0–P4 plan task's acceptance criteria reference this. Pre ACs do not.
 
 ## Dimension coverage
 


### PR DESCRIPTION
Closes #93

## Summary

`codebase-modernizer` plans now open with an unconditional **Pre — Agent environment** step (create or update `CLAUDE.md` and `AGENTS.md` via a named `/agent-config` invocation) ordered before the existing P0–P4 modernization phases. Workflow Phase 0 Baseline and plan P0 Stabilize are unchanged. The skill stays read-only: the pre-step is planned, not applied during the audit.

## Approach

Option 2 — Balanced pre-step across emit, validate, and evals: wire the pre-step through the plan template, architect, SKILL Phase 4 acceptance, validator, evals, delegation policy, and human docs. Name `/agent-config create|update`; never invoke it during the audit.

## Decision Record

- **Root cause:** Emitted plans used a fixed P0–P4 Stabilize→Secure→Modernize→Clean→Polish skeleton. Agent-facing `CLAUDE.md`/`AGENTS.md` never appeared, so later phases assumed an already-briefed agent on stale or inherited repos.
- **Options considered:** Option 1 — Minimal pre-step in the plan skeleton; Option 2 — Balanced pre-step across emit, validate, and evals; Option 3 — Comprehensive plan-model and agent-config integration
- **Options rejected:** Option 1 — Does not update plan-validator or evals, so the new pre-step is neither validated nor locked; Option 3 — Over-scopes into agent-config, report-template, dimension-map, and baseline.md beyond what is needed to emit an unconditional planned pre-step
- **Selected option:** Option 2 — Balanced pre-step across emit, validate, and evals
- **Residual risk:** Evals are prompt expectations, not an executable runner (same gap as #88)

Analyzed at: `refactor/93-add-agent-environment-setup-pre-step @ 78818f6` (2026-08-18)

## Changes

| File | Change |
|------|--------|
| `skills/codebase-modernizer/references/plan-template.md` | Unconditional Pre / Agent environment before unrenumbered P0–P4; Pre exempt from green-suite AC on RED; Pre.3 is AGENTS.md checklists only |
| `skills/codebase-modernizer/agents/plan-architect.md` | Always emit Pre; name `/agent-config`, never run it; green AC only on P0–P4 |
| `skills/codebase-modernizer/SKILL.md` | 1.1.0 → 1.2.1; Phase 4 / acceptance = Pre + P0–P4 |
| `skills/codebase-modernizer/agents/plan-validator.md` | Require Pre before M0; treat `/agent-config` as planned, not applied |
| `skills/codebase-modernizer/references/delegation-policy.md` | `/agent-config create\|update` is a later writing skill, never an audit invoke |
| `skills/codebase-modernizer/evals/evals.json` | Plan-shape cases expect Pre first; create-vs-improve case; green AC scoped to P0–P4 |
| `skills/codebase-modernizer/references/baseline.md` | Qualify carry-forward green AC to P0–P4 |
| `skills/codebase-modernizer/references/report-template.md` | Qualify report line green AC to P0–P4 |
| `skills/codebase-modernizer/docs/README.md` | Human docs: Pre row, `/agent-config` planned only |
| `README.md` | Catalog version 1.2.1 |
| `CHANGELOG.md` | Unreleased 1.2.1 note |

## Test Results

- Unit tests: skipped — no framework
- Integration tests: skipped — no framework
- E2e tests: skipped — no framework
- Skill validate: 1 passed (`quick_validate.py skills/codebase-modernizer`)
- Build: passed (markdown/YAML skill; validator green)
- QA cycles: 5

## Acceptance Criteria Verification

| Criterion | Status | Evidence |
|-----------|--------|----------|
| Every plan emitted by `codebase-modernizer` contains a pre-step ordered before all existing modernization phases | pass | `skills/codebase-modernizer/references/plan-template.md` glance table + Phase Pre; architect self-check; evals plan-shape cases |
| The pre-step covers setting up the project environment so an AI agent can proceed autonomously | pass | Pre — Agent environment: install/run notes + agent-config files before P0 Stabilize |
| The pre-step explicitly covers creating or improving `CLAUDE.md` and `AGENTS.md` | pass | Pre.2 `/agent-config` for CLAUDE.md; Pre.3 `/agent-config` for AGENTS.md (create or update) |
| The pre-step is present whether or not those files already exist (create vs. fix/improve) | pass | `evals/evals.json` case 11 (existing files → update, not skip); template create-vs-update variants |
| The skill remains read-only — the pre-step is planned, not applied | pass | `delegation-policy.md` names `/agent-config` for later; evals keep `git diff --stat` empty |

<!-- gitissue:qa v1 head=78818f6b8cb89ed83ae8d01f97607e934ed660bf profile=full cycles=5 review=clean tests=1@78818f6b8cb89ed83ae8d01f97607e934ed660bf ui=none -->
