### PR TITLE
feat(dev-machine-setup): copy-pasteable run-blocks and resumable sessions

### DIFF
--- a/skills/dev-machine-setup/SKILL.md
+++ b/skills/dev-machine-setup/SKILL.md
@@ -5,22 +5,20 @@ license: MIT
 effort: high
 compatibility: "macOS, Linux (Debian/Ubuntu/Fedora/Arch), Windows (winget/PowerShell). Needs network and a package manager or permission to install one. Additive by default; anything that changes a working install needs an explicit per-item yes."
 metadata:
-  version: 0.4.0
+  version: 0.6.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Dev Machine Setup
 
-Bring **any** machine to a clean, ready-to-develop state — a factory laptop, a half-configured work box,
-or a daily driver that has drifted. Never a fresh-install-only script: phase 1 builds a **gap report** of
-what is missing and what is misconfigured, and every later phase acts only on that report.
+Bring **any** machine to a clean, ready-to-develop state — a factory laptop, a half-configured work box, or a
+daily driver that has drifted. Never a fresh-install-only script: phase 1 builds a **gap report** of what is
+missing and misconfigured, and every later phase acts only on that report.
 
-**Gap-driven** is the whole design. Each phase self-skips when its slice of the report is empty, so a
-re-run on an already-good machine installs nothing and still verifies. This makes the skill idempotent by
-construction and safe to run repeatedly.
+**Gap-driven** is the whole design. Each phase self-skips when its slice of the report is empty, so a re-run
+on an already-good machine installs nothing and still verifies — idempotent by construction.
 
-This is an orchestrator. Per-OS command tables live in `references/` so only the current platform is
-loaded, keeping the context budget small while the full detail stays one link away.
+This is an orchestrator: per-OS command tables live in `references/`, so only the current platform loads.
 
 ## Modes
 
@@ -29,16 +27,15 @@ fill them when the user only asked for a tune-up.
 
 | Mode | Selected by | Runs |
 |------|-------------|------|
-| `setup` (default) | "set up this machine", "install my dev environment", "get this laptop ready" | Phases 1 → 6 |
-| `tune` | "*just* optimize what's there", "don't install anything, fix my setup", "why is `claude` not found" | Phases 1, 5, 6 only |
+| `setup` (default) | "set up this machine", "install my dev environment", "get this laptop ready" | Phases 0 → 6 |
+| `tune` | "*just* optimize what's there", "don't install anything, fix my setup", "why is `claude` not found" | Phases 0, 1, 5, 6 only |
 
-**Tie-break:** `setup` is the default and wins whenever the request mentions missing pieces *at all* —
-"verify what's missing and optimize it" is `setup`, not `tune`. Choose `tune` only when the ask is limited to
-what is already installed. Still unsure once phase 1's gap report is on screen? Ask once, before phase 3.
+**Tie-break:** `setup` wins whenever the request mentions missing pieces *at all* — "verify what's missing
+and optimize it" is `setup`. Choose `tune` only when the ask is limited to what is already installed; still
+unsure once the gap report is on screen, ask once, before phase 3.
 
-In `tune`, phases 3 and 4 are skipped entirely — never bulk-install baseline tools or agent CLIs the user
-did not ask for. Phase 5 may still install a package when that *is* the approved fix for a reported
-finding (e.g. `uv` for `python-externally-managed`).
+`tune` skips phases 3 and 4 entirely — never bulk-install what the user did not ask for. Phase 5 may still
+install a package when that *is* the approved fix for a finding (e.g. `uv` for `python-externally-managed`).
 
 ## Additive vs mutating
 
@@ -54,19 +51,87 @@ forward to another mutating item.
 
 ## Human-in-the-loop (mandatory)
 
-Every phase runs a strict four-step loop. Do not skip a step; do not batch phases into one approval.
+Every phase runs a strict five-step loop. Do not skip a step; do not batch phases into one approval.
 
-1. **Present** — exactly what will run: each command, what it changes, and its **additive/mutating** tag.
+1. **Present** — exactly what will run, as **run-blocks** (§ Presenting commands): each command, what it
+   changes, and its **additive/mutating** tag.
 2. **Approve** — wait for an explicit go-ahead. A blanket "do everything" covers additive steps only.
 3. **Execute** — only what was approved. On failure, stop and re-present; never silently widen scope.
 4. **Verify** — confirm the phase actually took (version checks, file presence, exit codes).
+5. **Record** — write the outcome to the **session file** (§ Pausing and resuming) before moving on, so a
+   pause, a crash, or a closed terminal never loses what was already decided and done.
 
 **Read-only probes are exempt from step 2** — `detect_env.py`, version checks, `winget list`, `brew outdated`.
 Say what you are running, then run it. The gate exists to guard *changes*; making the user approve a read that
 changes nothing trains them to rubber-stamp the approvals that matter.
 
