### PR TITLE
fix(logo-designer): quote metadata.author, bump to 1.2.4 (#144)

### DIFF
--- a/skills/logo-designer/SKILL.md
+++ b/skills/logo-designer/SKILL.md
@@ -4,8 +4,8 @@ description: "Generate professional SVG logos from project context: 7 brand vari
 license: MIT
 effort: medium
 metadata:
-  version: 1.2.3
-  author: Luong NGUYEN <luongnv89@gmail.com>
+  version: 1.2.4
+  author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # Logo Designer


### PR DESCRIPTION
Closes #144

Ran `/skill-auto-improver skills/logo-designer` in **Mode 1 (retrofit)**. Outcome: **PASS** in 1 iteration of 8.

## Decision Record

- The baseline nearly early-exited: `quick_validate.py` exited 0 and `asm eval` already scored **99 (A)** with min category 9. The one real Gate 1 failure was **Frontmatter Audit check #10** — `metadata.author` holds `Luong NGUYEN <luongnv89@gmail.com>`, which contains `<`, `>` and `@`, and was unquoted. PyYAML parsing it and `quick_validate` passing do not clear #10; it has no mechanical validator. This matches the precedent fixes on `doc-manager` (#135), `test-coverage` (#157) and `frontend-design` (#138).
- **Rejected:** chasing `Prompt engineering` 9 → 10 via the "imperative voice" suggestion. Phase 3 stops at every category `>= 8`; editing a passing category risks the 99 for no gate benefit.
- **Rejected:** collapsing the repeated wordmark-casing rule. It is a Phase 2b advisory finding, and the no-bloat rule forbids wholesale prose rewrites inside the loop.
- `asm eval --fix --dry-run` reported "No fixes needed", so Phase 1 wrote nothing and no `SKILL.md.bak` exists.

## Gate status

| Gate | Baseline | Final |
|---|---|---|
| `quick_validate.py` | exit 0 | exit 0 |
| Frontmatter Audit | **FAIL (#10)** | **PASS** |
| Body size | 200 lines / 1431 words (caps 500 / 3000) | unchanged |
| Negative-trigger clause | present | present |
| `docs/README.md` AI-skip notice | present | present |
| Dependency preflight | n/a — invokes no other skill | n/a |
| `asm eval` overall | 99 (A) | 99 (A) |
| min category | 9 | 9 |

Categories (unchanged): Structure 10 · Description 10 · Prompt engineering 9 · Context efficiency 10 · Safety 10 · Testability 10 · Naming 10.

## Predictability findings (Phase 2b — advisory, non-blocking)

5 pass, 2 open and deliberately not acted on:

- **#4 delegability** — the three agent spawns (`brand-researcher`, `svg-generator`, `svg-reviewer`) name no slice of `references/` for their workers; `svg-generator` in particular needs `svg-deliverables.md` + `design-principles.md`. Routes to **Mode 2 (delegation conversion)**, which is out of scope here and needs explicit opt-in.
- **#6 duplication** — the wordmark-casing rule is restated in Phase 2, Edge Cases, and Notes.

## Acceptance Criteria Verification

- [x] Runs to completion in retrofit mode, reports PASS not BLOCKER
- [x] Gate 1 clears — validator exit 0, Frontmatter Audit passes, 200 lines < 500, 1431 words < 3000, negative-trigger clause present, no preflight needed (invokes no skill)
- [x] Gate 2 clears — `overallScore` 99 > 85, every category >= 8
- [x] `metadata.version` bumped 1.2.3 → 1.2.4 (patch — frontmatter-only). Second clause is vacuous: nothing was cut from the body, so nothing needed relocating to `references/`
- [x] Phase 2b findings reported above and treated as advisory

## Test Results

No test suite in this repo. Verification is the two gates above, both re-run after the edit.