### PR TITLE
feat(dev-machine-setup): self-contained zsh setup, drop inbash dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **`dev-machine-setup` 0.6.0 → 0.9.0:** now **self-contained** — no `luongnv89/inbash` clone. The shell config ships as `assets/zshrc-config` (a vendored fork; upstream fixes no longer flow in) and the `.sh` wrappers are replaced by the plain brew / apt / dnf / pacman commands and `git clone`s they wrapped.
+- **Zsh parity:** `detect_env.py` now reports `starship` as a baseline tool and emits `starship-config-missing` / `starship-config-not-managed`, deploying `assets/starship.toml`. Detection reads a first-line marker so phase 5's re-run can actually observe the fix.
+- **`oh-my-zsh-missing` is no longer flatly additive:** deploying the shipped `~/.zshrc` is additive when none exists and **mutating** (backup + its own yes) when one does, so a blanket approval can't silently overwrite a working config.
+- **SKILL.md split** for progressive disclosure — approval protocol → `references/approvals.md`, phase bodies → `references/procedure.md`. 354 → 176 lines; `asm eval` 90 → 94, min category 6 → 8.
 
 ## v2.0.0 — 2026-08-18
 

--- a/skills/dev-machine-setup/SKILL.md
+++ b/skills/dev-machine-setup/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dev-machine-setup
-description: "Set up or tune any machine — factory laptop or daily driver — on macOS, Linux, or Windows: report what's missing, install only that, then fix PATH, duplicate runtimes, shell config. Don't use for Dockerfiles, CI images, or single package installs."
+description: "Set up or tune any dev machine, fresh or drifted, on macOS, Linux, or Windows: report what's missing, install only that, then fix PATH, duplicate runtimes, and shell config. Don't use for Dockerfiles, CI images, or single package installs."
 license: MIT
 effort: high
 compatibility: "macOS, Linux (Debian/Ubuntu/Fedora/Arch), Windows (winget/PowerShell). Needs network and a package manager or permission to install one. Additive by default; anything that changes a working install needs an explicit per-item yes."
 metadata:
-  version: 0.6.0
+  version: 0.9.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -18,7 +18,10 @@ missing and misconfigured, and every later phase acts only on that report.
 **Gap-driven** is the whole design. Each phase self-skips when its slice of the report is empty, so a re-run
 on an already-good machine installs nothing and still verifies — idempotent by construction.
 
-This is an orchestrator: per-OS command tables live in `references/`, so only the current platform loads.
+**Self-contained:** no external scripts repo is cloned. The shell config the skill deploys ships in `assets/`.
+
+This is an orchestrator. Per-OS command tables and per-phase detail live in `references/`, so only the current
+platform loads and the token budget stays on the machine in front of you.
 
 ## Modes
 
@@ -37,101 +40,22 @@ unsure once the gap report is on screen, ask once, before phase 3.
 `tune` skips phases 3 and 4 entirely — never bulk-install what the user did not ask for. Phase 5 may still
 install a package when that *is* the approved fix for a finding (e.g. `uv` for `python-externally-managed`).
 
-## Additive vs mutating
+## Approvals
 
-The load-bearing distinction for every approval in this skill:
+**Read `references/approvals.md` before phase 2** — it holds the rules every phase runs under, in full. The
+four that must be in your head from the start:
 
-- **Additive** — installs something that is *absent*. Nothing working can break. Batch-approvable per phase.
+- **Additive** — installs something *absent*. Nothing working can break. Batch-approvable per phase.
 - **Mutating** — changes something that *already works*: upgrades, removals, `chsh`, rc-file edits,
-  `curl | sh`, PATH rewrites, replacing a runtime. Needs an explicit **per-item yes**, with the risk named,
-  and any rc file backed up first (`optimize.md` § top).
+  `curl | sh`, PATH rewrites. Needs an explicit **per-item yes**, with the risk named, and any rc file backed
+  up first. A prior yes never carries forward to another mutating item.
+- **Five-step loop, every phase:** Present → Approve → Execute → Verify → Record. Read-only probes
+  (`detect_env.py`, version checks, `winget list`) skip the approve step; nothing that changes state does.
+- **Run-blocks:** every proposed command ships as a copy-whole fenced block — never inside a table cell, never
+  with a `<placeholder>` or an assumed cwd, always tagged `you run this` / `I can run this`.
 