-Keep a running log of every step's outcome (✓ / ✗ + evidence). The final report is built from that log,
-never from memory.
+The session file *is* the running log (✓ / ✗ + evidence per item). The final report is built from it, never
+from memory.
+
+## Presenting commands (run-blocks)
+
+Every command you propose ships as a **run-block**: a fenced block the user can copy whole and run without
+editing it first. Every phase, not just phase 5.
+
+**Never put a command in a table cell** — cells wrap mid-token and produce something nobody can copy. Tables
+carry `finding id · severity · what breaks today · additive/mutating` and *name* the mechanism ("Oh My Zsh
+installer, `curl | sh`"); the command goes in the block underneath.
+
+A run-block is:
+
+- **One item per block**, headed by the finding id or item name and its additive/mutating tag.
+- **Self-contained** — no assumed cwd (`cd` inside the block, or use an absolute path), no `$` prompt
+  prefixes, no `<placeholders>`. If a value must come from the user (git identity, an npm prefix), **ask
+  first, then present the block with it filled in.**
+- **One purpose per block.** Inspect and fix never share a block — pasting one must not run the other.
+- **Tagged with who runs it.** `you run this` for anything needing a password prompt (`chsh`), a GUI dialog
+  (`xcode-select --install`), a browser login, or a shell replacement (`exec zsh -l`); otherwise
+  `I can run this`. Says *where it runs*, never a substitute for additive/mutating, which says *what it risks*.
+- Followed by its **verify** block where one is worth running.
+
+Ask for approval as a numbered list, so the user answers `1` or `1,3` instead of retyping ids. Approved
+`you run this` blocks may then be concatenated into one paste-once block — built **only** from items that
+each already got their own yes, in approval order. A combined block is never the thing being approved.
+
+**Example** — two low findings, presented right:
+
+````markdown
+| Finding | Sev | What breaks today | Tag |
+|---------|-----|-------------------|-----|
+| `login-shell-not-zsh` | low | zsh is installed but bash is still your login shell | mutating |
+| `oh-my-zsh-missing` | low | no completion/plugin baseline for zsh | additive |
+
+**1 · `login-shell-not-zsh`** — mutating · you run this (asks for your password; corporate policy or LDAP
+may refuse it, which is not a failure — we just skip it)
+
+```bash
+chsh -s "$(command -v zsh)"
+```
+
+**2 · `oh-my-zsh-missing`** — additive · I can run this (downloads and runs the installer from
+github.com/ohmyzsh, and creates `~/.zshrc`)
+
+```bash
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+```
+
+Approve which — `1`, `2`, `1,2`, or `none`?
+````
+
+## Pausing and resuming
+
+Machine setup is long, interruptible work, so state lives on disk rather than in the conversation.
+
+**Session file:** `~/.dev-machine-setup/session.json` (PowerShell: `$HOME\.dev-machine-setup\session.json`).
+Create it at the end of phase 1 and rewrite it at every **Record** step — after each phase, and after each
+individual approve/decline/execute inside phases 2–5. Schema and the write command are in
+`references/session.md`.
+
+The user can say "pause" at any point. Answer with three things and nothing else: the session file path, what
+is left, and a **paste-once block of the remaining approved commands** so they can finish by hand if they
+never come back. Never leave a half-applied rc edit behind at a pause.
+
+Resuming needs no arguments — triggering the skill again is enough (phase 0).
 
 ## When to Use
 
@@ -97,22 +162,38 @@ Don't use for: Dockerfiles, CI runners, or installing a single named package.
 | `references/linux.md` | Linux: apt/dnf/pacman, NodeSource LTS, python3-pip |
 | `references/agent-clis.md` | Phase 4 — Claude Code, Codex, Pi, OpenCode install + verify |
 | `references/optimize.md` | Phase 5 — one section per finding id, each tagged additive/mutating |
+| `references/session.md` | Phase 0 and every **Record** step — session-file schema, write command, reconcile rules |
+| `references/report-template.md` | Phase 6 — the FINAL REPORT block and what each line must carry |
 | `references/edge-cases.md` | No python3, Windows ARM64, WSL, containers, re-runs, inbash distro limits |
 
 ## Procedure
 
-Every phase runs the four-step loop above. Do not advance until the current phase verifies green, self-skips
+Every phase runs the five-step loop above. Do not advance until the current phase verifies green, self-skips
 on an empty gap set, or is explicitly deferred by the user.
+
+### 0. Resume check
+
+- Read `~/.dev-machine-setup/session.json`. **Absent, or `status: complete`** → say nothing, start at phase 1.
+- **Present and unfinished** → show one screen (mode, phases done, items done / approved-but-not-run /
+  declined, next step) and offer **resume** (default) · **start fresh** · **discard**.
+- On resume, **always re-run `detect_env.py` first and reconcile** — the machine moved on while you were away,
+  possibly because the user pasted the remaining blocks themselves. Rules in `references/session.md`.
+- Stale — `machine` mismatches this host, or the file is over 30 days old — say so and default to start fresh.
+- **Discard** deletes the file immediately; a discarded session left on disk is what makes a later resume
+  replay decisions the user threw away. **Start fresh** keeps it until phase 1 overwrites it.
+
+**Phase 0 done when:** the run is resuming from a reconciled session file, or starting clean with any
+discarded session deleted.
 
 ### 1. Detect and build the gap report
 
-- **Present:** "Running `detect_env.py` — read-only, no network, no changes. It reports OS, arch, package
-  managers, installed versions, what's missing, and what's misconfigured." Read-only: no approval needed.
-- **Execute:** `python3 <skill-dir>/scripts/detect_env.py` — path it from the skill's own directory, never
-  assume the user's cwd. Needs Python 3.9+; if `python3` is absent, use the fallbacks in `references/detect.md`.
+- **Present:** say what it does — read-only, no network, no changes; reports OS, arch, package managers,
+  installed versions, what's missing, what's misconfigured. Read-only, so no approval needed.
+- **Execute:** `python3 <skill-dir>/scripts/detect_env.py`, pathed from the skill's own directory, never the
+  user's cwd. Needs Python 3.9+; without `python3`, use the fallbacks in `references/detect.md`.
 - **Verify:** the JSON parses and contains `os`, `arch`, `tools`, `missing`, `findings`.
 
-Then **show the user the gap report** as three short lists before doing anything else:
+Then **show the gap report** as three short lists before doing anything else:
 
 ```
 Present:  git 2.55 · node v26.7 · python 3.14 · uv 0.11 · zsh · claude · codex
@@ -120,37 +201,36 @@ Missing:  baseline → uv          agents → pi, opencode
 Findings: 1 high · 0 medium · 2 low   (npm-global-bin-not-on-path, path-duplicates, oh-my-zsh-missing)
 ```
 
-Read **only** the OS reference that matches (`windows.md` / `macos.md` / `linux.md`). Confirm the mode
-(`setup` / `tune`) with the user if their request was ambiguous.
+Read **only** the matching OS reference (`windows.md` / `macos.md` / `linux.md`), and confirm the mode if the
+request was ambiguous.
 
-**Phase 1 done when:** the gap report JSON is captured, the three lists are shown, the mode is fixed, and the
-matching OS reference is loaded.
+**Phase 1 done when:** the gap report JSON is captured, the three lists are shown, the mode is fixed, the
+matching OS reference is loaded, and the session file exists with phase 1 recorded `done`.
 
 ### 2. Debloat — fresh Windows only, opt-in
 
-Skip this phase entirely unless the machine is Windows **and** the user asked to clean OEM junk. Never on a
-daily driver, a container, or a remote host. Inspired by
-[XFreeze](https://x.com/xfreeze/status/2090189407659999603): factory Windows boxes ship trial AV, OEM
-utilities, and partner games. **List before delete.**
+Skip entirely unless the machine is Windows **and** the user asked to clean OEM junk — never on a daily
+driver, container, or remote host. Factory Windows boxes ship trial AV, OEM utilities, and partner games
+(inspired by [XFreeze](https://x.com/xfreeze/status/2090189407659999603)). **List before delete.**
 
-- **Present** the read-only inventory commands (`winget list`, `Get-AppxPackage`).
+- **Present** the read-only inventory commands (`winget list`, `Get-AppxPackage`) as a run-block.
 - **Execute** `references/windows.md` § Inventory; build a `keep / review / remove-candidate` table.
-- Then **per removal** (mutating): present the exact command and what is lost, get an explicit yes for that
-  one package, execute, and verify it no longer lists.
+- Then **per removal** (mutating): one run-block per package naming what is lost, an explicit yes for that
+  one package, then execute, verify it no longer lists, and record it.
 
 **Phase 2 done when:** skipped with a reason logged, or the inventory is shown and every removal is
 individually confirmed and verified.
 
 ### 3. Baseline gaps  *(skipped in `tune`)*
 
-**Blocking findings first.** Four findings make installs fail or land invisibly, so they are fixed *here*,
-before anything else, rather than waiting for phase 5: `no-package-manager`, `no-sudo`,
-`brew-bin-not-on-path`, `npm-global-bin-not-on-path`. Fix per `references/optimize.md`, then continue. (A
-missing package manager arrives as a finding, not as a `missing.baseline` entry.)
+**Blocking findings first.** Four findings make installs fail or land invisibly, so they are fixed *here*
+rather than in phase 5: `no-package-manager`, `no-sudo`, `brew-bin-not-on-path`, `npm-global-bin-not-on-path`.
+Fix per `references/optimize.md`, then continue. (A missing package manager arrives as a finding, not as a
+`missing.baseline` entry.)
 
-Then act only on `missing.baseline`. **If that list is empty, print `✓ baseline complete — nothing to install`
-and skip to phase 4.** Never reinstall or upgrade a tool that is already present — an upgrade is mutating
-and belongs to phase 5.
+Then act only on `missing.baseline`. **Empty list → print `✓ baseline complete — nothing to install` and skip
+to phase 4.** Never reinstall or upgrade something already present — an upgrade is mutating, and belongs to
+phase 5.
 
 | Missing item | Install command lives in |
 |--------------|--------------------------|
@@ -159,10 +239,10 @@ and belongs to phase 5.
 | `node`, `npm` | the OS reference § Node.js LTS |
 | `python3`, `uv` | the OS reference § Python |
 
-- **Present:** the exact command for each missing item, tagged additive. Flag anything that would touch an
-  existing Node or Python — that is mutating and needs its own yes.
-- **Verify:** `git --version`, `node -v`, `npm -v`, `python3 --version`, `uv --version` succeed for the items
-  just installed. On Unix, `zsh --version`.
+- **Present:** one run-block per missing item, tagged additive. Flag anything that would touch an existing
+  Node or Python — that is mutating and needs its own yes.
+- **Verify:** `git --version`, `node -v`, `npm -v`, `python3 --version`, `uv --version` (Unix also
+  `zsh --version`) succeed for the items just installed.
 
 **Phase 3 done when:** every item that was in `missing.baseline` verifies green, or is logged as deferred.
 
@@ -171,8 +251,8 @@ and belongs to phase 5.
 Acts only on `missing.agents`, in this order: Claude Code → Codex → Pi → OpenCode. **Empty list → print
 `✓ all agent CLIs present` and skip.** Ask which the user actually wants; do not assume all four.
 
-- **Present:** the commands from `references/agent-clis.md`, naming any `curl | sh` URL (mutating — needs its
-  own yes).
+- **Present:** one run-block per CLI from `references/agent-clis.md`, with any `curl | sh` URL visible inside
+  the block (mutating — needs its own yes).
 - **Execute:** install only the requested missing ones. Requires Node on PATH from phase 3.
 - **Verify:** each prints a version (`claude --version`, `codex --version`, `pi --version`,
   `opencode --version`). If a just-installed CLI is "not found", that is
@@ -187,28 +267,30 @@ Auth is the first interactive run of each CLI. Never write API keys into the log
 Acts on `findings[]`, highest severity first. Each finding's `fix_ref` names its section in
 `references/optimize.md`; read only the sections for findings that actually fired.
 
-- **Present** one table: finding id · severity · what breaks today · the fix · **additive/mutating**.
-- **Approve:** additive fixes can be batched. **Every mutating fix needs its own yes** — and back up any rc
-  file before editing it.
+- **Present** one table — finding id · severity · what breaks today · **additive/mutating** — then one
+  run-block per finding beneath it (§ Presenting commands). No command goes in the table.
+- **Approve:** ask as a numbered list. Additive fixes can be batched. **Every mutating fix needs its own
+  yes** — and back up any rc file before editing it. Record each decision as it is made, not at the end.
 - **Execute** approved fixes only. A declined finding is recorded, not retried.
-- **Verify** by re-running `detect_env.py` and confirming the fixed ids are gone from `findings`. This re-run
+- **Verify** by re-running `detect_env.py` and confirming the fixed ids are gone from `findings`. That re-run
   is the phase's proof — never verify from memory. **PATH and rc-file fixes keep reporting until a new shell
-  reads them:** re-run inside a fresh login shell (`zsh -l -c '<skill-dir>/scripts/detect_env.py'`, or a new
-  PowerShell window). If no fresh shell is available, confirm the rc file now contains the line and log the
-  finding as *fixed — needs new shell*.
+  reads them:** re-run in a fresh login shell (`zsh -l -c '<skill-dir>/scripts/detect_env.py'`, or a new
+  PowerShell window); with no fresh shell available, confirm the rc file contains the line and log the finding
+  as *fixed — needs new shell*.
 
-Optional deep checks (`brew outdated`, `winget upgrade`, `npm outdated -g`) need network and are opt-in;
-see `optimize.md` § Deep checks. Never volunteer disk cleanup during a setup run.
+Deep checks (`brew outdated`, `winget upgrade`, `npm outdated -g`) need network and are opt-in — `optimize.md`
+§ Deep checks. Never volunteer disk cleanup during a setup run.
 
 **Phase 5 done when:** the verification re-run shows every approved fix gone from `findings` — or logged as
 *fixed — needs new shell* — and each remaining finding is recorded as declined or deferred with its severity.
 
 ### 6. Final report
 
-Nothing executes here. Assemble the report below from the running log built across phases 1–5.
+Nothing executes. Assemble the report from the session file (`references/report-template.md`), then set its
+`status` to `complete` so the next run starts clean instead of offering a resume.
 
-**Phase 6 done when:** the report is printed with a `Result` line, and every gap and finding is accounted for
-as fixed, declined, or deferred.
+**Phase 6 done when:** the report is printed with a `Result` line, every gap and finding is accounted for as
+fixed, declined, or deferred, and the session file is marked `complete`.
 
 ## Safety
 
@@ -223,27 +305,8 @@ Beyond the additive/mutating rule above:
 
 ## Verification report
 
-```
-◆ Dev machine setup — FINAL REPORT
-  Machine:   <os> / <arch> / <distro or build>   Mode: setup | tune
-  Manager:   <package manager>
-
-  Phase 1 · Gap report
-    ✓ present N · missing B baseline, A agents · findings H high / M med / L low
-  Phase 2 · Debloat
-    ✓ skipped (not fresh Windows) | listed N, removed K (names: …)
-  Phase 3 · Baseline gaps
-    ✓ nothing missing | installed: uv 0.11 · node v22.14  (deferred: …)
-  Phase 4 · Agent CLI gaps
-    ✓ nothing missing | installed: pi 0.84 · opencode 1.18  (declined: …)
-  Phase 5 · Optimize
-    ✓ fixed:    npm-global-bin-not-on-path (high) · path-duplicates (low)
-    ○ declined: intel-homebrew-on-apple-silicon (medium) — user deferred migration
-    verified by re-running detect_env.py: 0 high remaining
-
-  Result:    READY | PARTIAL | BLOCKED
-  Next:      <what the user should do — open a new shell, run `claude` to log in, …>
-```
+Phase 6 prints the FINAL REPORT block from `references/report-template.md` — one line per phase, sourced from
+the session file. `Result` is decided by these three rules:
 
 - **READY** — no unresolved `high` findings, and in `setup` no baseline gap left unfilled. Declined agent CLIs
   and deferred low/medium findings are still READY.
@@ -253,19 +316,24 @@ Beyond the additive/mutating rule above:
 
 ## Acceptance Criteria
 
-- `python3 scripts/detect_env.py` prints valid JSON with `os`, `arch`, `tools`, `missing`, and `findings`.
-- The phase-1 gap report (present / missing / findings) was shown to the user before anything was installed.
+- `detect_env.py` printed valid JSON with `os`, `arch`, `tools`, `missing`, `findings`, and the phase-1 gap
+  report was shown before anything was installed.
 - Mode was fixed before phase 3; in `tune`, phases 3 and 4 installed nothing.
 - Blocking findings (`no-package-manager`, `no-sudo`, `brew-bin-not-on-path`, `npm-global-bin-not-on-path`)
   were fixed at the top of phase 3, not deferred.
-- Phases 3 and 4 acted **only** on `missing.*` — no tool that was already present was reinstalled or upgraded.
-- Every mutating step has its own recorded yes; every rc file edited has a backup path in the log.
-- Phase 5 verified by **re-running** `detect_env.py`, and the report's finding counts come from that re-run.
-- The FINAL REPORT is printed from the running log with a `Result` of READY / PARTIAL / BLOCKED, and every gap
-  and finding is fixed, declined, or deferred — none unaccounted for.
+- Phases 3 and 4 acted **only** on `missing.*` — nothing already present was reinstalled or upgraded.
+- Every command reached the user as a run-block: none in a table cell, none with an unresolved
+  `<placeholder>` or an assumed cwd, each tagged `you run this` / `I can run this`.
+- The session file existed from phase 1 on, was rewritten at every Record step, and is `complete` by phase 6 —
+  an interrupted run resumes by triggering the skill again.
+- Every mutating step has its own recorded yes; every rc file edited has a backup path in the session file.
+- Phase 5 verified by **re-running** `detect_env.py`; the report's counts come from that re-run. On a resumed
+  run that re-run and its reconcile happened before any new work.
+- The FINAL REPORT printed with a `Result` of READY / PARTIAL / BLOCKED and every gap and finding accounted
+  for as fixed, declined, or deferred.
 - `quick_validate.py` exits 0 on the shipped SKILL.md.
 
-**Expected output:** the FINAL REPORT block above.
+**Expected output:** the FINAL REPORT block (`references/report-template.md`).
 
 ## Edge Cases
 

--- a/skills/dev-machine-setup/docs/README.md
+++ b/skills/dev-machine-setup/docs/README.md
@@ -33,6 +33,24 @@ OEM bloat and remove it one confirmed package at a time.
 | `setup` | "set up this machine", "install my dev environment" | Fills every gap, then optimizes |
 | `tune` | "optimize my dev setup", "why is `claude` not found" | Optimizes only — installs nothing you didn't ask for |
 
+## Copy-paste, not narration
+
+Every command it proposes arrives as its own fenced block you can copy whole and run — never a command
+wedged into a table cell, never a `<placeholder>` you have to fill in, never a snippet that only works if
+you happen to be in the right directory. Blocks that need *your* terminal (a `chsh` password prompt, a GUI
+dialog, a browser login) are labelled as such, so it's always clear who runs what.
+
+## Pause anywhere, resume by asking again
+
+Long setups get interrupted. Progress — mode, what you approved, what you declined, which rc files were
+backed up and where — is written to `~/.dev-machine-setup/session.json` after every step. Say "stop here"
+and you get the file path, what's left, and one paste-once block of the remaining approved commands in case
+you'd rather finish by hand.
+
+To resume, just trigger the skill again. It re-probes the machine first and reconciles against what you
+already did — including anything you ran yourself while it wasn't watching — so nothing is re-asked and
+nothing is run twice.
+
 ## Usage
 
 Ask an agent that has this skill:

--- a/skills/dev-machine-setup/evals/evals.json
+++ b/skills/dev-machine-setup/evals/evals.json
@@ -37,7 +37,8 @@
         "Selected mode 'tune'",
         "Did not propose installing any agent CLI or baseline tool from missing.*",
         "Presented findings with severity and an additive/mutating tag on each fix",
-        "Requested a separate per-item yes for each mutating fix"
+        "Requested a separate per-item yes for each mutating fix",
+        "Presented each fix as its own fenced run-block, not as a command squeezed into a table cell"
       ]
     },
     {
@@ -50,7 +51,8 @@
         "Diagnosed via detect_env.py findings rather than guessing",
         "Did not propose reinstalling the CLI as the first fix",
         "Tagged the rc-file edit as mutating and offered a backup of the rc file first",
-        "Stated that verification requires a fresh login shell"
+        "Stated that verification requires a fresh login shell",
+        "Gave a complete, copy-pasteable command block with no <placeholders> and no assumed working directory"
       ]
     },
     {
@@ -99,6 +101,34 @@
       "expectations": [
         "Did not start the phased setup workflow",
         "Did not run a full gap report for a single package request"
+      ]
+    },
+    {
+      "id": 9,
+      "kind": "edge-case",
+      "prompt": "Just optimize what's already here.  (Run against a macOS machine whose findings are exactly login-shell-not-zsh and oh-my-zsh-missing.)",
+      "expected_output": "Phase 5 presented as a table of id/severity/impact/tag plus one fenced run-block per finding, each labelled you-run-this or I-can-run-this, then a numbered approval prompt.",
+      "files": [],
+      "expectations": [
+        "No command appears inside a table cell",
+        "Each finding has its own fenced code block the user can copy and run unedited",
+        "chsh is labelled 'you run this' and its password prompt / policy-denial risk is named",
+        "The Oh My Zsh installer URL is visible inside the block, tagged mutating-or-additive per the skill",
+        "Approval was requested as a numbered list rather than as prose per-finding questions"
+      ]
+    },
+    {
+      "id": 10,
+      "kind": "edge-case",
+      "prompt": "Stop here, I need to head out — I'll finish this later.",
+      "expected_output": "The run pauses cleanly: session file written and its path given, remaining work summarized, and a single paste-once block of the already-approved commands so the user can finish by hand. Triggering the skill again resumes without re-asking.",
+      "files": [],
+      "expectations": [
+        "Wrote ~/.dev-machine-setup/session.json and told the user the path",
+        "Summarized what is done, approved-but-not-run, and declined",
+        "Emitted one paste-once block containing only already-approved commands, in approval order",
+        "Did not leave a partially applied rc-file edit behind",
+        "Said that re-triggering the skill resumes, with no arguments needed"
       ]
     }
   ]

