### PR TITLE
feat: add new-machine-setup skill

### DIFF
--- a/skills/new-machine-setup/SKILL.md
+++ b/skills/new-machine-setup/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: new-machine-setup
-description: "Set up a clean, ready-to-develop machine across macOS, Linux, and Windows with OS/arch detection and a human-in-the-loop per phase. Use when the user wants a fresh dev box, to bootstrap Node/Python, install Claude Code, Codex, Pi, OpenCode, or Oh My Zsh, or to debloat OEM apps. Don't use for Dockerfiles, CI images, or one-off package installs."
+description: "Set up a clean, ready-to-develop machine on macOS, Linux, or Windows: OS/arch detection, Node/Python bootstrap, Claude Code, Codex, Pi, or OpenCode installs with per-phase approval. Don't use for Dockerfiles, CI images, or one-off package installs."
 license: MIT
 compatibility: "macOS, Linux (Debian/Ubuntu/Fedora/Arch), Windows (winget/PowerShell). Needs network and a package manager or permission to install one. Never run destructive uninstalls without an explicit yes."
 metadata:
-  version: 0.3.0
+  version: 0.3.1
   author: "Luong NGUYEN <luongnv89@gmail.com>"
   effort: high
 ---

--- a/skills/new-machine-setup/SKILL.md
+++ b/skills/new-machine-setup/SKILL.md
@@ -4,7 +4,7 @@ description: "Set up a clean, ready-to-develop machine across macOS, Linux, and 
 license: MIT
 compatibility: "macOS, Linux (Debian/Ubuntu/Fedora/Arch), Windows (winget/PowerShell). Needs network and a package manager or permission to install one. Never run destructive uninstalls without an explicit yes."
 metadata:
-  version: 0.1.0
+  version: 0.2.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
   effort: high
 ---
@@ -16,6 +16,17 @@ Turn a factory laptop into a **clean, ready-to-develop** machine. Detect OS + CP
 This skill is an orchestrator. Long per-OS command tables live in `references/` so only the current platform is loaded.
 
 **Do not** pipe remote scripts to a shell until the user has approved that step. Prefer official installers and the user's own [inbash](https://github.com/luongnv89/inbash) scripts when they match the OS.
+
+## Human-in-the-loop (mandatory)
+
+Every phase runs as a strict four-step loop. Do not skip any step, and do not batch multiple phases into one approval.
+
+1. **Present** — show exactly what will be executed for this phase: each command, what it installs/changes, and any risk (especially removals or `curl | sh`).
+2. **Approve** — wait for the user's explicit go-ahead (a clear "yes" or "run it"). For removals and remote-script installs, require an explicit per-item yes; a blanket "do everything" only covers non-destructive steps.
+3. **Execute** — run only what was approved. If something fails, stop and re-present before retrying; never silently widen scope.
+4. **Verify** — after execution, confirm the phase actually succeeded (version checks, file pres:ence, exit-code reads). Record pass/fail in the running log.
+
+Keep a running list of every step's outcome (✓ / ✗ + evidence). The final report is built from this log, never from memory.
 
 ## When to Use
 
@@ -46,64 +57,68 @@ Don't use for: Dockerfiles, CI runners, or installing a single package.
 
 ## Procedure
 
+Each phase follows the **Human-in-the-loop** loop (present → approve → execute → verify). Begin every phase by presenting the concrete plan for that phase; do not move to the next phase until the current one verifies green (or is explicitly deferred by the user).
+
 ### 1. Detect the machine
 
-Run:
+- **Present:** "I'll run `python3 scripts/detect_env.py` to read OS, arch, package managers, and which dev tools already exist. Read-only, no changes."
+- **Approve:** wait.
+- **Execute:** run `python3 scripts/detect_env.py` (or the fallback one-liners from `references/detect.md` if `python3` is missing).
+- **Verify:** confirm JSON contains `os`, `arch`, a package manager, and the tool map. Read **only** the OS reference that matches (`windows.md` / `macos.md` / `linux.md`).
 