-On a daily driver, mutating steps are the real hazard — not missing packages. A prior yes never carries
-forward to another mutating item.
-
-## Human-in-the-loop (mandatory)
-
-Every phase runs a strict five-step loop. Do not skip a step; do not batch phases into one approval.
-
-1. **Present** — exactly what will run, as **run-blocks** (§ Presenting commands): each command, what it
-   changes, and its **additive/mutating** tag.
-2. **Approve** — wait for an explicit go-ahead. A blanket "do everything" covers additive steps only.
-3. **Execute** — only what was approved. On failure, stop and re-present; never silently widen scope.
-4. **Verify** — confirm the phase actually took (version checks, file presence, exit codes).
-5. **Record** — write the outcome to the **session file** (§ Pausing and resuming) before moving on, so a
-   pause, a crash, or a closed terminal never loses what was already decided and done.
-
-**Read-only probes are exempt from step 2** — `detect_env.py`, version checks, `winget list`, `brew outdated`.
-Say what you are running, then run it. The gate exists to guard *changes*; making the user approve a read that
-changes nothing trains them to rubber-stamp the approvals that matter.
-
-The session file *is* the running log (✓ / ✗ + evidence per item). The final report is built from it, never
-from memory.
-
-## Presenting commands (run-blocks)
-
-Every command you propose ships as a **run-block**: a fenced block the user can copy whole and run without
-editing it first. Every phase, not just phase 5.
-
-**Never put a command in a table cell** — cells wrap mid-token and produce something nobody can copy. Tables
-carry `finding id · severity · what breaks today · additive/mutating` and *name* the mechanism ("Oh My Zsh
-installer, `curl | sh`"); the command goes in the block underneath.
-
-A run-block is:
-
-- **One item per block**, headed by the finding id or item name and its additive/mutating tag.
-- **Self-contained** — no assumed cwd (`cd` inside the block, or use an absolute path), no `$` prompt
-  prefixes, no `<placeholders>`. If a value must come from the user (git identity, an npm prefix), **ask
-  first, then present the block with it filled in.**
-- **One purpose per block.** Inspect and fix never share a block — pasting one must not run the other.
-- **Tagged with who runs it.** `you run this` for anything needing a password prompt (`chsh`), a GUI dialog
-  (`xcode-select --install`), a browser login, or a shell replacement (`exec zsh -l`); otherwise
-  `I can run this`. Says *where it runs*, never a substitute for additive/mutating, which says *what it risks*.
-- Followed by its **verify** block where one is worth running.
-
-Ask for approval as a numbered list, so the user answers `1` or `1,3` instead of retyping ids. Approved
-`you run this` blocks may then be concatenated into one paste-once block — built **only** from items that
-each already got their own yes, in approval order. A combined block is never the thing being approved.
-
-**Example** — two low findings, presented right:
-
-````markdown
-| Finding | Sev | What breaks today | Tag |
-|---------|-----|-------------------|-----|
-| `login-shell-not-zsh` | low | zsh is installed but bash is still your login shell | mutating |
-| `oh-my-zsh-missing` | low | no completion/plugin baseline for zsh | additive |
-
-**1 · `login-shell-not-zsh`** — mutating · you run this (asks for your password; corporate policy or LDAP
-may refuse it, which is not a failure — we just skip it)
-
-```bash
-chsh -s "$(command -v zsh)"
-```
-
-**2 · `oh-my-zsh-missing`** — additive · I can run this (downloads and runs the installer from
-github.com/ohmyzsh, and creates `~/.zshrc`)
-
-```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
-```
-
-Approve which — `1`, `2`, `1,2`, or `none`?
-````
-
-## Pausing and resuming
-
-Machine setup is long, interruptible work, so state lives on disk rather than in the conversation.
-
-**Session file:** `~/.dev-machine-setup/session.json` (PowerShell: `$HOME\.dev-machine-setup\session.json`).
-Create it at the end of phase 1 and rewrite it at every **Record** step — after each phase, and after each
-individual approve/decline/execute inside phases 2–5. Schema and the write command are in
-`references/session.md`.
-
-The user can say "pause" at any point. Answer with three things and nothing else: the session file path, what
-is left, and a **paste-once block of the remaining approved commands** so they can finish by hand if they
-never come back. Never leave a half-applied rc edit behind at a pause.
-
-Resuming needs no arguments — triggering the skill again is enough (phase 0).
+The session file (`~/.dev-machine-setup/session.json`) *is* the running log. Write it at every Record step;
+build the final report from it, never from memory. Pause and resume protocol: `references/approvals.md`.
 
 ## When to Use
 
@@ -148,153 +72,66 @@ Don't use for: Dockerfiles, CI runners, or installing a single named package.
 - Network.
 - Admin/sudo (or winget) for system packages. Without it, only user-level installs are possible — say which
   requests that blocks rather than failing them silently.
-- Optional clone of `https://github.com/luongnv89/inbash` — preferred source for Unix/mac scripts this user
-  already maintains.
 
 ## Reference files (load only what you need)
 
 | File | When |
 |------|------|
 | `scripts/detect_env.py` | Phase 1 — prints the gap report JSON (inventory + `missing` + `findings`) |
+| `references/approvals.md` | Before phase 2 — additive/mutating, the five-step loop, run-blocks, pause/resume |
+| `references/procedure.md` | Every phase — what each phase actually does, step by step |
 | `references/detect.md` | How to run the probe without `python3` and how to read every JSON key |
 | `references/windows.md` | Windows: inventory, conservative debloat, winget stack |
-| `references/macos.md` | macOS: Homebrew, Node, Python+uv, zsh |
-| `references/linux.md` | Linux: apt/dnf/pacman, NodeSource LTS, python3-pip |
+| `references/macos.md` | macOS: Homebrew, Node, Python+uv, zsh, starship |
+| `references/linux.md` | Linux: apt/dnf/pacman, NodeSource LTS, python3-pip, zsh, starship |
 | `references/agent-clis.md` | Phase 4 — Claude Code, Codex, Pi, OpenCode install + verify |
 | `references/optimize.md` | Phase 5 — one section per finding id, each tagged additive/mutating |
-| `references/session.md` | Phase 0 and every **Record** step — session-file schema, write command, reconcile rules |
+| `references/session.md` | Phase 0 and every Record step — session-file schema, write command, reconcile rules |
 | `references/report-template.md` | Phase 6 — the FINAL REPORT block and what each line must carry |
-| `references/edge-cases.md` | No python3, Windows ARM64, WSL, containers, re-runs, inbash distro limits |
+| `references/edge-cases.md` | No python3, Windows ARM64, WSL, containers, re-runs, unsupported distros |
+| `assets/zshrc-config` | Phases 3 and 5 — the `~/.zshrc` deployed by `oh-my-zsh-missing`; owns the theme, plugin list, and starship init |
+| `assets/starship.toml` | Phases 3 and 5 — the prompt config deployed by `starship-config-*`; `cp` it from the skill dir, never inline its contents |
 
 ## Procedure
 
-Every phase runs the five-step loop above. Do not advance until the current phase verifies green, self-skips
-on an empty gap set, or is explicitly deferred by the user.
+Full step-by-step detail for every phase is in **`references/procedure.md`** — read it at phase 0 and keep it
+open. This table is the spine: the order, and the condition that lets you advance. Do not advance until the
+current phase verifies green, self-skips on an empty gap set, or is explicitly deferred by the user.
 
-### 0. Resume check
+| # | Phase | Done when |
+|---|-------|-----------|
+| 0 | Resume check | Resuming from a reconciled session file, or starting clean with any discarded session deleted |
+| 1 | Detect and build the gap report | Gap report JSON captured, three lists shown, mode fixed, OS reference loaded, session file written |
+| 2 | Debloat *(fresh Windows only, opt-in)* | Skipped with a reason logged, or inventory shown and every removal individually confirmed and verified |
+| 3 | Baseline gaps *(skipped in `tune`)* | Every item in `missing.baseline` verifies green, or is logged as deferred |
+| 4 | Agent CLI gaps *(skipped in `tune`)* | Every requested agent CLI verifies green, or is explicitly declined |
+| 5 | Optimize | Verification re-run shows every approved fix gone from `findings`; each remaining one recorded as declined or deferred |
+| 6 | Final report | Report printed with a `Result` line, every gap and finding accounted for, session file marked `complete` |
 
-- Read `~/.dev-machine-setup/session.json`. **Absent, or `status: complete`** → say nothing, start at phase 1.
-- **Present and unfinished** → show one screen (mode, phases done, items done / approved-but-not-run /
-  declined, next step) and offer **resume** (default) · **start fresh** · **discard**.
-- On resume, **always re-run `detect_env.py` first and reconcile** — the machine moved on while you were away,
-  possibly because the user pasted the remaining blocks themselves. Rules in `references/session.md`.
-- Stale — `machine` mismatches this host, or the file is over 30 days old — say so and default to start fresh.
-- **Discard** deletes the file immediately; a discarded session left on disk is what makes a later resume
-  replay decisions the user threw away. **Start fresh** keeps it until phase 1 overwrites it.
+Three things bite often enough to belong here rather than only in the detail file:
 
-**Phase 0 done when:** the run is resuming from a reconciled session file, or starting clean with any
-discarded session deleted.
+- **Blocking findings go first, in phase 3** — `no-package-manager`, `no-sudo`, `brew-bin-not-on-path`,
+  `npm-global-bin-not-on-path` make installs fail or land invisibly.
+- **Phases 3 and 4 act only on `missing.*`.** Never reinstall or upgrade something already present; an upgrade
+  is mutating and belongs to phase 5.
+- **Phase 5 verifies by re-running `detect_env.py`**, never from memory. PATH and rc-file fixes keep reporting
+  until a new shell reads them — re-run in a fresh login shell, or log the finding as *fixed — needs new shell*.
 
-### 1. Detect and build the gap report
+### Zsh: one source of truth
 
-- **Present:** say what it does — read-only, no network, no changes; reports OS, arch, package managers,
-  installed versions, what's missing, what's misconfigured. Read-only, so no approval needed.
-- **Execute:** `python3 <skill-dir>/scripts/detect_env.py`, pathed from the skill's own directory, never the
-  user's cwd. Needs Python 3.9+; without `python3`, use the fallbacks in `references/detect.md`.
-- **Verify:** the JSON parses and contains `os`, `arch`, `tools`, `missing`, `findings`.
+`ZSH_THEME="wedisagree"`, the four-plugin list, and the `starship init zsh` line all live in
+`assets/zshrc-config`, which this skill ships and deploys by `cp`. Never hand-write those lines into
+`~/.zshrc` instead — edit the asset. It is a vendored **fork** of `luongnv89/inbash`'s config: upstream fixes
+do not flow in, which is the price of having no dependency.
 
-Then **show the gap report** as three short lists before doing anything else:
-
-```
-Present:  git 2.55 · node v26.7 · python 3.14 · uv 0.11 · zsh · claude · codex
-Missing:  baseline → uv          agents → pi, opencode
-Findings: 1 high · 0 medium · 2 low   (npm-global-bin-not-on-path, path-duplicates, oh-my-zsh-missing)
-```
-
-Read **only** the matching OS reference (`windows.md` / `macos.md` / `linux.md`), and confirm the mode if the
-request was ambiguous.
-
-**Phase 1 done when:** the gap report JSON is captured, the three lists are shown, the mode is fixed, the
-matching OS reference is loaded, and the session file exists with phase 1 recorded `done`.
-
-### 2. Debloat — fresh Windows only, opt-in
-
-Skip entirely unless the machine is Windows **and** the user asked to clean OEM junk — never on a daily
-driver, container, or remote host. Factory Windows boxes ship trial AV, OEM utilities, and partner games
-(inspired by [XFreeze](https://x.com/xfreeze/status/2090189407659999603)). **List before delete.**
-
-- **Present** the read-only inventory commands (`winget list`, `Get-AppxPackage`) as a run-block.
-- **Execute** `references/windows.md` § Inventory; build a `keep / review / remove-candidate` table.
-- Then **per removal** (mutating): one run-block per package naming what is lost, an explicit yes for that
-  one package, then execute, verify it no longer lists, and record it.
-
-**Phase 2 done when:** skipped with a reason logged, or the inventory is shown and every removal is
-individually confirmed and verified.
-
-### 3. Baseline gaps  *(skipped in `tune`)*
-
-**Blocking findings first.** Four findings make installs fail or land invisibly, so they are fixed *here*
-rather than in phase 5: `no-package-manager`, `no-sudo`, `brew-bin-not-on-path`, `npm-global-bin-not-on-path`.
-Fix per `references/optimize.md`, then continue. (A missing package manager arrives as a finding, not as a
-`missing.baseline` entry.)
-
-Then act only on `missing.baseline`. **Empty list → print `✓ baseline complete — nothing to install` and skip
-to phase 4.** Never reinstall or upgrade something already present — an upgrade is mutating, and belongs to
-phase 5.
-
-| Missing item | Install command lives in |
-|--------------|--------------------------|
-| `git` (+ curl, wget, editor) | the OS reference § Baseline |
-| `zsh` / Oh My Zsh | `macos.md` / `linux.md` § Zsh (Unix only; Windows keeps PowerShell) |
-| `node`, `npm` | the OS reference § Node.js LTS |
-| `python3`, `uv` | the OS reference § Python |
-
-- **Present:** one run-block per missing item, tagged additive. Flag anything that would touch an existing
-  Node or Python — that is mutating and needs its own yes.
-- **Verify:** `git --version`, `node -v`, `npm -v`, `python3 --version`, `uv --version` (Unix also
-  `zsh --version`) succeed for the items just installed.
-
-**Phase 3 done when:** every item that was in `missing.baseline` verifies green, or is logged as deferred.
-
-### 4. Agent CLI gaps  *(skipped in `tune`)*
-
-Acts only on `missing.agents`, in this order: Claude Code → Codex → Pi → OpenCode. **Empty list → print
-`✓ all agent CLIs present` and skip.** Ask which the user actually wants; do not assume all four.
-
-- **Present:** one run-block per CLI from `references/agent-clis.md`, with any `curl | sh` URL visible inside
-  the block (mutating — needs its own yes).
-- **Execute:** install only the requested missing ones. Requires Node on PATH from phase 3.
-- **Verify:** each prints a version (`claude --version`, `codex --version`, `pi --version`,
-  `opencode --version`). If a just-installed CLI is "not found", that is
-  `optimize.md#npm-global-bin-not-on-path` — carry it into phase 5 rather than reinstalling.
-
-Auth is the first interactive run of each CLI. Never write API keys into the log or into `~/.zshrc`.
-
-**Phase 4 done when:** every requested agent CLI verifies green, or is explicitly declined.
-
-### 5. Optimize
-
-Acts on `findings[]`, highest severity first. Each finding's `fix_ref` names its section in
-`references/optimize.md`; read only the sections for findings that actually fired.
-
-- **Present** one table — finding id · severity · what breaks today · **additive/mutating** — then one
-  run-block per finding beneath it (§ Presenting commands). No command goes in the table.
-- **Approve:** ask as a numbered list. Additive fixes can be batched. **Every mutating fix needs its own
-  yes** — and back up any rc file before editing it. Record each decision as it is made, not at the end.
-- **Execute** approved fixes only. A declined finding is recorded, not retried.
-- **Verify** by re-running `detect_env.py` and confirming the fixed ids are gone from `findings`. That re-run
-  is the phase's proof — never verify from memory. **PATH and rc-file fixes keep reporting until a new shell
-  reads them:** re-run in a fresh login shell (`zsh -l -c '<skill-dir>/scripts/detect_env.py'`, or a new
-  PowerShell window); with no fresh shell available, confirm the rc file contains the line and log the finding
-  as *fixed — needs new shell*.
-
-Deep checks (`brew outdated`, `winget upgrade`, `npm outdated -g`) need network and are opt-in — `optimize.md`
-§ Deep checks. Never volunteer disk cleanup during a setup run.
-
-**Phase 5 done when:** the verification re-run shows every approved fix gone from `findings` — or logged as
-*fixed — needs new shell* — and each remaining finding is recorded as declined or deferred with its severity.
-
-### 6. Final report
-
-Nothing executes. Assemble the report from the session file (`references/report-template.md`), then set its
-`status` to `complete` so the next run starts clean instead of offering a resume.
-
-**Phase 6 done when:** the report is printed with a `Result` line, every gap and finding is accounted for as
-fixed, declined, or deferred, and the session file is marked `complete`.
+**Deploying it is not always additive.** `cp assets/zshrc-config ~/.zshrc` overwrites an existing `~/.zshrc`,
+so it is additive only when none is present and **mutating** — backup plus its own yes — when one is. A
+blanket "do everything" approval never covers the mutating case. Full split in
+`optimize.md#oh-my-zsh-missing`.
 
 ## Safety
 
-Beyond the additive/mutating rule above:
+Beyond the additive/mutating rule:
 
 - Never run a third-party "debloat everything" script unattended. OEM audio/chipset tools can be load-bearing.
 - Never commit secrets, and never write an API key into a shell rc file. Auth for every agent CLI is its own
@@ -306,7 +143,7 @@ Beyond the additive/mutating rule above:
 ## Verification report
 
 Phase 6 prints the FINAL REPORT block from `references/report-template.md` — one line per phase, sourced from
-the session file. `Result` is decided by these three rules:
+the session file. `Result` is one of:
 
 - **READY** — no unresolved `high` findings, and in `setup` no baseline gap left unfilled. Declined agent CLIs
   and deferred low/medium findings are still READY.
@@ -319,16 +156,13 @@ the session file. `Result` is decided by these three rules:
 - `detect_env.py` printed valid JSON with `os`, `arch`, `tools`, `missing`, `findings`, and the phase-1 gap
   report was shown before anything was installed.
 - Mode was fixed before phase 3; in `tune`, phases 3 and 4 installed nothing.
-- Blocking findings (`no-package-manager`, `no-sudo`, `brew-bin-not-on-path`, `npm-global-bin-not-on-path`)
-  were fixed at the top of phase 3, not deferred.
+- Blocking findings were fixed at the top of phase 3, not deferred.
 - Phases 3 and 4 acted **only** on `missing.*` — nothing already present was reinstalled or upgraded.
 - Every command reached the user as a run-block: none in a table cell, none with an unresolved
   `<placeholder>` or an assumed cwd, each tagged `you run this` / `I can run this`.
-- The session file existed from phase 1 on, was rewritten at every Record step, and is `complete` by phase 6 —
-  an interrupted run resumes by triggering the skill again.
+- The session file existed from phase 1 on, was rewritten at every Record step, and is `complete` by phase 6.
 - Every mutating step has its own recorded yes; every rc file edited has a backup path in the session file.
-- Phase 5 verified by **re-running** `detect_env.py`; the report's counts come from that re-run. On a resumed
-  run that re-run and its reconcile happened before any new work.
+- Phase 5 verified by **re-running** `detect_env.py`; the report's counts come from that re-run.
 - The FINAL REPORT printed with a `Result` of READY / PARTIAL / BLOCKED and every gap and finding accounted
   for as fixed, declined, or deferred.
 - `quick_validate.py` exits 0 on the shipped SKILL.md.
@@ -337,6 +171,6 @@ the session file. `Result` is decided by these three rules:
 
 ## Edge Cases
 
-No `python3`, Windows ARM64, WSL, containers and remote-SSH hosts, interrupted runs, and inbash distro limits
-live in `references/edge-cases.md`. Machine states the probe reports as findings are in `references/optimize.md`,
-keyed by finding id.
+No `python3`, Windows ARM64, WSL, containers and remote-SSH hosts, interrupted runs, and distros outside the
+shipped apt/dnf/pacman tables live in `references/edge-cases.md`. Machine states the probe reports as findings
+are in `references/optimize.md`, keyed by finding id.

--- a/skills/dev-machine-setup/assets/starship.toml
+++ b/skills/dev-machine-setup/assets/starship.toml
@@ -1,0 +1,132 @@
+# dev-machine-setup:starship-config v1
+# ===============================================
+# STARSHIP - Clean Dev Prompt (Node, Python, Docker, LLM, CTF)
+# ===============================================
+
+# --- Global ---
+add_newline = true
+command_timeout = 1200
+
+format = """
+$hostname\
+$directory\
+$git_branch$git_status\
+$nodejs$python\
+$docker_context\
+$custom_llm$custom_ctf\
+$cmd_duration\
+$line_break\
+$character
+"""
+
+# -----------------------------------------------
+# CORE SECTIONS
+# -----------------------------------------------
+
+[directory]
+style = "bold blue"
+truncation_length = 3              # show up to 3 folders
+truncate_to_repo = true           # collapse everything above git root
+fish_style_pwd_dir_length = 1     # shows /u/p/proj instead of full names
+read_only = " "                  # shows lock icon if not writable
+format = "[$path]($style) "
+disabled = false
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"
+vimcmd_symbol = "[❮](bold yellow)"
+format = "$symbol "
+
+[cmd_duration]
+min_time = 2000
+show_milliseconds = false
+format = "⏱ [$duration]($style) "
+style = "yellow"
+
+[git_branch]
+symbol = " "
+format = "[$symbol$branch]($style) "
+style = "bold purple"
+
+[git_status]
+format = '([$all_status$ahead_behind]($style)) '
+style = "cyan"
+conflicted = "⚔ "
+ahead = "⇡${count} "
+behind = "⇣${count} "
+diverged = "⇕ "
+untracked = "? "
+modified = "✎ "
+staged = "+ "
+renamed = "» "
+deleted = "✘ "
+
+# -----------------------------------------------
+# LANGUAGES - Node + Python
+# -----------------------------------------------
+
+[nodejs]
+symbol = " "
+format = "[$symbol($version)](bold green) "
+detect_extensions = ["js", "jsx", "ts", "tsx", "mjs", "cjs"]
+detect_files = ["package.json", "vite.config.ts", "next.config.js"]
+detect_folders = ["node_modules"]
+
+[python]
+symbol = " "
+format = '[$symbol(${version} )(\($virtualenv\))]($style) '
+style = "bold yellow"
+python_binary = "python3"
+
+# -----------------------------------------------
+# DOCKER
+# -----------------------------------------------
+
+[docker_context]
+symbol = " "
+format = "[$symbol$context]($style) "
+style = "bold blue"
+only_with_files = true
+detect_files = ["Dockerfile", "docker-compose.yml", "compose.yaml"]
+disabled = false
+
+# -----------------------------------------------
+# CUSTOM MODULES: LLM / CTF
+# -----------------------------------------------
+# Convention: drop a file `.llm` or `.ctf` in your repo root to enable
+
+[custom.llm]
+command = "echo 'LLM'"
+when = "test -f .llm"
+format = "[ $output]($style) "
+style = "bold magenta"
+shell = ["bash", "-c"]
+
+[custom.ctf]
+command = "echo 'CTF'"
+when = "test -f .ctf"
+format = "[ $output]($style) "
+style = "bold red"
+shell = ["bash", "-c"]
+
+# -----------------------------------------------
+# QUALITY OF LIFE
+# -----------------------------------------------
+
+[time]
+disabled = true
+
+[hostname]
+format = "[$hostname]($style) "
+style = "dimmed"
+ssh_only = false
+
+[env_var.GIT_AUTHOR_EMAIL]
+# Useful if you switch identities work/personal
+format = " [$env_value]($style) "
+style = "blue"
+disabled = true  # set to false if you want it
+
+[battery]
+disabled = true

--- a/skills/dev-machine-setup/assets/zshrc-config
+++ b/skills/dev-machine-setup/assets/zshrc-config
@@ -1,0 +1,172 @@
+# =================================================================
+# dev-machine-setup :: Generic .zshrc
+# -----------------------------------------------------------------
+# Vendored fork of luongnv89/inbash `zshrc-config` so this skill has no
+# external repo dependency. It is a FORK, not a mirror: upstream fixes do not
+# flow in. Edit this file directly; do not re-point it at inbash.
+# -----------------------------------------------------------------
+# A portable Zsh configuration for Linux & macOS machines.
+# Works with Oh My Zsh and common developer toolchains.
+# =================================================================
+
+# If you come from bash you might have to change your $PATH.
+# export PATH=$HOME/bin:/usr/local/bin:$PATH
+
+# Path to your oh-my-zsh installation.
+export ZSH="$HOME/.oh-my-zsh"
+
+# Set name of the theme to load.
+ZSH_THEME="wedisagree"
+
+# Uncomment the following line to enable command auto-correction.
+ENABLE_CORRECTION="true"
+
+# Which plugins would you like to load?
+# Standard plugins can be found in ~/.oh-my-zsh/plugins/*
+# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
+plugins=(
+  git
+  zsh-syntax-highlighting
+  zsh-autosuggestions
+  zsh-completions
+)
+
+source $ZSH/oh-my-zsh.sh
+
+# =================================================================
+# Starship prompt (cross-platform, installed via brew / curl / etc.)
+# =================================================================
+if command -v starship >/dev/null 2>&1; then
+  eval "$(starship init zsh)"
+fi
+
+# =================================================================
+# User configuration
+# =================================================================
+
+# Set personal aliases, overriding those provided by oh-my-zsh libs,
+# plugins, and themes. Aliases can be placed here, though oh-my-zsh
+# users are encouraged to define aliases within the ZSH_CUSTOM folder.
+# For a full list of active aliases, run `alias`.
+
+# =================================================================
+# Homebrew (macOS / Linuxbrew)
+# =================================================================
+if command -v brew >/dev/null 2>&1; then
+  _BREW_BIN="$(command -v brew)"
+  eval "$("$_BREW_BIN" shellenv 2>/dev/null)"
+  unset _BREW_BIN
+fi
+
+# =================================================================
+# Python (homebrew / system)
+# =================================================================
+# Homebrew Python on macOS (Apple Silicon)
+if [ -d "/opt/homebrew/Frameworks/Python.framework/Versions" ]; then
+  for ver in /opt/homebrew/Frameworks/Python.framework/Versions/*/bin; do
+    case ":$PATH:" in
+      *":$ver:"*) ;; *) export PATH="$ver:$PATH";;
+    esac
+  done
+fi
+
+# Homebrew Python on macOS (Intel)
+if [ -d "/usr/local/Frameworks/Python.framework/Versions" ]; then
+  for ver in /usr/local/Frameworks/Python.framework/Versions/*/bin; do
+    case ":$PATH:" in
+      *":$ver:"*) ;; *) export PATH="$ver:$PATH";;
+    esac
+  done
+fi
+
+# Python 3.10 system path (macOS legacy)
+if [ -d "/Library/Frameworks/Python.framework/Versions/3.10/bin" ]; then
+  PATH="/Library/Frameworks/Python.framework/Versions/3.10/bin:${PATH}"
+  export PATH
+fi
+
+# =================================================================
+# pipx / user-local binaries
+# =================================================================
+if [ -d "$HOME/.local/bin" ]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# =================================================================
+# Developer CLI tools (optional — only adds to PATH if present)
+# =================================================================
+
+# =================================================================
+# AI Coding Assistants (optional — only adds to PATH if present)
+# =================================================================
+
+_COMPLETION_CACHE_DIR="$HOME/.local/share"
+
+# Claude Code (Anthropic)
+# Installed via: npm i -g @anthropic-ai/claude-code  OR  pipx install claude-code
+if command -v claude >/dev/null 2>&1; then
+  # Generate and source shell completion (one-time, cached)
+  _CLAUDE_COMP="$_COMPLETION_CACHE_DIR/claude-shell-completion.zsh"
+  if [ ! -f "$_CLAUDE_COMP" ]; then
+    mkdir -p "$_COMPLETION_CACHE_DIR"
+    claude completion zsh > "$_CLAUDE_COMP" 2>/dev/null || true
+  fi
+  [ -s "$_CLAUDE_COMP" ] && source "$_CLAUDE_COMP"
+fi
+
+# Codex CLI (OpenAI)
+# Installed via: npm i -g @openai/codex
+if command -v codex >/dev/null 2>&1; then
+  export PATH="$HOME/.codex/bin:$PATH"
+  # Generate and source shell completion (one-time, cached)
+  _CODEX_COMP="$_COMPLETION_CACHE_DIR/codex-shell-completion.zsh"
+  if [ ! -f "$_CODEX_COMP" ]; then
+    mkdir -p "$_COMPLETION_CACHE_DIR"
+    codex completion zsh > "$_CODEX_COMP" 2>/dev/null || true
+  fi
+  [ -s "$_CODEX_COMP" ] && source "$_CODEX_COMP"
+fi
+
+# Pi (Pi.dev — Pi Coding Agent)
+# Installed via: npm i -g @earendil-works/pi-coding-agent
+if command -v pi >/dev/null 2>&1; then
+  # Generate and source shell completion (one-time, cached)
+  _PI_COMP="$_COMPLETION_CACHE_DIR/pi-shell-completion.zsh"
+  if [ ! -f "$_PI_COMP" ]; then
+    mkdir -p "$_COMPLETION_CACHE_DIR"
+    pi completion zsh > "$_PI_COMP" 2>/dev/null || true
+  fi
+  [ -s "$_PI_COMP" ] && source "$_PI_COMP"
+fi
+
+unset _COMPLETION_CACHE_DIR _CLAUDE_COMP _CODEX_COMP _PI_COMP
+
+# =================================================================
+# NVM (Node Version Manager) — optional
+# =================================================================
+if [ -s "$HOME/.nvm/nvm.sh" ]; then
+  export NVM_DIR="$HOME/.nvm"
+  . "$NVM_DIR/nvm.sh"
+elif [ -s "/usr/local/share/nvm/nvm.sh" ]; then
+  export NVM_DIR="/usr/local/share/nvm"
+  . "$NVM_DIR/nvm.sh"
+fi
+
+# =================================================================
+# Pyenv — optional
+# =================================================================
+if command -v pyenv >/dev/null 2>&1; then
+  export PYENV_ROOT="$HOME/.pyenv"
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  if command -v pyenv >/dev/null 2>&1; then
+    eval "$(pyenv init --path)"
+    eval "$(pyenv init -)"
+  fi
+fi
+
+# =================================================================
+# Direnv — optional
+# =================================================================
+if command -v direnv >/dev/null 2>&1; then
+  eval "$(direnv hook zsh)"
+fi

--- a/skills/dev-machine-setup/docs/README.md
+++ b/skills/dev-machine-setup/docs/README.md
@@ -11,7 +11,8 @@ Set up **or tune** any machine (macOS, Linux, Windows) — a factory laptop, a h
 daily driver that has drifted.
 
 Inspired by [XFreeze on new Windows boxes](https://x.com/xfreeze/status/2090189407659999603) (inventory OEM
-junk before installing anything) and this user's [inbash](https://github.com/luongnv89/inbash) scripts.
+junk before installing anything). Self-contained: no external scripts repo is cloned — the shell config it
+deploys ships in the skill's own `assets/`.
 
 ## How it works
 