--- a/skills/dev-machine-setup/references/detect.md
+++ b/skills/dev-machine-setup/references/detect.md
@@ -7,13 +7,18 @@ Run this first. Do not install anything until the JSON is in hand.
 From the skill directory (or any clone of this skill):
 
 ```bash
-python3 scripts/detect_env.py
+python3 "$HOME/.claude/skills/dev-machine-setup/scripts/detect_env.py"
 ```
+
+`~/.claude/skills/dev-machine-setup/` is the default install path. If this skill lives somewhere else
+(plugin bundle, repo checkout), resolve that directory **once** and present the block with the real absolute
+path already substituted — never a relative path and never a `<placeholder>`, per SKILL.md § Presenting
+commands.
 
 On Windows PowerShell, if `python3` is missing:
 
 ```powershell
-py -3 scripts/detect_env.py
+py -3 "$HOME\.claude\skills\dev-machine-setup\scripts\detect_env.py"
 ```
 
 ## Fallback one-liners

--- a/skills/dev-machine-setup/references/edge-cases.md
+++ b/skills/dev-machine-setup/references/edge-cases.md
@@ -31,5 +31,14 @@ On Fedora/Arch, use `linux.md` package-manager switches instead of running the `
 
 ## Partial or interrupted runs
 
-The skill is safe to re-run: phase 1 rebuilds the gap report from the machine's real state, so anything
-that already succeeded drops out of `missing` and is skipped. Never resume from an old report.
+Trigger the skill again — phase 0 picks the run back up from `~/.dev-machine-setup/session.json`
+(`references/session.md`). Two rules keep that honest:
+
+- The session file carries **decisions** (mode, what was approved, what was declined, backup paths). It never
+  carries machine state.
+- Machine state always comes from a fresh `detect_env.py` on resume. Anything that already succeeded drops
+  out of `missing` and is skipped; anything that regressed comes back. **Never resume from an old gap
+  report.**
+
+With no session file — a different machine, or the user discarded it — a plain re-run is still safe, just
+chattier: phase 1 rebuilds everything from scratch and re-asks the questions.

--- a/skills/dev-machine-setup/references/linux.md
+++ b/skills/dev-machine-setup/references/linux.md
@@ -5,15 +5,16 @@ inbash Unix scripts target **Debian/Ubuntu** (`apt`). On Fedora/RHEL/Arch, use t
 Clone when apt-based:
 
 ```bash