-```bash
-python3 scripts/detect_env.py
-```
-
-If `python3` is missing, use the one-liners in `references/detect.md`.
-
-**Done when:** you have `os` (`macos` | `linux` | `windows`), `arch` (`x86_64` | `arm64` | other), package manager, and which of `{git,node,npm,python3,zsh,brew,winget}` already exist.
-
-Then read **only** the matching OS reference (`windows.md` / `macos.md` / `linux.md`).
+**Phase 1 done when:** inventory JSON is captured and the correct OS reference is selected.
 
 ### 2. Inventory (Windows first; useful everywhere)
 
 Inspired by [XFreeze](https://x.com/xfreeze/status/2090189407659999603): factory Windows boxes ship trial AV, OEM utilities, and partner games. **List before delete.**
 
-On Windows, follow `references/windows.md` § Inventory. On macOS/Linux, list unexpected GUI apps and leftover vendor agents, but do not uninstall by default.
+- **Present:** the inventory commands (e.g. `winget list`, `Get-AppxPackage`). State this is read-only.
+- **Approve:** wait.
+- **Execute:** follow `references/windows.md` § Inventory (or list GUI apps / vendor agents on macOS/Linux).
+- **Verify:** you have a complete list; build a `keep / review / remove-candidate` table.
 
-Present a short table: keep / review / remove-candidate. Wait for an explicit yes on every removal.
+Then, **per removal**:
+- **Present** each removal candidate with its exact command and the risk (e.g. losing a vendor utility).
+- **Approve:** explicit per-item yes. No removal without it.
+- **Execute** only confirmed rows.
+- **Verify** the package is gone (`winget list` / `Get-AppxPackage` no longer shows it).
 
-**Done when:** the user has seen the inventory. Removals are either skipped or confirmed one-by-one.
+**Phase 2 done when:** inventory shown; removals are either skipped or confirmed one-by-one and verified.
 
 ### 3. Baseline toolchain
 
-Install missing pieces only (idempotent):
+- **Present:** the full list of what will be installed for this machine, drawn from the table below, with the exact commands (Homebrew/inbash/winget). Flag anything that overwrites an existing Node/Python.
+- **Approve:** wait.
+- **Execute:** install **missing** pieces only (idempotent):
+  - Package manager — Homebrew (mac), winget (Windows), distro pkg (Linux)
+  - CLI baseline — git, curl, wget, vim/editor (inbash `unix/basic.sh` on Debian)
+  - Shell — zsh + Oh My Zsh + inbash `setup-ohMyZsh.sh` (mac/linux); Windows keeps PowerShell, optional WSL2
+  - Node.js LTS — inbash `unix/nodejs.sh` / `mac/nodejs.sh`; Windows `winget install OpenJS.NodeJS.LTS`
+  - Python — mac: inbash `mac/python-pip-uv.sh`; Linux: `unix/python3-pip.sh` + **uv**; Windows: `winget install Python.Python.3.12` + **uv**
+- **Verify:** `git --version`, `node -v`, `npm -v`, `python3 --version` (and `uv --version`) succeed for the target OS. Prefer LTS Node and a venv/uv workflow.
 
-| Layer | Purpose |
-|-------|---------|
-| Package manager | Homebrew (mac), winget (Windows), distro pkg (Linux) |
-| CLI baseline | git, curl, wget, vim/editor — inbash `unix/basic.sh` on Debian |
-| Shell | zsh + Oh My Zsh + inbash `setup-ohMyZsh.sh` (mac/linux). Windows: keep PowerShell; optional WSL2 + same Unix path |
-| Node.js LTS | inbash `unix/nodejs.sh` / `mac/nodejs.sh`; Windows: `winget install OpenJS.NodeJS.LTS` |
-| Python | mac: inbash `mac/python-pip-uv.sh` (Homebrew python + **uv**). Linux: `unix/python3-pip.sh` then install **uv**. Windows: `winget install Python.Python.3.12` + uv |
-
-Prefer **LTS Node** and a **venv/uv** workflow. Do not overwrite a working Node/Python without asking.
-
-**Done when:** `git --version`, `node -v`, `npm -v`, `python3 --version` succeed for the target OS.
+**Phase 3 done when:** baseline verification commands all pass (or deferred items are recorded).
 
 ### 4. Coding-agent CLIs
 
-Read `references/agent-clis.md` and install, in this order (Node is already on PATH):
+- **Present:** the install order and exact commands from `references/agent-clis.md` (Claude Code, Codex, Pi, OpenCode), noting any `curl | sh` URL that needs explicit approval.
+- **Approve:** wait. Per-tool yes is fine; a blanket yes covers all non-destructive installs.
+- **Execute:** install in order, skipping any already present:
+  1. Claude Code
+  2. Codex
+  3. Pi (`@mariozechner/pi-coding-agent`)
+  4. OpenCode
+- **Verify:** each requested CLI prints a version (`claude --version`, `codex --version`, `pi --version`, `opencode --version`). Never store API keys in the skill or shell history.
 
-1. Claude Code
-2. Codex
-3. Pi (`@mariozechner/pi-coding-agent`)
-4. OpenCode
+**Phase 4 done when:** each requested CLI verifies green (or explicitly skipped by the user).
 
-Skip any the user already has. Do not store API keys in the skill or in shell history snippets.
+### 5. Final report
 
-**Done when:** each requested CLI prints a version (`claude --version`, `codex --version`, `pi --version`, `opencode --version`).
+- **Present:** nothing to execute here — this is the consolidated deliverable.
+- **Execute/Verify:** assemble the report from the running step log (built across phases 1–4), not from memory.
+- Print the report (template below). Offer optional extras from inbash (Docker, C/C++, SSH, MongoDB) only if the user asks.
 
-### 5. Ready-to-develop check
-
-Print a verification report (see below). Offer optional extras from inbash only if asked: Docker, C/C++, SSH server, MongoDB.
-
-**Done when:** the report is shown and gaps are either fixed or explicitly deferred.
+**Phase 5 done when:** the report is shown and any gaps are either fixed or explicitly deferred by the user.
 
 ## Safety
 
@@ -111,28 +126,34 @@ Print a verification report (see below). Offer optional extras from inbash only 
 - Never `curl | bash` without naming the URL and getting a yes.
 - Never commit secrets. Auth for Claude/Codex is interactive login after install.
 - Windows ARM64 (Snapdragon / Copilot+): prefer arm64 winget packages; say so when a tool is x64-only.
+- **Approval is per-phase and, for removals/remote scripts, per-item.** A prior yes does not carry forward.
 
 ## Verification report
 
-Always print:
+Always print a consolidated report built from the running log:
 
 ```
-◆ New machine setup
-  OS / arch:          …
-  Package manager:    …
-  Inventory:          √ listed (N removal candidates, K removed)
-  git / curl:         √ / ×
-  Node LTS + npm:     √ version …
-  Python + uv:        √ version …
-  zsh + Oh My Zsh:    √ / skipped (Windows host)
-  Claude Code:        √ / skipped
-  Codex:              √ / skipped
-  Pi:                 √ / skipped
-  OpenCode:           √ / skipped
-  Result:             READY | PARTIAL | BLOCKED
+◆ New machine setup — FINAL REPORT
+  Machine:   <os> / <arch> / <distro or build>
+  Manager:   <package manager>
+
+  Phase 1 · Detect
+    ✓ inventory captured (os/arch/tools)
+  Phase 2 · Inventory
+    ✓ listed N packages; removed K (names: …) / skipped
+  Phase 3 · Baseline
+    ✓ git <v>   ✓ node <v>   ✓ npm <v>
+    ✓ python <v>   ✓ uv <v>
+    ✓ zsh + Oh My Zsh  / skipped (Windows host)
+  Phase 4 · Agent CLIs
+    ✓ Claude Code <v>   ✓ Codex <v>   ✓ Pi <v>   ✓ OpenCode <v>
+    (skipped: …)
+
+  Result:    READY | PARTIAL | BLOCKED
+  Deferred:  <optional extras the user declined>
 ```
 
-`READY` = baseline + Node + Python work. Agents may be skipped and still READY if the user declined them.
+`READY` = baseline + Node + Python verify green. Agents may be skipped and still READY if the user declined them. `PARTIAL` = some verification failed but non-fatal; `BLOCKED` = a required phase could not be approved or executed.
 
 ## Pitfalls
 

--- a/skills/new-machine-setup/SKILL.md
+++ b/skills/new-machine-setup/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: new-machine-setup
+description: "Set up a clean, ready-to-develop machine across macOS, Linux, and Windows with OS/arch detection. Use when the user bought a new laptop, wants a fresh dev box, asks to bootstrap Node/Python, install Claude Code, Codex, Pi, OpenCode, or Oh My Zsh, or mentions OEM bloat / Grok Build-style cleanup. Don't use for Dockerfiles, CI images, or one-off package installs."
+license: MIT
+compatibility: "macOS, Linux (Debian/Ubuntu/Fedora/Arch), Windows (winget/PowerShell). Needs network and a package manager or permission to install one. Never run destructive uninstalls without an explicit yes."
+metadata:
+  version: 0.1.0
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
+  effort: high
+---
+
+# New Machine Setup
+
+Turn a factory laptop into a **clean, ready-to-develop** machine. Detect OS + CPU arch first, optionally inventory/remove OEM junk (the XFreeze / Grok Build idea), then install a consistent baseline: git, shell, Node.js, Python, and the coding-agent CLIs this user actually uses.
+
+This skill is an orchestrator. Long per-OS command tables live in `references/` so only the current platform is loaded.
+
+**Do not** pipe remote scripts to a shell until the user has approved that step. Prefer official installers and the user's own [inbash](https://github.com/luongnv89/inbash) scripts when they match the OS.
+
+## When to Use
+
+- "set up this new laptop / new machine / fresh install"
+- "install my dev environment" (Node, Python, agents)
+- Windows OEM bloat, trial antivirus, preinstalled games
+- Need Claude Code, Codex, Pi, OpenCode, and Oh My Zsh on a clean box
+
+Don't use for: Dockerfiles, CI runners, or installing a single package.
+
+## Prerequisites
+
+- Network.
+- Admin/sudo (or winget) for system packages.
+- User confirmation before: removing apps, changing the default shell, or `curl | sh` installers.
+- Optional clone of `https://github.com/luongnv89/inbash` — preferred source for Unix/mac scripts this user already maintains.
+
+## Reference files (load only what you need)
+
+| File | When |
+|------|------|
+| `references/detect.md` | Always first — how to probe OS/arch and interpret `scripts/detect_env.py` |
+| `references/windows.md` | Windows: inventory, conservative debloat, winget stack |
+| `references/macos.md` | macOS: Homebrew, Node, Python+uv, zsh |
+| `references/linux.md` | Linux: apt/dnf/pacman, NodeSource LTS, python3-pip |
+| `references/agent-clis.md` | Claude Code, Codex, Pi, OpenCode install + verify |
+| `scripts/detect_env.py` | Print a JSON inventory (OS, arch, package managers, tools) |
+
+## Procedure
+
+### 1. Detect the machine
+
+Run:
+
+```bash
+python3 scripts/detect_env.py
+```
+
+If `python3` is missing, use the one-liners in `references/detect.md`.
+
+**Done when:** you have `os` (`macos` | `linux` | `windows`), `arch` (`x86_64` | `arm64` | other), package manager, and which of `{git,node,npm,python3,zsh,brew,winget}` already exist.
+
+Then read **only** the matching OS reference (`windows.md` / `macos.md` / `linux.md`).
+
+### 2. Inventory (Windows first; useful everywhere)
+
+Inspired by [XFreeze](https://x.com/xfreeze/status/2090189407659999603): factory Windows boxes ship trial AV, OEM utilities, and partner games. **List before delete.**
+
+On Windows, follow `references/windows.md` § Inventory. On macOS/Linux, list unexpected GUI apps and leftover vendor agents, but do not uninstall by default.
+
+Present a short table: keep / review / remove-candidate. Wait for an explicit yes on every removal.
+
+**Done when:** the user has seen the inventory. Removals are either skipped or confirmed one-by-one.
+
+### 3. Baseline toolchain
+
+Install missing pieces only (idempotent):
+
+| Layer | Purpose |
+|-------|---------|
+| Package manager | Homebrew (mac), winget (Windows), distro pkg (Linux) |
+| CLI baseline | git, curl, wget, vim/editor — inbash `unix/basic.sh` on Debian |
+| Shell | zsh + Oh My Zsh + inbash `setup-ohMyZsh.sh` (mac/linux). Windows: keep PowerShell; optional WSL2 + same Unix path |
+| Node.js LTS | inbash `unix/nodejs.sh` / `mac/nodejs.sh`; Windows: `winget install OpenJS.NodeJS.LTS` |
+| Python | mac: inbash `mac/python-pip-uv.sh` (Homebrew python + **uv**). Linux: `unix/python3-pip.sh` then install **uv**. Windows: `winget install Python.Python.3.12` + uv |
+
+Prefer **LTS Node** and a **venv/uv** workflow. Do not overwrite a working Node/Python without asking.
+
+**Done when:** `git --version`, `node -v`, `npm -v`, `python3 --version` succeed for the target OS.
+
+### 4. Coding-agent CLIs
+
+Read `references/agent-clis.md` and install, in this order (Node is already on PATH):
+
+1. Claude Code
+2. Codex
+3. Pi (`@mariozechner/pi-coding-agent`)
+4. OpenCode
+
+Skip any the user already has. Do not store API keys in the skill or in shell history snippets.
+
+**Done when:** each requested CLI prints a version (`claude --version`, `codex --version`, `pi --version`, `opencode --version`).
+
+### 5. Ready-to-develop check
+
+Print a verification report (see below). Offer optional extras from inbash only if asked: Docker, C/C++, SSH server, MongoDB.
+
+**Done when:** the report is shown and gaps are either fixed or explicitly deferred.
+
+## Safety
+
+- Never run a third-party "debloat everything" script unattended. OEM audio/chipset tools can be load-bearing.
+- Never `curl | bash` without naming the URL and getting a yes.
+- Never commit secrets. Auth for Claude/Codex is interactive login after install.
+- Windows ARM64 (Snapdragon / Copilot+): prefer arm64 winget packages; say so when a tool is x64-only.
+
+## Verification report
+
+Always print:
+
+```
+◆ New machine setup
+  OS / arch:          …
+  Package manager:    …
+  Inventory:          √ listed (N removal candidates, K removed)
+  git / curl:         √ / ×
+  Node LTS + npm:     √ version …
+  Python + uv:        √ version …
+  zsh + Oh My Zsh:    √ / skipped (Windows host)
+  Claude Code:        √ / skipped
+  Codex:              √ / skipped
+  Pi:                 √ / skipped
+  OpenCode:           √ / skipped
+  Result:             READY | PARTIAL | BLOCKED
+```
+
+`READY` = baseline + Node + Python work. Agents may be skipped and still READY if the user declined them.
+
+## Pitfalls
+
+- **PEP 668 on Linux:** do not `pip install` into the system Python. Use `uv` or a venv.
+- **Node via both nvm and apt/brew:** pick one; prefer the inbash path unless nvm is already in use.
+- **Oh My Zsh `chsh`:** needs a login session; don't fail the whole setup if `chsh` is denied.
+- **WSL vs native Windows:** if the user wants Linux-native agents, set up WSL2 Ubuntu and re-run this skill *inside* WSL rather than mixing paths.
+- **inbash scripts are Debian/mac-oriented.** On Fedora/Arch, follow `references/linux.md` package-manager switches, not the `.sh` files blindly.

--- a/skills/new-machine-setup/SKILL.md
+++ b/skills/new-machine-setup/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: new-machine-setup
-description: "Set up a clean, ready-to-develop machine across macOS, Linux, and Windows with OS/arch detection. Use when the user bought a new laptop, wants a fresh dev box, asks to bootstrap Node/Python, install Claude Code, Codex, Pi, OpenCode, or Oh My Zsh, or mentions OEM bloat / Grok Build-style cleanup. Don't use for Dockerfiles, CI images, or one-off package installs."
+description: "Set up a clean, ready-to-develop machine across macOS, Linux, and Windows with OS/arch detection and a human-in-the-loop per phase. Use when the user wants a fresh dev box, to bootstrap Node/Python, install Claude Code, Codex, Pi, OpenCode, or Oh My Zsh, or to debloat OEM apps. Don't use for Dockerfiles, CI images, or one-off package installs."
 license: MIT
 compatibility: "macOS, Linux (Debian/Ubuntu/Fedora/Arch), Windows (winget/PowerShell). Needs network and a package manager or permission to install one. Never run destructive uninstalls without an explicit yes."
 metadata:
-  version: 0.2.0
+  version: 0.3.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
   effort: high
 ---
@@ -13,7 +13,7 @@ metadata:
 
 Turn a factory laptop into a **clean, ready-to-develop** machine. Detect OS + CPU arch first, optionally inventory/remove OEM junk (the XFreeze / Grok Build idea), then install a consistent baseline: git, shell, Node.js, Python, and the coding-agent CLIs this user actually uses.
 
-This skill is an orchestrator. Long per-OS command tables live in `references/` so only the current platform is loaded.
+This skill is an orchestrator. Long per-OS command tables live in `references/` so only the current platform is loaded, keeping the agent's context budget small while the full detail stays one link away.
 
 **Do not** pipe remote scripts to a shell until the user has approved that step. Prefer official installers and the user's own [inbash](https://github.com/luongnv89/inbash) scripts when they match the OS.
 
@@ -53,6 +53,7 @@ Don't use for: Dockerfiles, CI runners, or installing a single package.
 | `references/macos.md` | macOS: Homebrew, Node, Python+uv, zsh |
 | `references/linux.md` | Linux: apt/dnf/pacman, NodeSource LTS, python3-pip |
 | `references/agent-clis.md` | Claude Code, Codex, Pi, OpenCode install + verify |
+| `references/edge-cases.md` | ARM64, nvm conflicts, PEP 668, WSL, chsh, inbash distro limits |
 | `scripts/detect_env.py` | Print a JSON inventory (OS, arch, package managers, tools) |
 
 ## Procedure
@@ -154,6 +155,24 @@ Always print a consolidated report built from the running log:
 ```
 
 `READY` = baseline + Node + Python verify green. Agents may be skipped and still READY if the user declined them. `PARTIAL` = some verification failed but non-fatal; `BLOCKED` = a required phase could not be approved or executed.
+
+## Acceptance Criteria
+
+The skill is done when all of these hold:
+
+- `python3 scripts/detect_env.py` prints valid JSON with `os`, `arch`, a package manager, and a tool map.
+- Every phase ran the present → approve → execute → verify loop, and each approval is recorded in the running log.
+- No removal or `curl | sh` ran without an explicit, per-item yes.
+- Phase 3 verifies green: `git --version`, `node -v`, `npm -v`, `python3 --version`, `uv --version` succeed (or deferred items are logged).
+- Each requested agent CLI (Claude Code, Codex, Pi, OpenCode) verifies via its `--version` (or is explicitly skipped).
+- The FINAL REPORT (template above) is printed, built from the running log — not from memory — with a `Result` of READY / PARTIAL / BLOCKED.
+- `quick_validate.py` exits 0 on the shipped SKILL.md.
+
+**Expected output:** the consolidated FINAL REPORT block shown under "Verification report" above.
+
+## Edge Cases
+
+Environment-specific gotchas (ARM64, nvm conflicts, PEP 668, WSL, `chsh` denial, inbash distro limits) live in `references/edge-cases.md` — read it when a phase hits an unusual machine.
 
 ## Pitfalls
 

--- a/skills/new-machine-setup/docs/README.md
+++ b/skills/new-machine-setup/docs/README.md
@@ -1,0 +1,36 @@
+<!--
+  DO NOT READ THIS FILE - This README.md is for human catalog browsing only.
+  It ships inside the .skill package but is NEVER auto-loaded into agent context.
+  The runtime loader only reads SKILL.md + references/ + scripts/ + agents/ when the skill triggers.
+  If you're an AI agent, read the SKILL.md file instead for skill instructions.
+-->
+
+# New Machine Setup
+
+Bootstrap a **clean, ready-to-develop** laptop (macOS, Linux, or Windows).
+
+Inspired by [XFreeze on new Windows boxes](https://x.com/xfreeze/status/2090189407659999603) (inventory OEM junk before installing anything) and this user's [inbash](https://github.com/luongnv89/inbash) scripts.
+
+## What it installs
+
+1. Detects OS + CPU architecture
+2. Optionally inventories / removes OEM bloat (Windows; confirm each removal)
+3. Baseline: git, curl, package manager
+4. Node.js LTS + npm
+5. Python 3 + uv (no system-pip pollution)
+6. Oh My Zsh (Unix) via inbash
+7. Agent CLIs: Claude Code, Codex, Pi, OpenCode
+
+## Usage
+
+Ask an agent that has this skill:
+
+> Set up this new machine for development.
+
+Or point it at a specific OS:
+
+> Fresh Windows ARM laptop — debloat then install Node, Python, and Claude Code.
+
+## Safety
+
+The skill never mass-uninstalls OEM tools and never pipes a remote script to the shell without an explicit yes.

--- a/skills/new-machine-setup/references/agent-clis.md
+++ b/skills/new-machine-setup/references/agent-clis.md
@@ -1,0 +1,76 @@
+# Coding-agent CLIs
+
+Install only after Node.js LTS is on PATH (`node -v`, `npm -v`). Prefer official documented commands. Confirm any `curl | sh` URL before running.
+
+Skip a tool if `command -v` already finds it and `--version` works.
+
+## Claude Code
+
+Preferred (native installer — check [Anthropic's current setup page](https://docs.anthropic.com/en/docs/claude-code/setup) if this drifts):
+
+```bash
+# Unix — confirm URL with the user
+curl -fsSL https://claude.ai/install.sh | bash
+```
+
+Fallback (needs Node 18+):
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Windows: prefer `winget search claude` / the official Windows installer from the same docs page; npm global also works.
+
+Verify: `claude --version`. Login is interactive (`claude`) — do not paste API keys into the skill log.
+
+## Codex (OpenAI)
+
+```bash
+npm install -g @openai/codex
+```
+
+macOS alternative if the formula exists: `brew install codex` (only if `brew info codex` looks official).
+
+Verify: `codex --version`.
+
+## Pi
+
+This user's Pi is the [pi-coding-agent](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) (see `pi-extensions` / `pi-web-access` notes):
+
+```bash
+npm install -g @mariozechner/pi-coding-agent
+```
+
+Verify: `pi --version`. Optional later: `pi-web-access` — do not install extras unless asked.
+
+## OpenCode
+
+macOS:
+
+```bash
+brew install anomalyco/tap/opencode
+```
+
+Cross-platform (Node/bun):
+
+```bash
+npm install -g opencode-ai
+# or: bun add -g opencode-ai
+```
+
+Windows: `winget search opencode` first; otherwise npm global.
+
+Verify: `opencode --version`.
+
+## PATH
+
+If a global npm bin is "installed" but not found:
+
+```bash
+npm prefix -g
+# add <prefix>/bin (Unix) or <prefix> (Windows) to PATH, then open a new shell
+```
+
+## Auth
+
+Leave auth to the first interactive run of each CLI. Never write keys into `~/.zshrc` from this skill.

--- a/skills/new-machine-setup/references/detect.md
+++ b/skills/new-machine-setup/references/detect.md
@@ -1,0 +1,54 @@
+# Detect OS, arch, and existing tools
+
+Run this first. Do not install anything until the JSON is in hand.
+
+## Preferred
+
+From the skill directory (or any clone of this skill):
+
+```bash
+python3 scripts/detect_env.py
+```
+
+On Windows PowerShell, if `python3` is missing:
+
+```powershell
+py -3 scripts/detect_env.py
+```
+
+## Fallback one-liners
+
+**Unix**
+
+```bash
+uname -s; uname -m
+command -v apt-get dnf pacman brew git node python3 zsh
+```
+
+**Windows**
+
+```powershell
+[System.Environment]::OSVersion.VersionString
+$env:PROCESSOR_ARCHITECTURE
+Get-Command winget, git, node, python, py -ErrorAction SilentlyContinue
+```
+
+## How to read the JSON
+
+| Field | Meaning |
+|-------|---------|
+| `os` | `macos` / `linux` / `windows` / `unknown` |
+| `arch` | `x86_64` / `arm64` / raw uname |
+| `distro` | Linux ID from `/etc/os-release` (ubuntu, fedora, arch, …) |
+| `package_managers` | present managers (`apt`, `dnf`, `pacman`, `brew`, `winget`, `choco`, `scoop`) |
+| `tools` | `{name: version_or_null}` for git, node, npm, python3, pip, uv, zsh, claude, codex, pi, opencode |
+| `notes` | WSL, Rosetta, missing sudo |
+
+## Routing
+
+- `os=windows` → read `references/windows.md`
+- `os=macos` → read `references/macos.md`
+- `os=linux` → read `references/linux.md`
+- Then `references/agent-clis.md` for step 4
+
+Apple Silicon is `arm64`. Windows on Snapdragon is `ARM64` / `arm64`. Prefer native packages; mention x64-emulation only when a tool has no arm64 build.

--- a/skills/new-machine-setup/references/edge-cases.md
+++ b/skills/new-machine-setup/references/edge-cases.md
@@ -1,0 +1,31 @@
+# Edge cases & environment-specific notes
+
+These handle the non-happy-path situations `new-machine-setup` may hit. The orchestrator SKILL.md links here to keep its body lean.
+
+## No `python3` on a factory machine
+
+Use the fallback one-liners in `detect.md` to determine OS/arch, then proceed. `detect_env.py` only needs `python3`.
+
+## Windows ARM64 (Snapdragon / Copilot+)
+
+Prefer arm64 winget packages. If a CLI has no arm64 build, say so and install under x64 emulation only with the user's consent.
+
+## Node present via nvm/fnm AND a system install
+
+Pick one path; prefer inbash unless nvm is already in use. Do not create two conflicting installs.
+
+## `chsh` denied
+
+Setup still succeeds if zsh + Oh My Zsh exist. Note the denial rather than failing the phase.
+
+## Linux PEP 668
+
+Never `pip install` into the system interpreter — use `uv` or a venv.
+
+## WSL vs native Windows
+
+For Linux-native agents, set up WSL2 Ubuntu and re-run this skill *inside* WSL. Don't mix Windows-native and WSL Node paths.
+
+## inbash scripts are Debian/mac-oriented
+
+On Fedora/Arch, use `linux.md` package-manager switches instead of the `.sh` files blindly.

--- a/skills/new-machine-setup/references/linux.md
+++ b/skills/new-machine-setup/references/linux.md
@@ -1,0 +1,78 @@
+# Linux setup
+
+inbash Unix scripts target **Debian/Ubuntu** (`apt`). On Fedora/RHEL/Arch, use the same *intent* with the native package manager — do not run the `.sh` files blindly.
+
+Clone when apt-based:
+
+```bash
+git clone https://github.com/luongnv89/inbash.git
+cd inbash
+```
+
+## Package manager
+
+| Distro | Install |
+|--------|---------|
+| Debian/Ubuntu | `sudo apt-get update && sudo apt-get install -y git curl wget vim build-essential` or `./unix/basic.sh --yes` |
+| Fedora | `sudo dnf install -y git curl wget vim gcc gcc-c++ make` |
+| Arch | `sudo pacman -Sy --needed git curl wget vim base-devel` |
+
+## Node.js LTS
+
+**Debian/Ubuntu (inbash):**
+
+```bash
+./unix/nodejs.sh --yes
+```
+
+Uses NodeSource `setup_lts.x`. Review the downloaded setup script if the user is cautious.
+
+**Fedora:** `sudo dnf module install -y nodejs:lts` or NodeSource's rpm script (same review rule).
+
+**Arch:** `sudo pacman -S nodejs npm`.
+
+Prefer one Node. If `nvm`/`fnm` already exists, use it instead of adding a second copy.
+
+## Python
+
+**Debian/Ubuntu (inbash):**
+
+```bash
+./unix/python3-pip.sh --yes
+```
+
+Then **uv** (do not `pip install` into the system interpreter — PEP 668):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Confirm the URL first. Verify: `python3 --version`, `uv --version`.
+
+**Fedora:** `sudo dnf install -y python3 python3-pip` then uv.
+**Arch:** `sudo pacman -S python python-pip` then uv.
+
+## Zsh + Oh My Zsh
+
+```bash
+./install-zsh.sh --yes --set-default
+./setup-ohMyZsh.sh --yes
+```
+
+`install-zsh.sh` already switches on apt/dnf/yum/pacman/apk/zypper. Works on WSL.
+
+## Arch notes
+
+| Arch | Notes |
+|------|--------|
+| `x86_64` | Default NodeSource / distro packages |
+| `aarch64` / `arm64` | Use distro aarch64 packages. NodeSource supports arm64; confirm the setup script's arch list if it fails |
+| `riscv64` | Distro packages only; skip NodeSource |
+
+## Optional (only if asked)
+
+inbash: `unix/docker.sh`, `unix/c_cpp.sh`, `unix/setup-ssh.sh`, `unix/install-mongodb.sh`.
+
+## Agent CLIs
+
+See `agent-clis.md`. Global npm prefix: `npm prefix -g` must be on PATH (often `~/.npm-global` if the user cannot write `/usr/lib`).

--- a/skills/new-machine-setup/references/linux.md
+++ b/skills/new-machine-setup/references/linux.md
@@ -15,7 +15,7 @@ cd inbash
 |--------|---------|
 | Debian/Ubuntu | `sudo apt-get update && sudo apt-get install -y git curl wget vim build-essential` or `./unix/basic.sh --yes` |
 | Fedora | `sudo dnf install -y git curl wget vim gcc gcc-c++ make` |
-| Arch | `sudo pacman -Sy --needed git curl wget vim base-devel` |
+| Arch | `sudo pacman -Syu --needed git curl wget vim base-devel` |
 
 ## Node.js LTS
 

--- a/skills/new-machine-setup/references/macos.md
+++ b/skills/new-machine-setup/references/macos.md
@@ -1,0 +1,77 @@
+# macOS setup
+
+Prefer [inbash](https://github.com/luongnv89/inbash) mac scripts. Clone once:
+
+```bash
+git clone https://github.com/luongnv89/inbash.git
+cd inbash
+```
+
+## Homebrew
+
+If `brew` is missing:
+
+```bash
+# Confirm URL with the user first
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+On Apple Silicon, add to `~/.zprofile` if the installer says so:
+
+```bash
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+Intel Homebrew lives at `/usr/local`. Use `uname -m`: `arm64` vs `x86_64`. Never install x86 brew under Rosetta unless the user is stuck on an x86-only formula.
+
+## Baseline
+
+```bash
+brew install git curl wget
+```
+
+## Node.js LTS
+
+inbash:
+
+```bash
+./mac/nodejs.sh --yes --formula node
+```
+
+Or pin LTS:
+
+```bash
+./mac/nodejs.sh --yes --formula node@22 --force-link
+```
+
+Verify: `node -v`, `npm -v`. Optionally `corepack enable`.
+
+## Python + uv
+
+inbash (Homebrew `python@3.12`, pip, **uv**):
+
+```bash
+./mac/python-pip-uv.sh --yes --python-formula python@3.12
+```
+
+Verify: `python3 -V`, `uv --version`. Use `uv venv` for projects; do not `sudo pip3 install`.
+
+## Zsh + Oh My Zsh
+
+```bash
+./install-zsh.sh --yes --set-default
+./setup-ohMyZsh.sh --yes
+```
+
+`setup-ohMyZsh.sh` installs `zsh-syntax-highlighting`, `zsh-autosuggestions`, `zsh-completions` and deploys inbash `zshrc-config`. If the user already has a custom `~/.zshrc`, skip the config copy and only add plugins.
+
+`chsh` may require a password; setup is still a success if zsh + omz exist.
+
+## Optional (only if asked)
+
+- Docker Desktop: `./mac/docker.sh --yes`
+- Xcode CLT: `xcode-select --install` if compile tools are missing
+
+## Agent CLIs
+
+See `agent-clis.md`. On Apple Silicon, npm global bins go under `/opt/homebrew` or `$(npm prefix -g)/bin` — ensure that directory is on PATH.

--- a/skills/new-machine-setup/references/windows.md
+++ b/skills/new-machine-setup/references/windows.md
@@ -1,0 +1,81 @@
+# Windows setup
+
+Inspired by [XFreeze / Grok Build](https://x.com/xfreeze/status/2090189407659999603): new Windows laptops often ship trial antivirus, OEM utilities, and partner games. Inventory first. Never mass-uninstall.
+
+## Inventory
+
+Elevated PowerShell:
+
+```powershell
+Get-AppxPackage | Select-Object Name, PackageFullName | Sort-Object Name
+winget list
+```
+
+Flag as **review** (do not auto-remove):
+
+- Names matching `McAfee`, `Norton`, `WildTangent`, `CandyCrush`, `Xbox`, `Spotify`, `Disney`, `TikTok`, `Booking`, `Expedia`, vendor names (`Dell`, `HP`, `Lenovo`, `ASUS`, `Acer`) plus `Support`, `Update`, `Hotkey`
+- Trial security suites
+
+**Keep** unless the user says otherwise: GPU control panels, audio/chipset, Bluetooth, camera, OEM firmware updaters, BitLocker, Windows Security.
+
+Present a table. Remove only confirmed rows:
+
+```powershell
+# Example — only after an explicit yes for that package
+winget uninstall --id <Id> --silent
+# or
+Get-AppxPackage <Name> | Remove-AppxPackage
+```
+
+Optional: inbash `windows/system_check.ps1` for a hardware snapshot (`-AsJson`).
+
+## Package manager
+
+Prefer **winget** (built into current Windows 10/11). If missing, install App Installer from the Microsoft Store, then retry.
+
+```powershell
+winget --version
+```
+
+## Baseline
+
+```powershell
+winget install --id Git.Git -e --accept-source-agreements --accept-package-agreements
+winget install --id OpenJS.NodeJS.LTS -e
+winget install --id Python.Python.3.12 -e
+```
+
+Open a **new** PowerShell so PATH updates. Then:
+
+```powershell
+node -v; npm -v; py -3 --version
+```
+
+Install **uv** (user-level, no system pip pollution):
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+Confirm the URL with the user before running. Alternative: `winget install astral-sh.uv` if the package id resolves.
+
+## Shell
+
+Keep PowerShell 7 if available (`winget install Microsoft.PowerShell`). Oh My Zsh is a Unix skill — if the user wants the full inbash zsh setup, install **WSL2 Ubuntu** and re-run this skill *inside* WSL (then follow `linux.md`).
+
+```powershell
+wsl --install -d Ubuntu
+```
+
+Requires a reboot. Do not mix Windows-native Node with WSL Node in the same instructions.
+
+## Arch notes
+
+| Arch | Notes |
+|------|--------|
+| `AMD64` / `x86_64` | Default winget packages |
+| `ARM64` | Prefer packages that publish arm64. If a CLI is x64-only, say so and install under emulation only with consent |
+
+## Agent CLIs
+
+After Node is on PATH, follow `agent-clis.md`. `npm install -g` works on Windows if the npm prefix is writable; otherwise use each tool's Windows/native installer from that file.

--- a/skills/new-machine-setup/scripts/detect_env.py
+++ b/skills/new-machine-setup/scripts/detect_env.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Print a JSON inventory of OS, CPU arch, package managers, and dev tools.
+
+No third-party deps. Safe to run on a factory machine.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+
+def _run(cmd: list[str]) -> str | None:
+    try:
+        out = subprocess.run(
+            cmd, check=False, capture_output=True, text=True, timeout=8
+        )
+        if out.returncode != 0:
+            return None
+        return (out.stdout or "").strip() or None
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def detect_os() -> str:
+    sysname = platform.system().lower()
+    if sysname == "darwin":
+        return "macos"
+    if sysname == "windows":
+        return "windows"
+    if sysname == "linux":
+        return "linux"
+    return "unknown"
+
+
+def detect_arch() -> str:
+    machine = (platform.machine() or "").lower()
+    if machine in {"x86_64", "amd64"}:
+        return "x86_64"
+    if machine in {"arm64", "aarch64"}:
+        return "arm64"
+    return machine or "unknown"
+
+
+def detect_distro() -> str | None:
+    path = "/etc/os-release"
+    if not os.path.isfile(path):
+        return None
+    data: dict[str, str] = {}
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                if "=" not in line or line.startswith("#"):
+                    continue
+                key, val = line.rstrip().split("=", 1)
+                data[key] = val.strip().strip('"')
+    except OSError:
+        return None
+    return data.get("ID")
+
+
+def managers() -> list[str]:
+    names = ("apt-get", "dnf", "yum", "pacman", "zypper", "apk", "brew", "winget", "choco", "scoop")
+    found = []
+    for name in names:
+        if shutil.which(name):
+            found.append("apt" if name == "apt-get" else name)
+    return found
+
+
+def tool_version(names: list[str], args: list[str] | None = None) -> str | None:
+    args = args or ["--version"]
+    for name in names:
+        path = shutil.which(name)
+        if not path:
+            continue
+        ver = _run([path, *args])
+        if ver:
+            return ver.splitlines()[0][:120]
+        return "present"
+    return None
+
+
+def notes(os_name: str) -> list[str]:
+    out: list[str] = []
+    if os_name == "linux" and os.environ.get("WSL_DISTRO_NAME"):
+        out.append(f"wsl:{os.environ['WSL_DISTRO_NAME']}")
+    if os_name == "macos" and platform.machine().lower() == "arm64":
+        if os.path.isdir("/usr/local/Homebrew") and not os.path.isdir("/opt/homebrew"):
+            out.append("intel-homebrew-on-apple-silicon")
+    if os_name != "windows" and os.geteuid() != 0 and not shutil.which("sudo"):
+        out.append("no-sudo")
+    return out
+
+
+def main() -> int:
+    os_name = detect_os()
+    payload = {
+        "os": os_name,
+        "arch": detect_arch(),
+        "distro": detect_distro(),
+        "package_managers": managers(),
+        "tools": {
+            "git": tool_version(["git"], ["--version"]),
+            "node": tool_version(["node"], ["-v"]),
+            "npm": tool_version(["npm"], ["-v"]),
+            "python3": tool_version(["python3", "python", "py"], ["--version"]),
+            "pip": tool_version(["pip3", "pip"], ["--version"]),
+            "uv": tool_version(["uv"], ["--version"]),
+            "zsh": tool_version(["zsh"], ["--version"]),
+            "claude": tool_version(["claude"], ["--version"]),
+            "codex": tool_version(["codex"], ["--version"]),
+            "pi": tool_version(["pi"], ["--version"]),
+            "opencode": tool_version(["opencode"], ["--version"]),
+        },
+        "notes": notes(os_name),
+    }
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #98

## Summary
Add the `new-machine-setup` skill: an OS/arch-aware bootstrap for a clean, ready-to-develop machine (macOS, Linux, Windows).

- Inspired by the XFreeze / Grok Build new-laptop workflow (inventory OEM bloat before removing).
- Detects OS + CPU arch via `scripts/detect_env.py`, then routes to per-platform references.
- Installs: Node.js LTS, Python 3 + uv, Oh My Zsh (Unix, via inbash), and the agent CLIs Claude Code / Codex / Pi / OpenCode.
- Reuses the user's existing [inbash](https://github.com/luongnv89/inbash) scripts as the source of truth for Unix/mac installs.

## Structure
- `SKILL.md` — orchestrator (143 lines)
- `references/` — detect, windows, macos, linux, agent-clis
- `scripts/detect_env.py` — no-dep JSON inventory
- `docs/README.md` — human catalog page

## Safety
Never mass-uninstalls OEM tools; never pipes a remote script to the shell without an explicit yes. `quick_validate.py` passes.

## Test plan
- [x] `quick_validate.py skills/new-machine-setup` → "Skill is valid!"
- [x] `python3 scripts/detect_env.py` runs on this Linux host (x86_64/ubuntu)