--- a/skills/dev-machine-setup/evals/evals.json
+++ b/skills/dev-machine-setup/evals/evals.json
@@ -77,7 +77,8 @@
       "expectations": [
         "Proceeded with additive installs under the blanket approval",
         "Still stopped for an explicit per-item yes on at least one mutating step",
-        "Named the risk of each mutating step before asking"
+        "Named the risk of each mutating step before asking",
+        "Treated deploying assets/zshrc-config over an EXISTING ~/.zshrc as mutating and asked separately, rather than letting the blanket approval cover it"
       ]
     },
     {
@@ -106,7 +107,7 @@
     {
       "id": 9,
       "kind": "edge-case",
-      "prompt": "Just optimize what's already here.  (Run against a macOS machine whose findings are exactly login-shell-not-zsh and oh-my-zsh-missing.)",
+      "prompt": "Just optimize what's already here.  (Run against a macOS machine whose findings are exactly login-shell-not-zsh, oh-my-zsh-missing, and starship-config-not-managed.)",
       "expected_output": "Phase 5 presented as a table of id/severity/impact/tag plus one fenced run-block per finding, each labelled you-run-this or I-can-run-this, then a numbered approval prompt.",
       "files": [],
       "expectations": [
@@ -114,7 +115,10 @@
         "Each finding has its own fenced code block the user can copy and run unedited",
         "chsh is labelled 'you run this' and its password prompt / policy-denial risk is named",
         "The Oh My Zsh installer URL is visible inside the block, tagged mutating-or-additive per the skill",
-        "Approval was requested as a numbered list rather than as prose per-finding questions"
+        "Approval was requested as a numbered list rather than as prose per-finding questions",
+        "Tagged starship-config-not-managed as mutating and required its own yes, with the ~/.config/starship.toml backup shown before the overwrite",
+        "Did not inline the starship.toml contents into a run-block; copied it from the skill's assets/starship.toml instead",
+        "Deployed the shell config from the skill's assets/zshrc-config; did not clone or reference an external scripts repo"
       ]
     },
     {

--- a/skills/dev-machine-setup/references/approvals.md
+++ b/skills/dev-machine-setup/references/approvals.md
@@ -1,0 +1,100 @@
+# Approvals and interaction protocol
+
+Loaded by SKILL.md § Approvals. Every phase of `dev-machine-setup` runs under these rules — the
+additive/mutating split, the five-step loop, run-block formatting, and how a run pauses without losing state.
+
+## Additive vs mutating
+
+The load-bearing distinction for every approval in this skill:
+
+- **Additive** — installs something that is *absent*. Nothing working can break. Batch-approvable per phase.
+- **Mutating** — changes something that *already works*: upgrades, removals, `chsh`, rc-file edits,
+  `curl | sh`, PATH rewrites, replacing a runtime. Needs an explicit **per-item yes**, with the risk named,
+  and any rc file backed up first (`optimize.md` § top).
+
+On a daily driver, mutating steps are the real hazard — not missing packages. A prior yes never carries
+forward to another mutating item.
+
+## Human-in-the-loop (mandatory)
+
+Every phase runs a strict five-step loop. Do not skip a step; do not batch phases into one approval.
+
+1. **Present** — exactly what will run, as **run-blocks** (§ Presenting commands): each command, what it
+   changes, and its **additive/mutating** tag.
+2. **Approve** — wait for an explicit go-ahead. A blanket "do everything" covers additive steps only.
+3. **Execute** — only what was approved. On failure, stop and re-present; never silently widen scope.
+4. **Verify** — confirm the phase actually took (version checks, file presence, exit codes).
+5. **Record** — write the outcome to the **session file** (§ Pausing and resuming) before moving on, so a
+   pause, a crash, or a closed terminal never loses what was already decided and done.
+
+**Read-only probes are exempt from step 2** — `detect_env.py`, version checks, `winget list`, `brew outdated`.
+Say what you are running, then run it. The gate exists to guard *changes*; making the user approve a read that
+changes nothing trains them to rubber-stamp the approvals that matter.
+
+The session file *is* the running log (✓ / ✗ + evidence per item). The final report is built from it, never
+from memory.
+
+## Presenting commands (run-blocks)
+
+Every command you propose ships as a **run-block**: a fenced block the user can copy whole and run without
+editing it first. Every phase, not just phase 5.
+
+**Never put a command in a table cell** — cells wrap mid-token and produce something nobody can copy. Tables
+carry `finding id · severity · what breaks today · additive/mutating` and *name* the mechanism ("Oh My Zsh
+installer, `curl | sh`"); the command goes in the block underneath.
+
+A run-block is:
+
+- **One item per block**, headed by the finding id or item name and its additive/mutating tag.
+- **Self-contained** — no assumed cwd (`cd` inside the block, or use an absolute path), no `$` prompt
+  prefixes, no `<placeholders>`. If a value must come from the user (git identity, an npm prefix), **ask
+  first, then present the block with it filled in.**
+- **One purpose per block.** Inspect and fix never share a block — pasting one must not run the other.
+- **Tagged with who runs it.** `you run this` for anything needing a password prompt (`chsh`), a GUI dialog
+  (`xcode-select --install`), a browser login, or a shell replacement (`exec zsh -l`); otherwise
+  `I can run this`. Says *where it runs*, never a substitute for additive/mutating, which says *what it risks*.
+- Followed by its **verify** block where one is worth running.
+
+Ask for approval as a numbered list, so the user answers `1` or `1,3` instead of retyping ids. Approved
+`you run this` blocks may then be concatenated into one paste-once block — built **only** from items that
+each already got their own yes, in approval order. A combined block is never the thing being approved.
+
+**Example** — two low findings, presented right:
+
+````markdown
+| Finding | Sev | What breaks today | Tag |
+|---------|-----|-------------------|-----|
+| `login-shell-not-zsh` | low | zsh is installed but bash is still your login shell | mutating |
+| `oh-my-zsh-missing` | low | no completion/plugin baseline for zsh | additive |
+
+**1 · `login-shell-not-zsh`** — mutating · you run this (asks for your password; corporate policy or LDAP
+may refuse it, which is not a failure — we just skip it)
+
+```bash
+chsh -s "$(command -v zsh)"
+```
+
+**2 · `oh-my-zsh-missing`** — additive · I can run this (downloads and runs the installer from
+github.com/ohmyzsh, and creates `~/.zshrc`)
+
+```bash
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+```
+
+Approve which — `1`, `2`, `1,2`, or `none`?
+````
+
+## Pausing and resuming
+
+Machine setup is long, interruptible work, so state lives on disk rather than in the conversation.
+
+**Session file:** `~/.dev-machine-setup/session.json` (PowerShell: `$HOME\.dev-machine-setup\session.json`).
+Create it at the end of phase 1 and rewrite it at every **Record** step — after each phase, and after each
+individual approve/decline/execute inside phases 2–5. Schema and the write command are in
+`references/session.md`.
+
+The user can say "pause" at any point. Answer with three things and nothing else: the session file path, what
+is left, and a **paste-once block of the remaining approved commands** so they can finish by hand if they
+never come back. Never leave a half-applied rc edit behind at a pause.
+
+Resuming needs no arguments — triggering the skill again is enough (phase 0).

--- a/skills/dev-machine-setup/references/detect.md
+++ b/skills/dev-machine-setup/references/detect.md
@@ -12,7 +12,7 @@ python3 "$HOME/.claude/skills/dev-machine-setup/scripts/detect_env.py"
 
 `~/.claude/skills/dev-machine-setup/` is the default install path. If this skill lives somewhere else
 (plugin bundle, repo checkout), resolve that directory **once** and present the block with the real absolute
-path already substituted — never a relative path and never a `<placeholder>`, per SKILL.md § Presenting
+path already substituted — never a relative path and never a `<placeholder>`, per `references/approvals.md` § Presenting
 commands.
 
 On Windows PowerShell, if `python3` is missing:
@@ -46,8 +46,8 @@ Get-Command winget, git, node, python, py -ErrorAction SilentlyContinue
 | `arch` | `x86_64` / `arm64` / raw uname |
 | `distro` | Linux ID from `/etc/os-release` (ubuntu, fedora, arch, …) |
 | `package_managers` | present managers (`apt`, `dnf`, `pacman`, `brew`, `winget`, `choco`, `scoop`) |
-| `tools` | `{name: version_or_null}` for git, node, npm, python3, pip, uv, zsh, claude, codex, pi, opencode |
-| `shell` | login shell + whether Oh My Zsh is installed |
+| `tools` | `{name: version_or_null}` for git, node, npm, python3, pip, uv, zsh, starship, claude, codex, pi, opencode |
+| `shell` | login shell, whether Oh My Zsh is installed, and `starship_config`: `managed` (the skill's `assets/starship.toml`, identified by its first-line marker) · `foreign` (a distro or hand-rolled toml) · `absent` |
 | `node_managers` | nvm / volta / asdf / fnm / n, found by directory (nvm is a shell function, not a binary) |
 | `missing.baseline` | baseline tools with no version — **the install list for phase 3** |
 | `missing.agents` | agent CLIs with no version — **the install list for phase 4** |

--- a/skills/dev-machine-setup/references/edge-cases.md
+++ b/skills/dev-machine-setup/references/edge-cases.md
@@ -25,9 +25,13 @@ and WSL Node paths — a gap report from one side says nothing about the other.
 debloat phase entirely, and skip `chsh` (containers usually have no login shell and the change dies with
 the container). Prefer user-level installs so the setup survives an image rebuild.
 
-## inbash scripts are Debian/mac-oriented
+## Distros outside the shipped tables
 
-On Fedora/Arch, use `linux.md` package-manager switches instead of running the `.sh` files blindly.
+`linux.md` carries explicit commands for **apt, dnf, and pacman** only. On anything else (Alpine, openSUSE,
+Void, NixOS) do not guess a package name: translate the *intent* using that distro's own manager, verify the
+binary afterwards, and say in the report which distro the commands were adapted for. NixOS in particular
+rejects imperative installs — declare the packages in the user's configuration instead, and record the finding
+as deferred rather than failed.
 
 ## Partial or interrupted runs
 

--- a/skills/dev-machine-setup/references/linux.md
+++ b/skills/dev-machine-setup/references/linux.md
@@ -1,66 +1,105 @@
 # Linux setup
 
-inbash Unix scripts target **Debian/Ubuntu** (`apt`). On Fedora/RHEL/Arch, use the same *intent* with the native package manager — do not run the `.sh` files blindly.
+Self-contained: every command below is a native package-manager command or copies a file this skill ships in
+`assets/`. There is no external scripts repo to clone.
 
-Clone when apt-based:
-
-```bash
-git clone https://github.com/luongnv89/inbash.git ~/.inbash 2>/dev/null || git -C ~/.inbash pull --ff-only
-```
-
-Every inbash command below then runs from any directory via its `~/.inbash/` path.
+Tables cover **Debian/Ubuntu (apt), Fedora (dnf), Arch (pacman)**. On any other distro, use the same *intent*
+with that distro's manager and say so in the report rather than guessing a package name.
 
 ## Package manager
 
 | Distro | Install |
 |--------|---------|
-| Debian/Ubuntu | `sudo apt-get update && sudo apt-get install -y git curl wget vim build-essential` or `~/.inbash/unix/basic.sh --yes` |
+| Debian/Ubuntu | `sudo apt-get update && sudo apt-get install -y git curl wget vim build-essential` |
 | Fedora | `sudo dnf install -y git curl wget vim gcc gcc-c++ make` |
 | Arch | `sudo pacman -Syu --needed git curl wget vim base-devel` |
 
 ## Node.js LTS
 
-**Debian/Ubuntu (inbash):**
+**Debian/Ubuntu** — NodeSource LTS (**mutating**: pipes a remote script to bash; confirm the URL first):
 
 ```bash
-~/.inbash/unix/nodejs.sh --yes
+curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+sudo apt-get install -y nodejs
 ```
-
-Uses NodeSource `setup_lts.x`. Review the downloaded setup script if the user is cautious.
 
 **Fedora:** `sudo dnf module install -y nodejs:lts` or NodeSource's rpm script (same review rule).
 
-**Arch:** `sudo pacman -S nodejs npm`.
+**Arch:** `sudo pacman -S --needed nodejs npm`.
 
 Prefer one Node. If `nvm`/`fnm` already exists, use it instead of adding a second copy.
 
 ## Python
 
-**Debian/Ubuntu (inbash):**
+| Distro | Install |
+|--------|---------|
+| Debian/Ubuntu | `sudo apt-get install -y python3 python3-pip python3-venv` |
+| Fedora | `sudo dnf install -y python3 python3-pip` |
+| Arch | `sudo pacman -S --needed python python-pip` |
+
+Then **uv** (do not `pip install` into the system interpreter — PEP 668). Arch and Fedora package it:
 
 ```bash
-~/.inbash/unix/python3-pip.sh --yes
+sudo pacman -S --needed uv      # Arch
+sudo dnf install -y uv          # Fedora
 ```
 
-Then **uv** (do not `pip install` into the system interpreter — PEP 668):
+Elsewhere, the installer (**mutating** — `curl | sh`; confirm the URL first):
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-Confirm the URL first. Verify: `python3 --version`, `uv --version`.
-
-**Fedora:** `sudo dnf install -y python3 python3-pip` then uv.
-**Arch:** `sudo pacman -S python python-pip` then uv.
+Verify: `python3 --version`, `uv --version`.
 
 ## Zsh + Oh My Zsh
 
+| Distro | Install |
+|--------|---------|
+| Debian/Ubuntu | `sudo apt-get install -y zsh` |
+| Fedora | `sudo dnf install -y zsh` |
+| Arch | `sudo pacman -S --needed zsh` |
+
+Oh My Zsh framework (**additive** — the installer creates `~/.zshrc` only when absent):
+
 ```bash
-~/.inbash/install-zsh.sh --yes --set-default
-~/.inbash/setup-ohMyZsh.sh --yes
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 ```
 
-`install-zsh.sh` already switches on apt/dnf/yum/pacman/apk/zypper. Works on WSL.
+Plugins — the three the shipped config expects, cloned into `$ZSH_CUSTOM`:
+
+```bash
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" pull --ff-only
+git clone https://github.com/zsh-users/zsh-autosuggestions.git "$ZSH_CUSTOM/plugins/zsh-autosuggestions" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-autosuggestions" pull --ff-only
+git clone https://github.com/zsh-users/zsh-completions.git "$ZSH_CUSTOM/plugins/zsh-completions" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-completions" pull --ff-only
+```
+
+Then deploy `assets/zshrc-config`, which pins `ZSH_THEME="wedisagree"`, the four-plugin list, and a
+`command -v starship`-guarded prompt init. **Tag depends on the machine:** additive when `~/.zshrc` is absent,
+**mutating** (backup + its own yes) when one already exists. See `optimize.md#oh-my-zsh-missing`.
+
+Making zsh the login shell is `optimize.md#login-shell-not-zsh` (`chsh`). Works on WSL.
+
+### Starship prompt
+
+Because that init line is guarded, a missing binary produces no prompt at all rather than an error:
+
+| Distro | Install |
+|--------|---------|
+| Debian/Ubuntu | `sudo apt-get install -y starship` (older releases lack it — fall back to the installer below) |
+| Fedora | `sudo dnf install -y starship` |
+| Arch | `sudo pacman -S --needed starship` |
+
+Fallback where no distro package exists (**mutating** — `curl | sh`; confirm the URL first):
+
+```bash
+curl -sS https://starship.rs/install.sh | sh
+```
+
+Then deploy the config (`optimize.md#starship-config-missing`). Arch spins such as Omarchy ship their **own** `~/.config/starship.toml` — that fires `starship-config-not-managed`, which is mutating and needs a per-item yes plus a backup.
+
+Verify: `starship --version`, then `head -n1 ~/.config/starship.toml`.
 
 ## Arch notes
 
@@ -72,7 +111,8 @@ Confirm the URL first. Verify: `python3 --version`, `uv --version`.
 
 ## Optional (only if asked)
 
-inbash: `unix/docker.sh`, `unix/c_cpp.sh`, `unix/setup-ssh.sh`, `unix/install-mongodb.sh`.
+Docker, C/C++ toolchains, SSH keys, MongoDB — install from the distro's own packages; this skill does not
+bundle recipes for them.
 
 ## Agent CLIs
 

--- a/skills/dev-machine-setup/references/macos.md
+++ b/skills/dev-machine-setup/references/macos.md
@@ -1,12 +1,7 @@
 # macOS setup
 
-Prefer [inbash](https://github.com/luongnv89/inbash) mac scripts. Clone once:
-
-```bash
-git clone https://github.com/luongnv89/inbash.git ~/.inbash 2>/dev/null || git -C ~/.inbash pull --ff-only
-```
-
-Every inbash command below then runs from any directory via its `~/.inbash/` path.
+Self-contained: every command below is a plain Homebrew/system command or copies a file this skill ships in
+`assets/`. There is no external scripts repo to clone.
 
 ## Homebrew
 
@@ -33,44 +28,75 @@ brew install git curl wget
 
 ## Node.js LTS
 
-inbash:
-
 ```bash
-~/.inbash/mac/nodejs.sh --yes --formula node
+brew install node
 ```
 
 Or pin LTS:
 
 ```bash
-~/.inbash/mac/nodejs.sh --yes --formula node@22 --force-link
+brew install node@22
+brew link --overwrite --force node@22
 ```
+
+`brew link --overwrite` is **mutating** — it replaces whatever `node` currently resolves to. Needs its own yes.
 
 Verify: `node -v`, `npm -v`. Optionally `corepack enable`.
 
 ## Python + uv
 
-inbash (Homebrew `python@3.12`, pip, **uv**):
-
 ```bash
-~/.inbash/mac/python-pip-uv.sh --yes --python-formula python@3.12
+brew install python@3.12 uv
 ```
 
 Verify: `python3 -V`, `uv --version`. Use `uv venv` for projects; do not `sudo pip3 install`.
 
 ## Zsh + Oh My Zsh
 
+macOS ships zsh already; install only if `zsh` is genuinely missing:
+
 ```bash
-~/.inbash/install-zsh.sh --yes --set-default
-~/.inbash/setup-ohMyZsh.sh --yes
+brew install zsh
 ```
 
-`setup-ohMyZsh.sh` installs `zsh-syntax-highlighting`, `zsh-autosuggestions`, `zsh-completions` and deploys inbash `zshrc-config`. If the user already has a custom `~/.zshrc`, skip the config copy and only add plugins.
+Oh My Zsh framework (**additive** — the installer creates `~/.zshrc` only when absent):
+
+```bash
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+```
+
+Plugins — the three the shipped config expects, cloned into `$ZSH_CUSTOM`:
+
+```bash
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" pull --ff-only
+git clone https://github.com/zsh-users/zsh-autosuggestions.git "$ZSH_CUSTOM/plugins/zsh-autosuggestions" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-autosuggestions" pull --ff-only
+git clone https://github.com/zsh-users/zsh-completions.git "$ZSH_CUSTOM/plugins/zsh-completions" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-completions" pull --ff-only
+```
+
+Then deploy `assets/zshrc-config` — it pins `ZSH_THEME="wedisagree"`, the four-plugin list, and the starship
+init. **Tag depends on the machine:** additive when `~/.zshrc` is absent, **mutating** (backup + its own yes)
+when one already exists. See `optimize.md#oh-my-zsh-missing`.
 
 `chsh` may require a password; setup is still a success if zsh + omz exist.
 
+### Starship prompt
+
+`assets/zshrc-config` runs `eval "$(starship init zsh)"` **only** `if command -v starship` — so without the binary the prompt silently degrades to the bare Oh My Zsh theme. Install it:
+
+```bash
+brew install starship
+```
+
+Then deploy the config the init line reads (`optimize.md#starship-config-missing`, or
+`#starship-config-not-managed` when a `~/.config/starship.toml` already exists — that one is mutating and
+needs its own yes).
+
+Verify: `starship --version`, then `head -n1 ~/.config/starship.toml`.
+
 ## Optional (only if asked)
 
-- Docker Desktop: `~/.inbash/mac/docker.sh --yes`
+- Docker Desktop: `brew install --cask docker`
 - Xcode CLT: `xcode-select --install` if compile tools are missing
 
 ## Agent CLIs

--- a/skills/dev-machine-setup/references/optimize.md
+++ b/skills/dev-machine-setup/references/optimize.md
@@ -4,7 +4,7 @@ Fix catalog for the `findings[]` array emitted by `scripts/detect_env.py`. Each 
 `fix_ref` pointing at the matching heading below.
 
 Every fix is tagged **additive** (adds something absent — batch-approvable) or **mutating** (changes an
-install or config that already works — needs a per-item yes, per SKILL.md § Human-in-the-loop).
+install or config that already works — needs a per-item yes, per `approvals.md` § Human-in-the-loop).
 
 **Before any in-place rc-file edit**, back the file up and show the user the path:
 
@@ -14,7 +14,7 @@ cp ~/.zshrc ~/.zshrc.bak.$(date +%Y%m%d%H%M%S)   # or ~/.zprofile, ~/.bashrc
 
 Windows equivalent: `Copy-Item $PROFILE "$PROFILE.bak"`.
 
-Every command here reaches the user as a **run-block** — SKILL.md § Presenting commands. Inspect blocks stay
+Every command here reaches the user as a **run-block** — `approvals.md` § Presenting commands. Inspect blocks stay
 separate from fix blocks, nothing assumes a working directory, and any value that has to come from the user
 is collected *before* the block is shown, never left as a `<placeholder>`.
 
@@ -235,28 +235,110 @@ echo "$SHELL"
 
 ## oh-my-zsh-missing
 
-**additive.** Downloads and runs a remote installer, and creates `~/.zshrc` — say both before asking.
+Downloads and runs a remote installer, then deploys the shell config this skill ships in
+`assets/zshrc-config` — say both before asking.
 
-inbash (preferred for this user; clones to a fixed path so the block works from any directory):
+**The tag depends on the machine, and this is the one place to get it right:**
+
+| State of `~/.zshrc` | Tag | Why |
+|---------------------|-----|-----|
+| absent | **additive** | nothing working can be lost; batch-approvable |
+| exists | **mutating** | the config copy replaces a file the user may have tuned by hand — own yes + backup |
+
+A blanket "do everything" approval covers only the additive case. Check first, in its own inspect block:
 
 ```bash
-git clone https://github.com/luongnv89/inbash.git ~/.inbash 2>/dev/null || git -C ~/.inbash pull --ff-only
-~/.inbash/setup-ohMyZsh.sh --yes
+ls -l ~/.zshrc 2>/dev/null || echo "no ~/.zshrc — additive"
 ```
 
-Upstream installer, if inbash is unavailable:
+**1 · framework** (additive — creates `~/.zshrc` only if absent):
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 ```
 
-If the user already has a hand-written `~/.zshrc`, install the framework and plugins but skip the config
-copy — and back the file up first either way.
+**2 · plugins** (additive — clones into `$ZSH_CUSTOM/plugins`, re-runnable):
+
+```bash
+ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
+git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" pull --ff-only
+git clone https://github.com/zsh-users/zsh-autosuggestions.git "$ZSH_CUSTOM/plugins/zsh-autosuggestions" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-autosuggestions" pull --ff-only
+git clone https://github.com/zsh-users/zsh-completions.git "$ZSH_CUSTOM/plugins/zsh-completions" 2>/dev/null || git -C "$ZSH_CUSTOM/plugins/zsh-completions" pull --ff-only
+```
+
+**3 · shell config** — resolve `<skill-dir>` to the skill's own absolute path before showing the block. When
+`~/.zshrc` already exists this is **mutating**: back it up, name the backup path out loud, and get its own yes.
+
+```bash
+cp ~/.zshrc ~/.zshrc.bak.$(date +%Y%m%d%H%M%S) 2>/dev/null || true
+cp <skill-dir>/assets/zshrc-config ~/.zshrc
+```
+
+Declining step 3 is a normal outcome — a hand-written `.zshrc` the user likes beats a uniform one. Install the
+framework and plugins, record the decline, and move on.
+
+Verify the framework *and* that the config actually took — `ls -d ~/.oh-my-zsh` alone passes on a machine
+whose theme and plugins never loaded:
+
+```bash
+ls -d ~/.oh-my-zsh
+grep -nE 'ZSH_THEME|^plugins=' ~/.zshrc
+ls ~/.oh-my-zsh/custom/plugins
+zsh -i -c 'echo "theme=$ZSH_THEME"'
+```
+
+Expect `ZSH_THEME="wedisagree"` and the four plugins `git zsh-syntax-highlighting zsh-autosuggestions
+zsh-completions`. `assets/zshrc-config` is the source of truth for those values, so a mismatch means step 3
+was skipped or declined — not that anything needs editing here.
+
+## starship-config-missing
+
+**additive.** No `~/.config/starship.toml` exists, so starship renders its stock prompt.
+`assets/zshrc-config` already carries the `command -v starship` guard and the `eval "$(starship init zsh)"`
+line — this fix supplies only the config that line reads.
+
+Deploy the skill's config (resolve `<skill-dir>` to the skill's own absolute path before showing the block —
+`approvals.md` § Presenting commands):
+
+```bash
+mkdir -p ~/.config
+cp <skill-dir>/assets/starship.toml ~/.config/starship.toml
+```
+
+Verify — the marker line is what `detect_env.py` reads, so check it, not just the file:
+
+```bash
+head -n1 ~/.config/starship.toml
+starship --version
+```
+
+## starship-config-not-managed
+
+**mutating.** A `starship.toml` is already there and working — a distro default (Omarchy, Manjaro), a
+Homebrew example, or the user's own. Overwriting it changes a prompt they may have tuned deliberately.
+
+Show them what they have before asking:
+
+```bash
+head -n 20 ~/.config/starship.toml
+wc -l ~/.config/starship.toml
+```
+
+If they want the skill's config, **back the existing one up first** and say the backup path out loud:
+
+```bash
+cp ~/.config/starship.toml ~/.config/starship.toml.bak.$(date +%Y%m%d%H%M%S)
+cp <skill-dir>/assets/starship.toml ~/.config/starship.toml
+```
+
+Declining is a normal outcome — a working prompt the user likes beats a uniform one. Record the decline and
+move on; do not re-offer it on the next phase.
 
 Verify:
 
 ```bash
-ls -d ~/.oh-my-zsh
+head -n1 ~/.config/starship.toml
+ls ~/.config/starship.toml.bak.*
 ```
 
 ## no-sudo

--- a/skills/dev-machine-setup/references/procedure.md
+++ b/skills/dev-machine-setup/references/procedure.md
@@ -1,0 +1,137 @@
+# Phase procedure — full detail
+
+Loaded by SKILL.md § Procedure, which carries the phase list and each phase's done-condition. This file
+carries what each phase actually does. Every phase runs the five-step loop in `references/approvals.md`.
+
+## 0. Resume check
+
+- Read `~/.dev-machine-setup/session.json`. **Absent, or `status: complete`** → say nothing, start at phase 1.
+- **Present and unfinished** → show one screen (mode, phases done, items done / approved-but-not-run /
+  declined, next step) and offer **resume** (default) · **start fresh** · **discard**.
+- On resume, **always re-run `detect_env.py` first and reconcile** — the machine moved on while you were away,
+  possibly because the user pasted the remaining blocks themselves. Rules in `references/session.md`.
+- Stale — `machine` mismatches this host, or the file is over 30 days old — say so and default to start fresh.
+- **Discard** deletes the file immediately; a discarded session left on disk is what makes a later resume
+  replay decisions the user threw away. **Start fresh** keeps it until phase 1 overwrites it.
+
+**Phase 0 done when:** the run is resuming from a reconciled session file, or starting clean with any
+discarded session deleted.
+
+## 1. Detect and build the gap report
+
+- **Present:** say what it does — read-only, no network, no changes; reports OS, arch, package managers,
+  installed versions, what's missing, what's misconfigured. Read-only, so no approval needed.
+- **Execute:** `python3 <skill-dir>/scripts/detect_env.py`, pathed from the skill's own directory, never the
+  user's cwd. Needs Python 3.9+; without `python3`, use the fallbacks in `references/detect.md`.
+- **Verify:** the JSON parses and contains `os`, `arch`, `tools`, `missing`, `findings`.
+
+Then **show the gap report** as three short lists before doing anything else:
+
+```
+Present:  git 2.55 · node v26.7 · python 3.14 · uv 0.11 · zsh · claude · codex
+Missing:  baseline → uv          agents → pi, opencode
+Findings: 1 high · 0 medium · 2 low   (npm-global-bin-not-on-path, path-duplicates, oh-my-zsh-missing)
+```
+
+Read **only** the matching OS reference (`windows.md` / `macos.md` / `linux.md`), and confirm the mode if the
+request was ambiguous.
+
+**Phase 1 done when:** the gap report JSON is captured, the three lists are shown, the mode is fixed, the
+matching OS reference is loaded, and the session file exists with phase 1 recorded `done`.
+
+## 2. Debloat — fresh Windows only, opt-in
+
+Skip entirely unless the machine is Windows **and** the user asked to clean OEM junk — never on a daily
+driver, container, or remote host. Factory Windows boxes ship trial AV, OEM utilities, and partner games
+(inspired by [XFreeze](https://x.com/xfreeze/status/2090189407659999603)). **List before delete.**
+
+- **Present** the read-only inventory commands (`winget list`, `Get-AppxPackage`) as a run-block.
+- **Execute** `references/windows.md` § Inventory; build a `keep / review / remove-candidate` table.
+- Then **per removal** (mutating): one run-block per package naming what is lost, an explicit yes for that
+  one package, then execute, verify it no longer lists, and record it.
+
+**Phase 2 done when:** skipped with a reason logged, or the inventory is shown and every removal is
+individually confirmed and verified.
+
+## 3. Baseline gaps  *(skipped in `tune`)*
+
+**Blocking findings first.** Four findings make installs fail or land invisibly, so they are fixed *here*
+rather than in phase 5: `no-package-manager`, `no-sudo`, `brew-bin-not-on-path`, `npm-global-bin-not-on-path`.
+Fix per `references/optimize.md`, then continue. (A missing package manager arrives as a finding, not as a
+`missing.baseline` entry.)
+
+Then act only on `missing.baseline`. **Empty list → print `✓ baseline complete — nothing to install` and skip
+to phase 4.** Never reinstall or upgrade something already present — an upgrade is mutating, and belongs to
+phase 5.
+
+| Missing item | Install command lives in |
+|--------------|--------------------------|
+| `git` (+ curl, wget, editor) | the OS reference § Baseline |
+| `zsh` / Oh My Zsh | `macos.md` / `linux.md` § Zsh (Unix only; Windows keeps PowerShell) |
+| `starship` | `macos.md` / `linux.md` § Zsh → Starship prompt (Unix only) |
+| `node`, `npm` | the OS reference § Node.js LTS |
+| `python3`, `uv` | the OS reference § Python |
+
+- **Present:** one run-block per missing item, tagged additive. Flag anything that would touch an existing
+  Node or Python — that is mutating and needs its own yes.
+- **Verify:** `git --version`, `node -v`, `npm -v`, `python3 --version`, `uv --version` (Unix also
+  `zsh --version` and `starship --version`) succeed for the items just installed.
+
+**The skill is self-contained — no external scripts repo is cloned.** `ZSH_THEME="wedisagree"`, the
+four-plugin list, and the `starship init zsh` line all live in `assets/zshrc-config`, which this skill ships
+and deploys by `cp`. Never hand-write those lines into `~/.zshrc` instead — edit the asset, so there stays one
+source of truth. `assets/zshrc-config` is a vendored **fork** of `luongnv89/inbash`'s config: upstream fixes do
+not flow in, which is the price of having no dependency.
+
+**Deploying it is not always additive.** `cp assets/zshrc-config ~/.zshrc` overwrites an existing `~/.zshrc`,
+so it is additive only when no `~/.zshrc` is present and **mutating** — backup plus its own yes — when one is.
+A blanket "do everything" approval never covers the mutating case. Full split in
+`optimize.md#oh-my-zsh-missing`.
+
+**Phase 3 done when:** every item that was in `missing.baseline` verifies green, or is logged as deferred.
+
+## 4. Agent CLI gaps  *(skipped in `tune`)*
+
+Acts only on `missing.agents`, in this order: Claude Code → Codex → Pi → OpenCode. **Empty list → print
+`✓ all agent CLIs present` and skip.** Ask which the user actually wants; do not assume all four.
+
+- **Present:** one run-block per CLI from `references/agent-clis.md`, with any `curl | sh` URL visible inside
+  the block (mutating — needs its own yes).
+- **Execute:** install only the requested missing ones. Requires Node on PATH from phase 3.
+- **Verify:** each prints a version (`claude --version`, `codex --version`, `pi --version`,
+  `opencode --version`). If a just-installed CLI is "not found", that is
+  `optimize.md#npm-global-bin-not-on-path` — carry it into phase 5 rather than reinstalling.
+
+Auth is the first interactive run of each CLI. Never write API keys into the log or into `~/.zshrc`.
+
+**Phase 4 done when:** every requested agent CLI verifies green, or is explicitly declined.
+
+## 5. Optimize
+
+Acts on `findings[]`, highest severity first. Each finding's `fix_ref` names its section in
+`references/optimize.md`; read only the sections for findings that actually fired.
+
+- **Present** one table — finding id · severity · what breaks today · **additive/mutating** — then one
+  run-block per finding beneath it (`approvals.md` § Presenting commands). No command goes in the table.
+- **Approve:** ask as a numbered list. Additive fixes can be batched. **Every mutating fix needs its own
+  yes** — and back up any rc file before editing it. Record each decision as it is made, not at the end.
+- **Execute** approved fixes only. A declined finding is recorded, not retried.
+- **Verify** by re-running `detect_env.py` and confirming the fixed ids are gone from `findings`. That re-run
+  is the phase's proof — never verify from memory. **PATH and rc-file fixes keep reporting until a new shell
+  reads them:** re-run in a fresh login shell (`zsh -l -c '<skill-dir>/scripts/detect_env.py'`, or a new
+  PowerShell window); with no fresh shell available, confirm the rc file contains the line and log the finding
+  as *fixed — needs new shell*.
+
+Deep checks (`brew outdated`, `winget upgrade`, `npm outdated -g`) need network and are opt-in — `optimize.md`
+§ Deep checks. Never volunteer disk cleanup during a setup run.
+
+**Phase 5 done when:** the verification re-run shows every approved fix gone from `findings` — or logged as
+*fixed — needs new shell* — and each remaining finding is recorded as declined or deferred with its severity.
+
+## 6. Final report
+
+Nothing executes. Assemble the report from the session file (`references/report-template.md`), then set its
+`status` to `complete` so the next run starts clean instead of offering a resume.
+
+**Phase 6 done when:** the report is printed with a `Result` line, every gap and finding is accounted for as
+fixed, declined, or deferred, and the session file is marked `complete`.

--- a/skills/dev-machine-setup/references/windows.md
+++ b/skills/dev-machine-setup/references/windows.md
@@ -27,7 +27,6 @@ winget uninstall --id <Id> --silent
 Get-AppxPackage <Name> | Remove-AppxPackage
 ```
 
-Optional: inbash `windows/system_check.ps1` for a hardware snapshot (`-AsJson`).
 
 ## Package manager
 
@@ -61,7 +60,7 @@ Confirm the URL with the user before running. Alternative: `winget install astra
 
 ## Shell
 
-Keep PowerShell 7 if available (`winget install Microsoft.PowerShell`). Oh My Zsh is a Unix skill — if the user wants the full inbash zsh setup, install **WSL2 Ubuntu** and re-run this skill *inside* WSL (then follow `linux.md`).
+Keep PowerShell 7 if available (`winget install Microsoft.PowerShell`). Oh My Zsh is a Unix skill — if the user wants the full zsh setup, install **WSL2 Ubuntu** and re-run this skill *inside* WSL (then follow `linux.md`).
 
 ```powershell
 wsl --install -d Ubuntu

--- a/skills/dev-machine-setup/scripts/detect_env.py
+++ b/skills/dev-machine-setup/scripts/detect_env.py
@@ -30,7 +30,7 @@ import sys
 NODE_MIN_MAJOR = 20  # oldest Node LTS still receiving security fixes
 PYTHON_MIN_MINOR = 10  # oldest CPython 3.x still receiving security fixes
 
-BASELINE_UNIX = ("git", "node", "npm", "python3", "uv", "zsh")
+BASELINE_UNIX = ("git", "node", "npm", "python3", "uv", "zsh", "starship")
 BASELINE_WINDOWS = ("git", "node", "npm", "python3", "uv")
 AGENTS = ("claude", "codex", "pi", "opencode")
 
@@ -174,11 +174,32 @@ def node_managers() -> list[str]:
     return found
 
 
+STARSHIP_CONFIG = (".config", "starship.toml")
+# First line of assets/starship.toml. Presence of this marker is how phase 5
+# tells "our config is deployed" from "some other starship.toml is here" —
+# without it the fix would be unverifiable and the finding would report forever.
+STARSHIP_MARKER = "# dev-machine-setup:starship-config"
+
+
+def starship_config_state() -> str:
+    """One of: 'managed' (ours), 'foreign' (someone else's), 'absent'."""
+    path = _home(*STARSHIP_CONFIG)
+    if not os.path.isfile(path):
+        return "absent"
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            head = fh.readline()
+    except OSError:
+        return "foreign"
+    return "managed" if head.startswith(STARSHIP_MARKER) else "foreign"
+
+
 def shell_info(os_name: str) -> dict[str, object]:
     login = os.environ.get("SHELL") if os_name != "windows" else os.environ.get("ComSpec")
     return {
         "login_shell": login,
         "oh_my_zsh": os.path.isdir(_home(".oh-my-zsh")),
+        "starship_config": starship_config_state(),
     }
 
 
@@ -276,6 +297,18 @@ def findings(os_name: str, arch: str, tools: dict[str, str | None], mgrs: list[s
         if not os.path.isdir(_home(".oh-my-zsh")):
             out.append(find("oh-my-zsh-missing", "low", "shell",
                             "zsh is installed without Oh My Zsh; no plugin/completion baseline."))
+        # The shipped assets/zshrc-config guards its prompt on `command -v starship`, so a
+        # missing binary or a foreign config degrades silently to no prompt at all.
+        if tools.get("starship"):
+            state = starship_config_state()
+            if state == "absent":
+                out.append(find("starship-config-missing", "low", "shell",
+                                "starship is installed but ~/.config/starship.toml is absent; "
+                                "the prompt falls back to starship defaults."))
+            elif state == "foreign":
+                out.append(find("starship-config-not-managed", "low", "shell",
+                                "~/.config/starship.toml exists but is not the dev-machine-setup config "
+                                "(distro or hand-rolled default)."))
 
     if os_name != "windows" and getattr(os, "geteuid", lambda: 0)() != 0 and not shutil.which("sudo"):
         out.append(find("no-sudo", "medium", "packaging",
@@ -318,6 +351,7 @@ def main() -> int:
         "pip": tool_version(["pip3", "pip"], ["--version"]),
         "uv": tool_version(["uv"], ["--version"]),
         "zsh": tool_version(["zsh"], ["--version"]),
+        "starship": tool_version(["starship"], ["--version"]),
         "claude": tool_version(["claude"], ["--version"]),
         "codex": tool_version(["codex"], ["--version"]),
         "pi": tool_version(["pi"], ["--version"]),


### PR DESCRIPTION
Closes #104
## What

Brings `dev-machine-setup` to parity with the reference machine's zsh setup, removes its dependency on the `luongnv89/inbash` repo, and restructures SKILL.md for progressive disclosure. `0.6.0 → 0.9.0`.

## Why

Setting up a second machine (Arch/omarchy) surfaced two gaps the skill couldn't see, and both needed hand-fixing:

1. `starship` wasn't in the baseline, so a machine without the binary never reported a gap — and the config's `command -v starship` guard then silently produced **no prompt at all** rather than an error.
2. Nothing deployed `~/.config/starship.toml`. The target already had the distro's default sitting there, which had to be backed up before overwriting.

## Changes

### Zsh parity
- `detect_env.py` reports `starship` as a baseline tool and emits two Unix-only findings: `starship-config-missing` (additive) and `starship-config-not-managed` (mutating).
- Detection reads a **first-line marker** in `~/.config/starship.toml`, not mere file existence. Phase 5 verifies by re-running the probe and confirming ids disappear — a finding whose fix the probe can't observe would report forever.
- `assets/starship.toml` ships the config; run-blocks `cp` from the skill dir instead of inlining (the skill's own rules ban `<placeholder>` blocks).

### Self-contained
- `assets/zshrc-config` vendors inbash's config as an **explicit fork** — upstream fixes no longer flow in, noted in-file and in SKILL.md.
- The `.sh` wrappers are replaced by the plain `brew`/`apt`/`dnf`/`pacman` commands and `$ZSH_CUSTOM` `git clone`s they wrapped (plugin repo list read from `setup-ohMyZsh.sh`, not guessed). Optional recipes — docker, c_cpp, mongodb, `system_check.ps1` — are dropped rather than reimplemented.

### ⚠️ The safety change worth reviewing
`oh-my-zsh-missing` was tagged flatly **additive**, correct only because the upstream OMZ installer refuses to clobber an existing `~/.zshrc`. `cp assets/zshrc-config ~/.zshrc` has no such scruple. It's now split — additive when absent, **mutating** (backup + its own yes) when present — with an inspect block to decide which, and the framework/plugins/config broken into three separately-approvable steps so declining the overwrite still gets you the plugins. Without the split, the blanket-approval path would silently overwrite a working config.

### Structure
- SKILL.md split into `references/approvals.md` + `references/procedure.md`; **354 → 176 lines**.
- Repaired 5 cross-references left dangling by the move (`SKILL.md § Presenting commands` → `approvals.md`).
- `edge-cases.md`'s inbash section rewritten, not deleted — the premise died, but the distro-coverage limit still applies to the new apt/dnf/pacman tables.

## Verification

| Check | Before | After |
|-------|--------|-------|
| `quick_validate.py` | pass | pass |
| `asm eval` overall | 90 (A) | **94 (A)** |
| min category | **6** | **8** |
| SKILL.md lines | 354 | 176 |

`detect_env.py` emits valid JSON; `zsh -n assets/zshrc-config` clean; assets scanned for secrets. `grep -rn inbash` returns only two deliberate fork-provenance notes.

## Notes for review

- `prompt-engineering` dipped 9 → 8: the worked run-block example moved to `approvals.md`, and the evaluator wants an `## Example` in SKILL.md. Re-inlining it re-fails `context-efficiency` — left at 8, which clears the floor.
- Two advisory predictability findings left open (non-blocking): done-conditions restated in both the spine table and `procedure.md`, and `optimize.md` growth at ~330 lines.