-git clone https://github.com/luongnv89/inbash.git
-cd inbash
+git clone https://github.com/luongnv89/inbash.git ~/.inbash 2>/dev/null || git -C ~/.inbash pull --ff-only
 ```
+
+Every inbash command below then runs from any directory via its `~/.inbash/` path.
 
 ## Package manager
 
 | Distro | Install |
 |--------|---------|
-| Debian/Ubuntu | `sudo apt-get update && sudo apt-get install -y git curl wget vim build-essential` or `./unix/basic.sh --yes` |
+| Debian/Ubuntu | `sudo apt-get update && sudo apt-get install -y git curl wget vim build-essential` or `~/.inbash/unix/basic.sh --yes` |
 | Fedora | `sudo dnf install -y git curl wget vim gcc gcc-c++ make` |
 | Arch | `sudo pacman -Syu --needed git curl wget vim base-devel` |
 
@@ -22,7 +23,7 @@ cd inbash
 **Debian/Ubuntu (inbash):**
 
 ```bash
-./unix/nodejs.sh --yes
+~/.inbash/unix/nodejs.sh --yes
 ```
 
 Uses NodeSource `setup_lts.x`. Review the downloaded setup script if the user is cautious.
@@ -38,7 +39,7 @@ Prefer one Node. If `nvm`/`fnm` already exists, use it instead of adding a secon
 **Debian/Ubuntu (inbash):**
 
 ```bash
-./unix/python3-pip.sh --yes
+~/.inbash/unix/python3-pip.sh --yes
 ```
 
 Then **uv** (do not `pip install` into the system interpreter — PEP 668):
@@ -55,8 +56,8 @@ Confirm the URL first. Verify: `python3 --version`, `uv --version`.
 ## Zsh + Oh My Zsh
 
 ```bash
-./install-zsh.sh --yes --set-default
-./setup-ohMyZsh.sh --yes
+~/.inbash/install-zsh.sh --yes --set-default
+~/.inbash/setup-ohMyZsh.sh --yes
 ```
 
 `install-zsh.sh` already switches on apt/dnf/yum/pacman/apk/zypper. Works on WSL.

--- a/skills/dev-machine-setup/references/macos.md
+++ b/skills/dev-machine-setup/references/macos.md
@@ -3,9 +3,10 @@
 Prefer [inbash](https://github.com/luongnv89/inbash) mac scripts. Clone once:
 
 ```bash
-git clone https://github.com/luongnv89/inbash.git
-cd inbash
+git clone https://github.com/luongnv89/inbash.git ~/.inbash 2>/dev/null || git -C ~/.inbash pull --ff-only
 ```
+
+Every inbash command below then runs from any directory via its `~/.inbash/` path.
 
 ## Homebrew
 
@@ -35,13 +36,13 @@ brew install git curl wget
 inbash:
 
 ```bash
-./mac/nodejs.sh --yes --formula node
+~/.inbash/mac/nodejs.sh --yes --formula node
 ```
 
 Or pin LTS:
 
 ```bash
-./mac/nodejs.sh --yes --formula node@22 --force-link
+~/.inbash/mac/nodejs.sh --yes --formula node@22 --force-link
 ```
 
 Verify: `node -v`, `npm -v`. Optionally `corepack enable`.
@@ -51,7 +52,7 @@ Verify: `node -v`, `npm -v`. Optionally `corepack enable`.
 inbash (Homebrew `python@3.12`, pip, **uv**):
 
 ```bash
-./mac/python-pip-uv.sh --yes --python-formula python@3.12
+~/.inbash/mac/python-pip-uv.sh --yes --python-formula python@3.12
 ```
 
 Verify: `python3 -V`, `uv --version`. Use `uv venv` for projects; do not `sudo pip3 install`.
@@ -59,8 +60,8 @@ Verify: `python3 -V`, `uv --version`. Use `uv venv` for projects; do not `sudo p
 ## Zsh + Oh My Zsh
 
 ```bash
-./install-zsh.sh --yes --set-default
-./setup-ohMyZsh.sh --yes
+~/.inbash/install-zsh.sh --yes --set-default
+~/.inbash/setup-ohMyZsh.sh --yes
 ```
 
 `setup-ohMyZsh.sh` installs `zsh-syntax-highlighting`, `zsh-autosuggestions`, `zsh-completions` and deploys inbash `zshrc-config`. If the user already has a custom `~/.zshrc`, skip the config copy and only add plugins.
@@ -69,7 +70,7 @@ Verify: `python3 -V`, `uv --version`. Use `uv venv` for projects; do not `sudo p
 
 ## Optional (only if asked)
 
-- Docker Desktop: `./mac/docker.sh --yes`
+- Docker Desktop: `~/.inbash/mac/docker.sh --yes`
 - Xcode CLT: `xcode-select --install` if compile tools are missing
 
 ## Agent CLIs

--- a/skills/dev-machine-setup/references/optimize.md
+++ b/skills/dev-machine-setup/references/optimize.md
@@ -14,23 +14,52 @@ cp ~/.zshrc ~/.zshrc.bak.$(date +%Y%m%d%H%M%S)   # or ~/.zprofile, ~/.bashrc
 
 Windows equivalent: `Copy-Item $PROFILE "$PROFILE.bak"`.
 
+Every command here reaches the user as a **run-block** — SKILL.md § Presenting commands. Inspect blocks stay
+separate from fix blocks, nothing assumes a working directory, and any value that has to come from the user
+is collected *before* the block is shown, never left as a `<placeholder>`.
+
 ---
 
 ## no-package-manager
 
-**additive.** Nothing installs until a manager exists. Install the one for the OS — macOS: Homebrew
-(`macos.md` § Homebrew), Linux: the distro's manager is already present unless the image is minimal
-(`linux.md`), Windows: App Installer from the Microsoft Store, then re-run `winget --version`.
+**additive.** Nothing installs until a manager exists.
+
+macOS — Homebrew (*you run this*: the installer prompts for your password):
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+Linux: the distro's manager is already present unless the image is minimal (`linux.md`).
+
+Windows — install **App Installer** from the Microsoft Store (*you run this*: Store GUI), then verify:
+
+```powershell
+winget --version
+```
 
 ## npm-global-bin-not-on-path
 
 **mutating** (edits a shell rc). This is the single most common cause of "installed it, command not
 found" — the CLI is on disk but the shim directory is invisible.
 
+Inspect — where npm actually puts global binaries:
+
 ```bash
-npm prefix -g                       # e.g. /Users/me/.npm-global
-export PATH="$(npm prefix -g)/bin:$PATH"          # verify in this shell first
-echo 'export PATH="$(npm prefix -g)/bin:$PATH"' >> ~/.zshrc   # then persist
+npm prefix -g
+```
+
+Persist (mutating; backs the rc file up first):
+
+```bash
+cp ~/.zshrc ~/.zshrc.bak.$(date +%Y%m%d%H%M%S)
+echo 'export PATH="$(npm prefix -g)/bin:$PATH"' >> ~/.zshrc
+```
+
+Verify — in a *fresh* login shell, since the current one never re-reads `~/.zshrc`:
+
+```bash
+zsh -l -c 'command -v claude && claude --version'
 ```
 
 Windows: add the `npm prefix -g` directory itself (no `/bin`) via
@@ -43,8 +72,17 @@ If the prefix is a root-owned directory the user cannot write, re-point it inste
 
 **mutating.** Homebrew is installed but its shellenv line never landed:
 
+Persist (mutating — Intel Macs use `/usr/local/bin/brew`; confirm which with `ls /opt/homebrew/bin/brew`
+before presenting the block):
+
 ```bash
-echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile   # Intel: /usr/local/bin/brew
+cp ~/.zprofile ~/.zprofile.bak.$(date +%Y%m%d%H%M%S) 2>/dev/null || true
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+```
+
+Reload (*you run this* — it replaces your running shell):
+
+```bash
 exec zsh -l
 ```
 
@@ -57,17 +95,31 @@ uninstall the x86 prefix — some formulae are x86-only.
 
 ## xcode-clt-missing
 
-**additive.** `xcode-select --install` (opens a GUI dialog; tell the user to accept it). Native builds,
-many Homebrew formulae, and `node-gyp` fail without it.
+**additive.** Native builds, many Homebrew formulae, and `node-gyp` fail without it.
+
+*You run this* — it opens a GUI dialog that has to be accepted:
+
+```bash
+xcode-select --install
+```
+
+Verify:
+
+```bash
+xcode-select -p
+```
 
 ## multiple-node-managers
 
 **mutating.** Two or more Node sources compete for PATH, so `node -v` depends on which rc file won.
 Do not uninstall anything automatically. Show the user which one is winning and let them pick:
 
+Inspect — which Node is winning and where it comes from:
+
 ```bash
-which -a node && node -v
-type -a node          # zsh/bash: shows function/alias shims too
+which -a node
+type -a node
+node -v
 ```
 
 Keep the version manager if one is in active use (a `.nvmrc`/`.node-version` in their projects is the
@@ -78,28 +130,71 @@ step — `brew uninstall node` or removing the manager's rc lines, never both bl
 
 **mutating.** The floor lives in `NODE_MIN_MAJOR` in `scripts/detect_env.py`. Upgrading a runtime can
 break projects pinned to the old major — say so before running anything. Upgrade through whatever
-already owns Node (`brew upgrade node`, `nvm install --lts`, `winget upgrade OpenJS.NodeJS.LTS`,
-distro path in `linux.md`), never by adding a second source.
+already owns Node, never by adding a second source. Pick the one block matching the owner found by
+`multiple-node-managers`'s inspect:
+
+```bash
+brew upgrade node
+```
+
+```bash
+nvm install --lts && nvm alias default 'lts/*'
+```
+
+```powershell
+winget upgrade --id OpenJS.NodeJS.LTS
+```
+
+Distro path in `linux.md`. Verify: `node -v` and `npm -v`.
 
 ## python-below-min
 
 **mutating.** Same rule: upgrade through the owner. Never replace the OS's own `/usr/bin/python3` on
-Linux or macOS — install a newer interpreter alongside (`brew install python@3.13`, `uv python install
-3.13`) and leave the system one alone.
+Linux or macOS — install a newer interpreter alongside and leave the system one alone:
+
+```bash
+brew install python@3.13
+```
+
+```bash
+uv python install 3.13
+```
+
+Verify: `python3 -V`, or `uv python list` for the uv-managed ones.
 
 ## python-externally-managed
 
-**additive.** The system interpreter is PEP 668 marked, so `pip install` into it fails by design.
-Install `uv` and use `uv venv` / `uv pip` per-project. Commands per OS in `macos.md`, `linux.md`,
-`windows.md`. Never suggest `--break-system-packages`.
+**additive.** The system interpreter is PEP 668 marked, so `pip install` into it fails by design. Install
+`uv` and work per-project. Never suggest `--break-system-packages`.
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Homebrew alternative — `brew install uv`. Windows — `winget install --id astral-sh.uv`. Fuller per-OS
+context in `macos.md`, `linux.md`, `windows.md`.
+
+Then, in any project directory (this is the habit to hand the user, not a one-off fix):
+
+```bash
+uv venv && source .venv/bin/activate
+```
 
 ## git-identity-missing
 
-**mutating** (writes `~/.gitconfig`) — and the values must come from the user, never invented:
+**mutating** (writes `~/.gitconfig`). The values must come from the user and never be invented — **ask for
+both first, then present the block with them already filled in.** A block still containing a placeholder is
+not a run-block; it makes the user edit before pasting, which is exactly what the format exists to avoid.
 
 ```bash
-git config --global user.name "<ask the user>"
-git config --global user.email "<ask the user>"
+git config --global user.name "Ada Lovelace"
+git config --global user.email "ada@example.com"
+```
+
+Verify:
+
+```bash
+git config --global --get-regexp '^user\.'
 ```
 
 ## path-duplicates
@@ -107,24 +202,62 @@ git config --global user.email "<ask the user>"
 **mutating.** Duplicate entries mean a profile is sourced twice (commonly `.zprofile` *and* `.zshrc`
 both adding the same line, or a re-entrant `exec zsh`). Show the offenders first:
 
+Inspect — which entries repeat, and which rc file adds them twice:
+
 ```bash
 echo "$PATH" | tr ':' '\n' | sort | uniq -d
 grep -n 'PATH=' ~/.zshrc ~/.zprofile ~/.zshenv 2>/dev/null
-time zsh -i -c exit          # startup cost, before and after
+time zsh -i -c exit
 ```
 
-Fix the duplicated export in the rc file (after the backup above). Do not rewrite PATH wholesale — one
-bad edit locks the user out of their own tools.
+There is no generic fix command: the fix is deleting one specific line. That also makes it the one finding
+whose fix is never stored for later replay — line numbers move. If the run pauses here, record the *inspect*
+block and re-derive the edit on resume (`session.md` § Reconciling). Read the `grep -n` output, then
+present a fix block naming that exact file and line number, after the backup above. Do not rewrite PATH
+wholesale — one bad edit locks the user out of their own tools. Re-run the `time zsh -i -c exit` block
+afterwards to show the startup win.
 
 ## login-shell-not-zsh
 
-**mutating.** `chsh -s "$(command -v zsh)"` needs a password and may be denied by policy or by an LDAP
-directory. A denial is not a failure of the phase — record it and move on (`edge-cases.md` § chsh).
+**mutating.** *You run this* — `chsh` asks for your password at a TTY, and a corporate policy or LDAP
+directory may refuse it. A denial is not a failure of the phase: record it and move on
+(`edge-cases.md` § chsh).
+
+```bash
+chsh -s "$(command -v zsh)"
+```
+
+Verify in a **newly opened terminal window** (the current one keeps its old shell):
+
+```bash
+echo "$SHELL"
+```
 
 ## oh-my-zsh-missing
 
-**additive.** `setup-ohMyZsh.sh` from inbash (`macos.md` / `linux.md`). If the user already has a
-hand-written `~/.zshrc`, install the framework and plugins but skip the config copy.
+**additive.** Downloads and runs a remote installer, and creates `~/.zshrc` — say both before asking.
+
+inbash (preferred for this user; clones to a fixed path so the block works from any directory):
+
+```bash
+git clone https://github.com/luongnv89/inbash.git ~/.inbash 2>/dev/null || git -C ~/.inbash pull --ff-only
+~/.inbash/setup-ohMyZsh.sh --yes
+```
+
+Upstream installer, if inbash is unavailable:
+
+```bash
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+```
+
+If the user already has a hand-written `~/.zshrc`, install the framework and plugins but skip the config
+copy — and back the file up first either way.
+
+Verify:
+
+```bash
+ls -d ~/.oh-my-zsh
+```
 
 ## no-sudo
 

--- a/skills/dev-machine-setup/references/report-template.md
+++ b/skills/dev-machine-setup/references/report-template.md
@@ -1,0 +1,36 @@
+# FINAL REPORT template (phase 6)
+
+Assembled from the session file, never from memory. Every line that has no data is still printed with its
+skip reason — an omitted phase reads as an oversight.
+
+```
+◆ Dev machine setup — FINAL REPORT
+  Machine:   <os> / <arch> / <distro or build>   Mode: setup | tune
+  Manager:   <package manager>
+
+  Phase 1 · Gap report
+    ✓ present N · missing B baseline, A agents · findings H high / M med / L low
+  Phase 2 · Debloat
+    ✓ skipped (not fresh Windows) | listed N, removed K (names: …)
+  Phase 3 · Baseline gaps
+    ✓ nothing missing | installed: uv 0.11 · node v22.14  (deferred: …)
+  Phase 4 · Agent CLI gaps
+    ✓ nothing missing | installed: pi 0.84 · opencode 1.18  (declined: …)
+  Phase 5 · Optimize
+    ✓ fixed:    npm-global-bin-not-on-path (high) · path-duplicates (low)
+    ○ declined: intel-homebrew-on-apple-silicon (medium) — user deferred migration
+    verified by re-running detect_env.py: 0 high remaining
+
+  Result:    READY | PARTIAL | BLOCKED
+  Next:      <what the user should do — open a new shell, run `claude` to log in, …>
+  Session:   ~/.dev-machine-setup/session.json (complete)
+```
+
+Fill `Machine` and `Manager` from the phase-1 gap report, each phase line from that phase's recorded items,
+and `Next` from the session file's `next` sentence. `Session` names the file and its final `status`.
+
+Lines to keep even when empty:
+
+- a skipped phase prints `✓ skipped (<reason>)` — never nothing
+- declined items print with `○` and the user's reason, so a declined `high` finding stays visible
+- phase 5 always prints the verification re-run's remaining-high count, even when it is `0`

--- a/skills/dev-machine-setup/references/session.md
+++ b/skills/dev-machine-setup/references/session.md
@@ -1,0 +1,99 @@
+# Session file — pause and resume
+
+`~/.dev-machine-setup/session.json` is the durable running log. It exists so a run interrupted anywhere —
+the user walks away, the terminal closes, the machine reboots — can be picked up by triggering the skill
+again, with nothing re-asked and nothing re-run.
+
+Created at the end of phase 1, rewritten whole at every **Record** step. Never patch it in place: rewriting
+the whole document is one command and cannot leave half-valid JSON behind.
+
+## Schema
+
+```json
+{
+  "schema": 1,
+  "status": "in-progress",
+  "mode": "setup",
+  "started": "2026-08-20T09:41:00Z",
+  "updated": "2026-08-20T10:12:33Z",
+  "machine": { "os": "darwin", "arch": "arm64", "host": "mbp-luong", "manager": "brew" },
+  "phases": { "1": "done", "2": "skipped", "3": "done", "4": "partial", "5": "in-progress", "6": "pending" },
+  "items": [
+    { "id": "uv", "kind": "baseline", "state": "done", "evidence": "uv 0.11.0" },
+    { "id": "opencode", "kind": "agent", "state": "declined", "note": "user wanted claude only" },
+    { "id": "npm-global-bin-not-on-path", "kind": "finding", "severity": "high",
+      "state": "needs-new-shell", "evidence": "export line appended to ~/.zshrc" },
+    { "id": "oh-my-zsh-missing", "kind": "finding", "severity": "low", "state": "approved",
+      "command": "sh -c \"$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)\"" }
+  ],
+  "backups": ["/Users/me/.zshrc.bak.20260820094533"],
+  "next": "run oh-my-zsh-missing, then re-run detect_env.py"
+}
+```
+
+| Field | Rule |
+|-------|------|
+| `status` | `in-progress` until phase 6 sets `complete`. Only a `complete` session is skipped silently at phase 0. |
+| `mode` | `setup` or `tune`, fixed in phase 1. A resume keeps it — do not re-derive it from the new prompt. |
+| `machine` | Identity check for staleness. A different `host` or `os` means a different machine: start fresh. |
+| `phases` | `pending` · `in-progress` · `done` · `skipped` · `partial`. |
+| `items[].kind` | `baseline` · `agent` · `finding` · `debloat`. |
+| `items[].state` | `pending` · `approved` · `done` · `needs-new-shell` · `failed` · `declined` · `deferred`. |
+| `items[].command` | Only on items still owing a command (`approved`, `failed`). This is what rebuilds the paste-once block at a pause — drop it once the item is `done`. |
+| `backups` | Absolute path of every rc file copy made, so a bad edit is recoverable without guessing. |
+| `next` | One sentence, written for a *cold* reader: the resume screen is built from it. |
+
+## Writing it
+
+Timestamps: run `date -u +%Y-%m-%dT%H:%M:%SZ` first and paste the literal value. The heredoc below is quoted,
+so `$(...)` inside the JSON is stored verbatim — which is what item commands need.
+
+```bash
+mkdir -p ~/.dev-machine-setup
+cat > ~/.dev-machine-setup/session.json <<'JSON'
+{ ...the whole document... }
+JSON
+```
+
+PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force -Path "$HOME\.dev-machine-setup" | Out-Null
+@'
+{ ...the whole document... }
+'@ | Set-Content -Encoding utf8 "$HOME\.dev-machine-setup\session.json"
+```
+
+## Reconciling on resume (phase 0)
+
+The machine moved on while you were away — the user may have pasted the remaining blocks by hand, or
+installed something else entirely. So re-run `detect_env.py` **before** trusting any recorded state, and
+treat the fresh probe as the authority:
+
+| Recorded state | Fresh probe says | Becomes |
+|----------------|------------------|---------|
+| `approved` / `pending` / `failed` | already satisfied | `done` — evidence `"verified on resume"` |
+| `approved` / `pending` | still missing / still a finding | stays — re-present its run-block |
+| `done` / `needs-new-shell` | still missing / still a finding | `pending` — say it regressed, then re-present |
+| `declined` / `deferred` | still a finding | unchanged — **do not re-propose** unless the user asks |
+| anything | `machine` block mismatches this host | session is stale — start fresh, keep the old file |
+
+**Never replay a stored `command` that names a file line number.** Line numbers move — a phase-3 install
+that appended to the same rc file invalidates them, and a stale `sed -i '12d'` deletes the wrong line. On
+resume, re-run the finding's inspect block and re-derive the fix from fresh output. Currently only
+`path-duplicates` produces such commands; store its `command` as the *inspect* block, never the edit.
+
+Never report an item as done on the strength of `evidence` alone. A finding that only clears in a new login
+shell is `needs-new-shell`, not `done`, until a fresh shell confirms it.
+
+## Pausing
+
+On "pause", "stop here", or "I'll finish later", output exactly three things:
+
+1. The session file path.
+2. What is left: counts by state, and the `next` sentence.
+3. A paste-once block of the `command` of every item still in state `approved`, in approval order — so the
+   user can finish by hand without the agent.
+
+Leave nothing half-applied: if an rc file was opened for edit, either complete that one edit or restore its
+backup before pausing.


### PR DESCRIPTION
Closes #101

## What changed

### 1. Run-blocks — commands are copy-pasteable again

New `## Presenting commands (run-blocks)` section in SKILL.md, applied by **every** phase, not just phase 5.

The direct cause of the reported output was phase 5's own instruction — *"Present one table: finding id · severity · what breaks today · **the fix** · additive/mutating"*. The fix column told the agent to put the command in a cell, where it wraps mid-token and cannot be copied. That line is rewritten; phases 2–4 now point at the same contract.

The contract:

- Tables carry `id · severity · impact · additive/mutating` and *name* the mechanism ("Oh My Zsh installer, `curl | sh`"). The command goes in a fenced block underneath.
- One item per block, self-contained — no assumed cwd, no `$` prompt prefixes, no `<placeholders>`. Values that must come from the user are asked for first, then filled in.
- One purpose per block: inspect and fix never share a block, so pasting one cannot run the other.
- Each block tagged `you run this` (TTY password prompt, GUI dialog, browser login, shell replacement) or `I can run this`. This is orthogonal to additive/mutating, which is about risk, not about whose terminal.
- Approval as a numbered list. Approved `you run this` blocks may be concatenated into one paste-once block — built **only** from items that each already got their own yes, so this stays a convenience *after* approval and never becomes the approval mechanism.

The reported findings are the worked example in the skill.

**Fix catalog backfill.** `login-shell-not-zsh` and `oh-my-zsh-missing` had no command block at all — with nothing to paste, the agent improvised into the cell. Added blocks there and for `no-package-manager`, `xcode-clt-missing`, `node-below-min`, `python-below-min`, `python-externally-managed`; split inspect from fix in `npm-global-bin-not-on-path`, `brew-bin-not-on-path`, `path-duplicates`; dropped the `<ask the user>` placeholder from `git-identity-missing`.

### 2. Session file — pause anywhere, resume by asking again

`~/.dev-machine-setup/session.json`, with the phase loop going from four steps to five: Present → Approve → Execute → Verify → **Record**. The session file replaces the in-memory running log, so durability is structural rather than bolted on.

- New **phase 0** reads it and offers resume (default) / start fresh / discard.
- Resume **re-runs `detect_env.py` first and reconciles** — the probe is the authority, so anything the user ran by hand while the agent wasn't watching is credited rather than repeated. Declined items stay declined.
- Line-number-bearing fixes (`path-duplicates`) are re-derived on resume, never replayed from the file — an intervening install moves the lines, and a stale `sed -i '12d'` would delete the wrong one.
- "Pause" returns three things: the file path, what's left, and a paste-once block of the remaining approved commands.

Schema, write commands, and the reconcile table live in `references/session.md`.

## Notes for review

Two judgment calls worth a look:

- **`~/.inbash` relocation.** The run-block self-containment rule made `cd inbash` + `./setup-ohMyZsh.sh` untenable, so inbash now clones to a fixed `~/.inbash` and every invocation uses that absolute path. This is a path change that wasn't strictly asked for — easy to revert if you'd rather keep the clone location free.
- **Body trimmed 3267 → 2969 words** to clear the asm-eval context-efficiency floor (6 → 8; overall 90 → 94, min category 8). The FINAL REPORT template moved to `references/report-template.md`, Acceptance Criteria collapsed 13 bullets → 10 with the same coverage, phase prose de-sprawled. The run-block contract and its example were deliberately **not** cut, despite being the largest available block — they're the behavior this PR exists to add.

## Verification

- `quick_validate.py` exits 0
- SKILL.md 342 lines (cap 500), 2969 words
- `asm eval`: overall 94 (A), min category 8 — both gates pass
- Evals extended: #9 covers run-block presentation on the exact reported findings, #10 covers pause/resume; format expectations added to #3 and #4

`metadata.version` 0.4.0 → 0.6.0. No CHANGELOG entry — this skill isn't in it yet (landed after v2.0.0).