### PR TITLE
Fix OpenCode skills for the devbox image

### DIFF
--- a/skills/opencode-handoff/SKILL.md
+++ b/skills/opencode-handoff/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires Docker on PATH and running, plus the opencode-sandbox skill at v2.1.0 or newer. The tmux panel additionally needs `tmux`; without it the skill prints the attach command instead."
 effort: medium
 metadata:
-  version: 1.0.1
+  version: 1.0.3
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -103,7 +103,8 @@ older sandbox would silently mount the host credentials, which is the one
 failure this skill must never ship.
 
 Options: `--name` / `--session` to override generated names, `--image` to pass a
-different image through, `--no-ssh` / `--no-github` to isolate the container from
+different image through (default: `ghcr.io/luongnv89/devbox:latest`),
+`--no-ssh` / `--no-github` to isolate the container from
 GitHub, `--no-tmux` to skip the panel and just print the attach command, and
 `--sandbox-script` to point at `run_opencode.sh` explicitly.
 
@@ -131,8 +132,9 @@ login lines. The user must run these — OpenCode is unauthenticated by design:
 ```bash
 tmux attach-session -t <SESSION_NAME>
 # then, inside the panel:
-opencode auth login
-opencode
+opencode2 auth login
+opencode2
+# (older images may use `opencode` instead)
 ```
 
 Never run `tmux attach-session` yourself from a non-TTY tool
@@ -160,9 +162,9 @@ bash ~/.claude/skills/opencode-handoff/scripts/handoff.sh \
 Expected output: the sandbox reports `opencode-config=0 agents=1`, then
 `Credential boundary: OK`, `Global agent setup: 74 skills`, then
 `SESSION_NAME=opencode-handoff-my-app-1788169556` with its
-`tmux attach-session` line. The user attaches, runs `opencode auth login` with a
+`tmux attach-session` line. The user attaches, runs `opencode2 auth login` with a
 different account, and continues on the same tree with the same skills — on a
-fresh allowance. The host session stays untouched and still rate-limited.
+fresh allowance (`opencode` is used on older images). The host session stays untouched and still rate-limited.
 
 ## Acceptance Criteria
 
@@ -174,7 +176,7 @@ fresh allowance. The host session stays untouched and still rate-limited.
       credential directories are not bind-mounted
 - [ ] A **detached** tmux session was created and its `attach-session` line was
       shown to the user; the skill never attached to it itself
-- [ ] The `opencode auth login` step was surfaced, not assumed
+- [ ] The `opencode2 auth login` step was surfaced, not assumed
 - [ ] The container was **not** removed unless the user confirmed
 
 **Edge cases this skill accounts for:** an `opencode-sandbox` older than v2.1.0
@@ -195,7 +197,7 @@ sessions writing one working tree (decide ownership before starting).
   Agent setup:           √ <N> global skills, project .agents present
   Credential boundary:   √ no opencode config/token/key | × LEAK <path>
   Panel:                 √ tmux <session> (detached) | — n/a (no tmux)
-  Login surfaced:        √ opencode auth login shown to user
+  Login surfaced:        √ opencode2 auth login shown to user
   Container:             √ kept (<name>) | √ removed (user confirmed)
   ____________________________
   Result:               PASS | FAIL

--- a/skills/opencode-handoff/SKILL.md
+++ b/skills/opencode-handoff/SKILL.md
@@ -5,20 +5,21 @@ license: MIT
 compatibility: "Requires Docker on PATH and running, plus the opencode-sandbox skill at v2.1.0 or newer. The tmux panel additionally needs `tmux`; without it the skill prints the attach command instead."
 effort: medium
 metadata:
-  version: 1.0.3
+  version: 1.0.4
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # OpenCode Handoff
 
-You hit the OpenCode usage limit mid-task. This skill gets you working again in
-a few minutes: it builds a sandbox container for the **same project** with the
-**same agent setup**, deliberately leaves the host's OpenCode config, token, and
-key behind, and opens it in a **new tmux panel**.
+You hit the OpenCode usage limit mid-task. This skill gives you a new local
+OpenCode profile for the **same project** with the **same agent setup**,
+deliberately leaves the host's OpenCode config, token, and key behind, and
+opens it in a **new tmux panel**.
 
-The credential exclusion is the point, not a side effect. OpenCode inside the
-container starts unauthenticated, so logging in there gives you a fresh usage
-allowance instead of the exhausted one.
+The credential exclusion is the point, not a side effect. Anonymous/free models
+may work without an account, and authentication is optional when the selected
+provider requires it. A fresh local profile does not guarantee a fresh provider,
+model, account, network, or service allowance.
 
 This skill **composes** two others rather than reimplementing them:
 
@@ -126,14 +127,16 @@ recreate rather than proceeding.
 
 ### Step 4 — Hand the panel to the user
 
-Surface the printed session and attach command as a fenced block, plus the two
-login lines. The user must run these — OpenCode is unauthenticated by design:
+Surface the printed session and attach command as a fenced block. OpenCode
+starts with a fresh local profile; start it directly for anonymous/free models,
+and log in only if the selected provider requires authentication:
 
 ```bash
 tmux attach-session -t <SESSION_NAME>
 # then, inside the panel:
-opencode2 auth login
 opencode2
+# If authentication is required:
+opencode2 auth login
 # (older images may use `opencode` instead)
 ```
 
@@ -162,9 +165,10 @@ bash ~/.claude/skills/opencode-handoff/scripts/handoff.sh \
 Expected output: the sandbox reports `opencode-config=0 agents=1`, then
 `Credential boundary: OK`, `Global agent setup: 74 skills`, then
 `SESSION_NAME=opencode-handoff-my-app-1788169556` with its
-`tmux attach-session` line. The user attaches, runs `opencode2 auth login` with a
-different account, and continues on the same tree with the same skills — on a
-fresh allowance (`opencode` is used on older images). The host session stays untouched and still rate-limited.
+`tmux attach-session` line. The user attaches and starts `opencode2` with a
+fresh local profile, optionally logging in when the selected provider requires
+it (`opencode` is used on older images). The host session stays untouched; a
+provider-side rate limit may still apply.
 
 ## Acceptance Criteria
 
@@ -176,7 +180,7 @@ fresh allowance (`opencode` is used on older images). The host session stays unt
       credential directories are not bind-mounted
 - [ ] A **detached** tmux session was created and its `attach-session` line was
       shown to the user; the skill never attached to it itself
-- [ ] The `opencode2 auth login` step was surfaced, not assumed
+- [ ] Optional `opencode2 auth login` instructions were surfaced, not assumed
 - [ ] The container was **not** removed unless the user confirmed
 
 **Edge cases this skill accounts for:** an `opencode-sandbox` older than v2.1.0
@@ -197,7 +201,7 @@ sessions writing one working tree (decide ownership before starting).
   Agent setup:           √ <N> global skills, project .agents present
   Credential boundary:   √ no opencode config/token/key | × LEAK <path>
   Panel:                 √ tmux <session> (detached) | — n/a (no tmux)
-  Login surfaced:        √ opencode2 auth login shown to user
+  Login surfaced:        √ optional opencode2 auth login shown to user
   Container:             √ kept (<name>) | √ removed (user confirmed)
   ____________________________
   Result:               PASS | FAIL

--- a/skills/opencode-handoff/docs/README.md
+++ b/skills/opencode-handoff/docs/README.md
@@ -33,8 +33,9 @@ Then:
 ```bash
 tmux attach-session -t <session>
 # inside the panel
-opencode auth login
-opencode
+opencode2 auth login
+opencode2
+# (older images may use `opencode` instead)
 ```
 
 ## Trigger phrases
@@ -47,7 +48,7 @@ opencode
 ## Requirements
 
 - Docker on PATH and running
-- `opencode-sandbox` v2.1.0 or newer (this skill composes its container logic)
+- `opencode-sandbox` v2.1.0 or newer (this skill composes its container logic); the default image is `ghcr.io/luongnv89/devbox:latest`
 - `tmux` for the panel — optional; without it you get the `docker exec` line
 
 ## Options
@@ -56,7 +57,7 @@ opencode
 |---|---|
 | `--project DIR` | project to hand off (required) |
 | `--name` / `--session` | override the generated container / tmux names |
-| `--image IMAGE` | use a different container image |
+| `--image IMAGE` | use a different container image (default: `ghcr.io/luongnv89/devbox:latest`) |
 | `--no-ssh` / `--no-github` | isolate the container from GitHub |
 | `--no-tmux` | skip the panel, just print the attach command |
 | `--sandbox-script PATH` | point at `run_opencode.sh` explicitly |

--- a/skills/opencode-handoff/docs/README.md
+++ b/skills/opencode-handoff/docs/README.md
@@ -2,8 +2,9 @@
 
 # OpenCode Handoff
 
-Hit the OpenCode usage limit mid-task? This skill gets you back to work in a
-few minutes, on the same project, with the same skills — on a fresh allowance.
+Hit the OpenCode usage limit mid-task? This skill gives you a fresh local
+OpenCode profile in a few minutes, on the same project, with the same skills.
+Provider-side limits may still apply.
 
 ## What it does
 
@@ -14,7 +15,8 @@ few minutes, on the same project, with the same skills — on a fresh allowance.
 3. Opens a detached tmux session attached to the container and hands you the
    `attach-session` line
 
-You log in inside the panel with a different account and carry on.
+Start OpenCode inside the panel without an account when anonymous/free models
+are available. Log in only if the selected provider requires authentication.
 
 ## Usage
 
@@ -33,8 +35,9 @@ Then:
 ```bash
 tmux attach-session -t <session>
 # inside the panel
-opencode2 auth login
 opencode2
+# If authentication is required:
+opencode2 auth login
 # (older images may use `opencode` instead)
 ```
 
@@ -42,7 +45,7 @@ opencode2
 
 - "I hit the OpenCode limit, get me a fresh session"
 - "hand this project off to a new OpenCode sandbox"
-- "continue this work with a fresh OpenCode usage limit"
+- "continue this work with a fresh OpenCode profile"
 - "same setup, new OpenCode account"
 
 ## Requirements
@@ -64,7 +67,7 @@ opencode2
 
 ## What is not shared
 
-Your OpenCode credentials. `~/.config/opencode/service.json` (a password) and
+Your OpenCode profile and credentials. `~/.config/opencode/service.json` (a password) and
 `~/.local/share/opencode/auth.json` (your key) never enter the container — the
 skill verifies this at runtime and refuses to hand over if either appears.
 SSH and GitHub auth *are* shared by default, so you can still commit and push.

--- a/skills/opencode-handoff/references/credential-boundary.md
+++ b/skills/opencode-handoff/references/credential-boundary.md
@@ -8,16 +8,17 @@ real container; change one only with the same evidence.
 | File | Key it holds | Default sandbox behavior |
 |---|---|---|
 | `~/.local/share/opencode/auth.json` | `opencode.type`, `opencode.key` | never mounted (outside `~/.config`) |
-| `~/.config/opencode/service.json` | `password` | **mounted** by the default `~/.config/opencode` mount |
+| `~/.config/opencode/service.json` | `password` | not mounted by handoff (sandbox mounts it only with `--with-opencode-config`) |
 
-`opencode-sandbox`'s default run mounts all of `~/.config/opencode`, which
-carries `service.json` along with it. That is correct for its own use case —
-running a task on the host's account — and wrong for this one. `handoff.sh`
-therefore passes `--no-opencode-config`.
+`opencode-sandbox` does not mount `~/.config/opencode` by default. It can mount
+that host profile only when `--with-opencode-config` is requested, which is
+wrong for this handoff. `handoff.sh` explicitly passes `--no-opencode-config`.
 
-Mounting neither is what produces the fresh usage allowance: OpenCode in the
-container has no credential, so `opencode2 auth login` inside the panel
-establishes a new one (`opencode` is the fallback on older images).
+The container therefore gets a fresh local OpenCode profile with no host
+credential. Anonymous/free models may work without login; `opencode2 auth login`
+inside the panel is optional when the selected provider requires it (`opencode`
+is the fallback on older images). A fresh local profile does not guarantee a
+fresh provider-side allowance.
 
 ## The wiring problem, and why the subdirectory mount solves it
 

--- a/skills/opencode-handoff/references/credential-boundary.md
+++ b/skills/opencode-handoff/references/credential-boundary.md
@@ -16,8 +16,8 @@ running a task on the host's account — and wrong for this one. `handoff.sh`
 therefore passes `--no-opencode-config`.
 
 Mounting neither is what produces the fresh usage allowance: OpenCode in the
-container has no credential, so `opencode auth login` inside the panel
-establishes a new one.
+container has no credential, so `opencode2 auth login` inside the panel
+establishes a new one (`opencode` is the fallback on older images).
 
 ## The wiring problem, and why the subdirectory mount solves it
 

--- a/skills/opencode-handoff/scripts/handoff.sh
+++ b/skills/opencode-handoff/scripts/handoff.sh
@@ -4,8 +4,8 @@
 # Creates an opencode-sandbox container for a project with the host's agent
 # setup mounted but WITHOUT the host's OpenCode config, token, or key, then
 # opens a detached tmux session attached to it. OpenCode inside the container
-# is unauthenticated on purpose — that is what gives it a fresh usage
-# allowance. Log in inside the panel.
+# gets a fresh local profile; anonymous/free models may work without login.
+# Authenticate inside the panel only when the selected provider requires it.
 #
 # Usage:
 #   handoff.sh --project DIR [options]
@@ -110,7 +110,7 @@ Error: '$SANDBOX_SCRIPT' does not support $required_flag.
   To fix:  update opencode-sandbox to v2.1.0 or newer.
 
 Without it the container would inherit the host's OpenCode config and token,
-defeating the purpose of the handoff (a fresh usage allowance).
+defeating the purpose of the handoff (a fresh local profile).
 EOF
     exit 1
   fi
@@ -284,10 +284,13 @@ Open the panel:
 
   tmux attach-session -t ${SESSION_NAME}
 
-Then, inside it (OpenCode starts unauthenticated — this is the fresh allowance):
+Then, inside it (OpenCode starts with a fresh local profile; anonymous/free
+models may work without login):
 
-  ${OPENCODE_CLI} auth login
   ${OPENCODE_CLI}
+
+If the selected provider requires authentication:
+  ${OPENCODE_CLI} auth login
 
 Container kept: ${CONTAINER_NAME}. Remove it only when you confirm:
   docker rm -f ${CONTAINER_NAME}

--- a/skills/opencode-handoff/scripts/handoff.sh
+++ b/skills/opencode-handoff/scripts/handoff.sh
@@ -16,7 +16,8 @@
 # Optional:
 #   --name NAME          container name (default: opencode-handoff-<project>-<epoch>)
 #   --session NAME       tmux session name (default: derived from the container)
-#   --image IMAGE        docker image (passed through to run_opencode.sh)
+#   --image IMAGE        docker image (default: ghcr.io/luongnv89/devbox:latest;
+#                        passed through to run_opencode.sh)
 #   --no-ssh             do not mount ~/.ssh
 #   --no-github          do not mount ~/.config/gh or inject GH_TOKEN
 #   --no-tmux            create the container and print the attach command, but
@@ -35,7 +36,7 @@ usage() { grep '^#' "${BASH_SOURCE[0]}" | sed -e '1d' -e 's/^# \{0,1\}//'; }
 PROJECT_DIR=""
 CONTAINER_NAME=""
 SESSION_NAME=""
-IMAGE=""
+IMAGE="ghcr.io/luongnv89/devbox:latest"
 SANDBOX_SCRIPT=""
 WITH_SSH=1
 WITH_GITHUB=1
@@ -232,6 +233,19 @@ if docker exec "$CONTAINER_NAME" test -d /workspace/.agents 2>/dev/null; then
   echo "Project-local agent setup: /workspace/.agents (same relative path as on the host)." >&2
 fi
 
+OPENCODE_CLI="$(docker exec "$CONTAINER_NAME" sh -c '
+  if command -v opencode2 >/dev/null 2>&1; then
+    command -v opencode2
+  elif command -v opencode >/dev/null 2>&1; then
+    command -v opencode
+  fi
+' 2>/dev/null || true)"
+if [ -z "$OPENCODE_CLI" ]; then
+  echo "Error: neither 'opencode2' nor 'opencode' is available in container '$CONTAINER_NAME'. Use an image with the OpenCode CLI installed." >&2
+  echo "Remove the container with: docker rm -f '$CONTAINER_NAME'" >&2
+  exit 1
+fi
+
 ATTACH_CMD="docker exec -it ${CONTAINER_NAME} zsh"
 
 if [ "$WITH_TMUX" != "1" ]; then
@@ -272,8 +286,8 @@ Open the panel:
 
 Then, inside it (OpenCode starts unauthenticated — this is the fresh allowance):
 
-  opencode auth login
-  opencode
+  ${OPENCODE_CLI} auth login
+  ${OPENCODE_CLI}
 
 Container kept: ${CONTAINER_NAME}. Remove it only when you confirm:
   docker rm -f ${CONTAINER_NAME}

--- a/skills/opencode-sandbox/SKILL.md
+++ b/skills/opencode-sandbox/SKILL.md
@@ -5,17 +5,20 @@ license: MIT
 compatibility: "Requires Docker (Desktop or Engine) on PATH and running. Interactive mode additionally needs `cdev` (auto-installable from luongnv89/docker-dev) plus a pane-management skill (herdr-agent-comms or tmux-agent-comms)."
 effort: medium
 metadata:
-  version: 2.1.3
+  version: 3.0.0
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
 # OpenCode Sandbox
 
 Run OpenCode inside a [luongnv89/docker-dev](https://github.com/luongnv89/docker-dev)
-container for a local project. **SSH and GitHub auth are on by default**
-(`~/.ssh`, `~/.config/gh`, `GH_TOKEN` from `gh auth token`) so `git commit`,
-`git push`, `gh pr create`, and `gh pr merge` work in the container. Pass
-`--no-ssh --no-github` when the task must not reach GitHub. Details:
+container for a local project. **A fresh local OpenCode profile is used by
+default**: the host's `~/.config/opencode` is not mounted. Pass
+`--with-opencode-config` only when the task must reuse the host profile or
+credentials. SSH and GitHub auth remain on by default (`~/.ssh`,
+`~/.config/gh`, `GH_TOKEN` from `gh auth token`) so `git commit`, `git push`,
+`gh pr create`, and `gh pr merge` work in the container. Pass `--no-ssh
+--no-github` when the task must not reach GitHub. Details:
 `references/mounts-and-credentials.md`.
 
 **Keep-by-default:** the container stays running after the task so the user
@@ -27,7 +30,7 @@ can attach a shell. Do not remove it unless they confirm (or they asked for
 - Run OpenCode against a project and let it commit, push, open, or merge a PR
   (`gh` / SSH available inside the container)
 - OpenCode keeps hitting provider rate limits and the task needs a fresh
-  container session
+  local profile (a new container with the default mounts, or `--fresh-profile`)
 - The task must **not** touch GitHub — pass `--no-ssh --no-github` and review
   the host diff; push stays a separate step
 
@@ -74,19 +77,23 @@ any `docker rm` (Step 4).
 ### Step 1 — Decide mounts
 
 Every run mounts the project directory (`/workspace`). **On by default:**
-`~/.config/opencode` (OpenCode's own auth — skip with `--no-opencode-config`),
-`~/.ssh`, GitHub auth (`~/.config/gh` + `GH_TOKEN`), and `~/.gitconfig`. Opt
-out when the user asks to isolate, or the task must not reach GitHub:
+`~/.ssh`, GitHub auth (`~/.config/gh` + `GH_TOKEN`), and `~/.gitconfig`. The
+host's `~/.config/opencode` is not mounted unless `--with-opencode-config` is
+passed. Opt out when the user asks to isolate, or the task must not reach
+GitHub:
 
 - `--no-ssh` — do not mount `~/.ssh`
 - `--no-github` — do not mount `~/.config/gh` or inject `GH_TOKEN`
 - `--no-git-identity` — do not mount `~/.gitconfig`
-- `--no-opencode-config` — do not mount `~/.config/opencode`. OpenCode then
-  starts unauthenticated (`opencode-handoff` builds on this). Combined with
-  `--with-agents`, the script also mounts `~/.config/opencode/skills`
-  read-only so its relative skill symlinks still resolve — and nothing else
-  from that directory, including `service.json`. See
-  `references/mounts-and-credentials.md`.
+- `--with-opencode-config` — mount the host's `~/.config/opencode` profile and
+  credentials. This is opt-in; the default is a fresh local profile.
+- `--fresh-profile` — explicitly select a fresh local OpenCode profile (alias
+  for `--no-opencode-config`). A new profile does not reset provider, model,
+  network, or service rate limits. Anonymous/free models may work without
+  login; authenticate only when needed. Combined with `--with-agents`, the
+  script also mounts `~/.config/opencode/skills` read-only so its relative
+  skill symlinks still resolve — and nothing else from that directory,
+  including `service.json`. See `references/mounts-and-credentials.md`.
 
 Add flags only for extras the task needs:
 
@@ -108,8 +115,10 @@ file *readable*, not *followed*. When using `--with-claude-skills`, the
 /root/.claude/skills/<name>/SKILL.md and follow it as your playbook for this
 task."`
 
-Additional options accepted by `run_opencode.sh`: `--image IMAGE` to override
-the default container image (`ghcr.io/luongnv89/devbox:latest`);
+Additional options accepted by `run_opencode.sh`: `--with-opencode-config` to
+opt in to mounting the host OpenCode profile; `--fresh-profile` or
+`--no-opencode-config` to explicitly select a fresh local profile; `--image IMAGE`
+to override the default container image (`ghcr.io/luongnv89/devbox:latest`);
 `--format FORMAT` to set `opencode2 run`'s output format (`default` or `json`;
 default: `default`); `--name NAME` to set the container name (default:
 `opencode-sandbox-<project>-<epoch>`); `--start-only` to create the container and
@@ -265,6 +274,8 @@ unfinished (see `references/troubleshooting.md`), not as a pass.
       the host before anything is committed or pushed
 - [ ] SSH (`~/.ssh`) and GitHub auth (`GH_TOKEN` / `~/.config/gh`) were
       mounted unless the user asked to isolate (`--no-ssh --no-github`)
+- [ ] Host OpenCode config was not mounted unless `--with-opencode-config` was
+      explicitly requested
 - [ ] Dependency-file diffs (`package.json`, lockfiles) were checked for
       container-only binaries before treating the run as safe to merge
 
@@ -283,7 +294,8 @@ the message or exits OpenCode entirely (see `references/interactive-mode.md`).
   Docker daemon:         √ pass (docker info)
   Image ready:           √ pass (ghcr.io/luongnv89/devbox:latest)
   OpenCode CLI:          √ opencode2 (fallback: opencode)
-  Mounts:                √ workspace, opencode config, ssh, gh, gitconfig [+ claude skills]
+  Profile:               √ fresh by default | √ host profile when requested
+  Mounts:                √ workspace, host opencode config when requested, ssh, gh, gitconfig [+ claude skills]
   Credentials:           √ ssh+gh on | √ --no-ssh --no-github (isolated)
   Attach command:        √ docker exec -it <name> zsh shown
   Task exit code:        √ 0 | × <N> — <error from output>

--- a/skills/opencode-sandbox/SKILL.md
+++ b/skills/opencode-sandbox/SKILL.md
@@ -5,7 +5,7 @@ license: MIT
 compatibility: "Requires Docker (Desktop or Engine) on PATH and running. Interactive mode additionally needs `cdev` (auto-installable from luongnv89/docker-dev) plus a pane-management skill (herdr-agent-comms or tmux-agent-comms)."
 effort: medium
 metadata:
-  version: 2.1.1
+  version: 2.1.3
   author: "Luong NGUYEN <luongnv89@gmail.com>"
 ---
 
@@ -62,8 +62,8 @@ mid-run.
 ## One-shot mode
 
 `scripts/run_opencode.sh` starts a named container (`sleep infinity` as PID 1
-so it stays running), prints an attach command, then runs `opencode run --auto`
-via `docker exec`. One exit code from OpenCode, output on stdout — no polling,
+so it stays running), prints an attach command, then runs `opencode2 run --auto`
+via `docker exec` (`opencode` is used as a fallback for older images). One exit code from OpenCode, output on stdout — no polling,
 no TUI, no permission dialogs to click through (`--auto` handles them; see
 `references/mounts-and-credentials.md` → _Why `--auto` is required_).
 
@@ -109,8 +109,8 @@ file *readable*, not *followed*. When using `--with-claude-skills`, the
 task."`
 
 Additional options accepted by `run_opencode.sh`: `--image IMAGE` to override
-the default container image (`ghcr.io/luongnv89/u2604dev:latest`);
-`--format FORMAT` to set `opencode run`'s output format (`default` or `json`;
+the default container image (`ghcr.io/luongnv89/devbox:latest`);
+`--format FORMAT` to set `opencode2 run`'s output format (`default` or `json`;
 default: `default`); `--name NAME` to set the container name (default:
 `opencode-sandbox-<project>-<epoch>`); `--start-only` to create the container and
 print the attach command without running OpenCode; `--exec-in NAME` to run
@@ -281,7 +281,8 @@ the message or exits OpenCode entirely (see `references/interactive-mode.md`).
 ◆ OpenCode Sandbox (one-shot run)
 ··································································
   Docker daemon:         √ pass (docker info)
-  Image ready:           √ pass (ghcr.io/luongnv89/u2604dev:latest)
+  Image ready:           √ pass (ghcr.io/luongnv89/devbox:latest)
+  OpenCode CLI:          √ opencode2 (fallback: opencode)
   Mounts:                √ workspace, opencode config, ssh, gh, gitconfig [+ claude skills]
   Credentials:           √ ssh+gh on | √ --no-ssh --no-github (isolated)
   Attach command:        √ docker exec -it <name> zsh shown

--- a/skills/opencode-sandbox/docs/README.md
+++ b/skills/opencode-sandbox/docs/README.md
@@ -7,7 +7,7 @@
 
 # OpenCode Sandbox
 
-> Run OpenCode inside a luongnv89/docker-dev container. SSH and GitHub auth are on by default so commit/push/PR work; pass `--no-ssh --no-github` to isolate. The container is kept by default so you can attach a shell.
+> Run OpenCode inside a luongnv89/docker-dev container. A fresh local OpenCode profile is used by default; pass `--with-opencode-config` to reuse the host profile. SSH and GitHub auth are on by default so commit/push/PR work; pass `--no-ssh --no-github` to isolate. The container is kept by default so you can attach a shell.
 
 ## Highlights
 
@@ -29,7 +29,7 @@
 
 ```mermaid
 graph TD
-    A["Decide mode: one-shot or interactive"] --> B["Decide mounts: workspace + opencode + ssh/gh (or --no-ssh --no-github)"]
+    A["Decide mode: one-shot or interactive"] --> B["Decide mounts: workspace + fresh OpenCode profile + ssh/gh (or --no-ssh --no-github)"]
     B --> C["preflight.sh: Docker running, image pulled"]
     C --> D["--start-only: kept container + attach command"]
     D --> E["--exec-in: opencode2 run --auto"]
@@ -40,7 +40,7 @@ graph TD
 
 ## Usage
 
-Model-invoked — ask to run OpenCode in a container (with git/gh by default), isolate it with `--no-ssh --no-github`, or dodge rate limits in a fresh container.
+Model-invoked — ask to run OpenCode in a container (with a fresh local profile and git/gh by default), pass `--with-opencode-config` to reuse the host profile, or isolate GitHub with `--no-ssh --no-github`.
 
 ## Resources
 
@@ -48,7 +48,7 @@ Model-invoked — ask to run OpenCode in a container (with git/gh by default), i
 | -------------------------------------------- | ----------------------------------------------------------------------------- |
 | `scripts/preflight.sh`                       | Ensures Docker is running and the image is pulled                            |
 | `scripts/run_opencode.sh`                    | `--start-only` then `--exec-in`: kept container, attach command, `opencode2 run --auto` (fallback: `opencode`) |
-| `references/mounts-and-credentials.md`       | Default SSH/GitHub mounts, `--no-ssh`/`--no-github` opt-out, `~/.claude` symlink gotcha |
+| `references/mounts-and-credentials.md`       | Fresh OpenCode profile by default, opt-in host config, SSH/GitHub mounts, `~/.claude` symlink gotcha |
 | `references/interactive-mode.md`             | TUI readiness timing, permission dialogs, completion detection               |
 | `references/troubleshooting.md`              | Provider errors, rate limits, outdated `cdev`, dependency-file leakage       |
 

--- a/skills/opencode-sandbox/docs/README.md
+++ b/skills/opencode-sandbox/docs/README.md
@@ -11,7 +11,7 @@
 
 ## Highlights
 
-- One-shot mode uses **`--start-only` then `--exec-in`**: a named keep-alive container, a copy-paste `docker exec -it <name> zsh` attach command *before* OpenCode runs, then `opencode run --auto` via `docker exec` — a plain exit code, no TUI to drive or permission dialogs to click through
+- One-shot mode uses **`--start-only` then `--exec-in`**: a named keep-alive container, a copy-paste `docker exec -it <name> zsh` attach command *before* OpenCode runs, then `opencode2 run --auto` via `docker exec` (falling back to `opencode` for older images) — a plain exit code, no TUI to drive or permission dialogs to click through
 - Container is **kept by default**; the agent asks before `docker rm`. Pass `--rm` only when you already want it gone
 - SSH (`~/.ssh`) and GitHub (`gh` config + token) are **on by default** so the container can commit, push, and open/merge PRs. Pass `--no-ssh --no-github` to isolate an untrusted task
 - Handles the `~/.claude` → `~/.agents` symlink gotcha automatically when mounting Claude Code skills into the container
@@ -32,7 +32,7 @@ graph TD
     A["Decide mode: one-shot or interactive"] --> B["Decide mounts: workspace + opencode + ssh/gh (or --no-ssh --no-github)"]
     B --> C["preflight.sh: Docker running, image pulled"]
     C --> D["--start-only: kept container + attach command"]
-    D --> E["--exec-in: opencode run --auto"]
+    D --> E["--exec-in: opencode2 run --auto"]
     E --> F["Review git diff on host, then ask before docker rm"]
     style A fill:#4CAF50,color:#fff
     style F fill:#2196F3,color:#fff
@@ -47,7 +47,7 @@ Model-invoked — ask to run OpenCode in a container (with git/gh by default), i
 | Path                                        | Description                                                                 |
 | -------------------------------------------- | ----------------------------------------------------------------------------- |
 | `scripts/preflight.sh`                       | Ensures Docker is running and the image is pulled                            |
-| `scripts/run_opencode.sh`                    | `--start-only` then `--exec-in`: kept container, attach command, `opencode run --auto` |
+| `scripts/run_opencode.sh`                    | `--start-only` then `--exec-in`: kept container, attach command, `opencode2 run --auto` (fallback: `opencode`) |
 | `references/mounts-and-credentials.md`       | Default SSH/GitHub mounts, `--no-ssh`/`--no-github` opt-out, `~/.claude` symlink gotcha |
 | `references/interactive-mode.md`             | TUI readiness timing, permission dialogs, completion detection               |
 | `references/troubleshooting.md`              | Provider errors, rate limits, outdated `cdev`, dependency-file leakage       |
@@ -59,5 +59,5 @@ copy-paste `docker exec -it <name> zsh` attach command, a prompt asking
 whether to remove the kept container, plus a Step Completion Report showing
 mounts used, exit code, attach shown, container kept/removed, and whether
 the host diff was reviewed before anything ships. One-shot mode's raw
-output is whatever `opencode run` printed (or JSON events, with
+output is whatever `opencode2 run` (or the older `opencode run`) printed (or JSON events, with
 `--format json`).

--- a/skills/opencode-sandbox/evals/evals.json
+++ b/skills/opencode-sandbox/evals/evals.json
@@ -8,7 +8,7 @@
       "expected_output": "The skill runs one-shot mode with --no-ssh --no-github (user asked not to touch GitHub credentials), checks Docker, starts a kept container, shows docker exec attach, runs the summary task, and reports the result plus a Step Completion Report.",
       "files": [],
       "expectations": [
-        "The run started the container with --start-only (or equivalent docker run -d ... sleep infinity), showed docker exec -it <name> zsh to the user, then ran OpenCode with --exec-in (or docker exec ... opencode run --auto) rather than driving an interactive TUI",
+        "The run started the container with --start-only (or equivalent docker run -d ... sleep infinity), showed docker exec -it <name> zsh to the user, then ran OpenCode with --exec-in (or docker exec ... opencode2 run --auto, falling back to opencode for older images) rather than driving an interactive TUI",
         "The invocation includes --no-ssh and --no-github (or equivalent: no ~/.ssh mount and no GH_TOKEN) because the user asked not to touch GitHub credentials",
         "The report/output states the exit code from the container run",
         "A Step Completion Report is printed with the documented rows (Docker daemon, Image ready, Mounts, Credentials, Attach command, Task exit code, Container)"

--- a/skills/opencode-sandbox/evals/evals.json
+++ b/skills/opencode-sandbox/evals/evals.json
@@ -74,6 +74,18 @@
         "The docker run that creates the container does not include --rm (unless the user asked for auto-remove)",
         "After the task, the assistant asks the user whether to remove the container rather than removing it unprompted"
       ]
+    },
+    {
+      "id": 7,
+      "kind": "happy-path",
+      "prompt": "Start OpenCode in the sandbox without using my host OpenCode account or configuration; anonymous/free model use is preferred.",
+      "expected_output": "The skill leaves ~/.config/opencode unmounted by default, creates a fresh local OpenCode profile in the new container, and does not require login before trying anonymous/free models. It does not promise that a fresh profile bypasses provider-side rate limits.",
+      "files": [],
+      "expectations": [
+        "The docker run does not mount ~/.config/opencode unless --with-opencode-config was explicitly requested",
+        "The output reports a fresh local profile or opencode-config=0",
+        "The assistant explains that provider-, model-, account-, network-, or service-side limits can still apply"
+      ]
     }
   ]
 }

--- a/skills/opencode-sandbox/references/interactive-mode.md
+++ b/skills/opencode-sandbox/references/interactive-mode.md
@@ -1,7 +1,7 @@
 # Interactive mode
 
 Use this when the user wants to **watch OpenCode work live** or **steer it
-mid-task** — things one-shot mode (`opencode run --auto`) can't do, since it's
+mid-task** — things one-shot mode (`opencode2 run --auto`) can't do, since it's
 a single fire-and-forget process with no way to send a follow-up.
 
 Interactive mode drives OpenCode's full-screen TUI, which needs a real
@@ -47,7 +47,7 @@ docker run -d --name <container-name> --label opencode-sandbox=1 \
   -v "$HOME/.gitconfig:/root/.gitconfig:ro" \
   [-v "$HOME/.claude:/root/.claude:ro" -v "$HOME/.agents:/root/.agents:ro"] \
   -w /workspace \
-  ghcr.io/luongnv89/u2604dev:latest sleep infinity
+  ghcr.io/luongnv89/devbox:latest sleep infinity
 ```
 
 As soon as that returns, surface this copy-paste block to the user (do not
@@ -58,7 +58,8 @@ docker exec -it <container-name> zsh
 ```
 
 Drive the pane with a second `docker exec -it <container-name> zsh` (or
-`opencode` inside that shell). The keep-alive `sleep infinity` is PID 1, so
+`opencode2` inside that shell; older images may use `opencode`). The keep-alive
+`sleep infinity` is PID 1, so
 closing OpenCode does not tear the container down.
 
 **This is the default mount list** — project, opencode config, `~/.ssh`,
@@ -83,7 +84,8 @@ Before the first send, read the pane and confirm **both** are visible:
   OpenCode Zen`)
 
 If only a partial render shows (e.g. just the ASCII logo), wait and re-read —
-don't send yet. After launching `opencode`, a `sleep 6`–`8` before the first
+don't send yet. After launching `opencode2` (or `opencode` on an older image),
+a `sleep 6`–`8` before the first
 read-and-check is a reasonable starting point; always verify by reading the
 pane rather than trusting a fixed sleep alone.
 

--- a/skills/opencode-sandbox/references/interactive-mode.md
+++ b/skills/opencode-sandbox/references/interactive-mode.md
@@ -40,7 +40,6 @@ performs):
 # Unique name, e.g. opencode-sandbox-<project>-$(date +%s)
 docker run -d --name <container-name> --label opencode-sandbox=1 \
   -v "$PROJECT_DIR:/workspace" \
-  -v "$HOME/.config/opencode:/root/.config/opencode" \
   -v "$HOME/.ssh:/root/.ssh" \
   -v "$HOME/.config/gh:/root/.config/gh" \
   -e GH_TOKEN="$(gh auth token)" -e GITHUB_TOKEN="$(gh auth token)" \
@@ -49,6 +48,9 @@ docker run -d --name <container-name> --label opencode-sandbox=1 \
   -w /workspace \
   ghcr.io/luongnv89/devbox:latest sleep infinity
 ```
+
+For a host-configured profile, add `-v "$HOME/.config/opencode:/root/.config/opencode"`
+only when using `--with-opencode-config`.
 
 As soon as that returns, surface this copy-paste block to the user (do not
 wait until OpenCode finishes):
@@ -62,8 +64,9 @@ Drive the pane with a second `docker exec -it <container-name> zsh` (or
 `sleep infinity` is PID 1, so
 closing OpenCode does not tear the container down.
 
-**This is the default mount list** — project, opencode config, `~/.ssh`,
-GitHub auth, gitconfig, plus optional Claude skills. Prefer
+**This is the default mount list** — project, a fresh local OpenCode profile,
+`~/.ssh`, GitHub auth, gitconfig, plus optional Claude skills. Add the host
+OpenCode config only with `--with-opencode-config`. Prefer
 `scripts/run_opencode.sh --start-only` over hand-rolling this, so token
 injection stays in one place. Pass `--no-ssh --no-github` on that script
 when the task must not reach GitHub. Do not log `gh auth token` output.

--- a/skills/opencode-sandbox/references/mounts-and-credentials.md
+++ b/skills/opencode-sandbox/references/mounts-and-credentials.md
@@ -61,7 +61,8 @@ somewhere else entirely (a plugin directory, a project-local
 
 ## Why `--auto` is required (and what credentials change)
 
-`opencode run` requires `--auto` to run non-interactively — without it,
+`opencode2 run` requires `--auto` to run non-interactively — without it (`opencode`
+is the fallback command on older images),
 OpenCode blocks on a permission dialog with nothing attached to answer it,
 and the container hangs until the process is killed. OpenCode's own `--help`
 labels `--auto` "dangerous": it auto-approves every action the agent wants
@@ -94,7 +95,7 @@ The account key itself lives elsewhere — `~/.local/share/opencode/auth.json`
 Pass `--no-opencode-config` for a container that must **not** inherit the host's
 OpenCode identity, e.g. one meant to run on a separate account with its own
 usage allowance. OpenCode inside then starts unauthenticated and needs its own
-`opencode auth login`.
+`opencode2 auth login` (`opencode auth login` on older images).
 
 Because that also drops the `skills/` wiring, `--no-opencode-config`
 `--with-agents` together re-mount just that subdirectory read-only:

--- a/skills/opencode-sandbox/references/mounts-and-credentials.md
+++ b/skills/opencode-sandbox/references/mounts-and-credentials.md
@@ -5,7 +5,9 @@
 `run_opencode.sh` mounts **`~/.ssh`** and GitHub auth (`~/.config/gh` plus
 `GH_TOKEN`/`GITHUB_TOKEN` from `gh auth token`) **by default**, so `git
 commit`, `git push`, `gh pr create`, and `gh pr merge` work inside the
-container. `~/.gitconfig` is also on by default for commit authorship.
+container. `~/.gitconfig` is also on by default for commit authorship. The
+host OpenCode profile/config is **not** mounted by default; pass
+`--with-opencode-config` only when the task needs it.
 
 That is a real blast radius: an SSH key or `GH_TOKEN` reaches **every repo
 and org that credential is scoped to**, not just the mounted project.
@@ -15,15 +17,15 @@ read-only task, pass **`--no-ssh --no-github`** (and `--no-git-identity` if
 you also do not want commits attributed as you).
 
 Do not print the token. The script logs
-`Credentials: ssh=1 github=1 gitconfig=1 opencode-config=1 agents=0`
-(0 = off).
+`Credentials: ssh=1 github=1 gitconfig=1 opencode-config=0 agents=0`
+(0 = off; `opencode-config=1` only when `--with-opencode-config` is used).
 
 ## Standard mounts
 
 | Mount | Container path | When |
 |---|---|---|
 | project directory | `/workspace` | always — the task's target |
-| `~/.config/opencode` | `/root/.config/opencode` | default on — OpenCode auth/config. Skip with `--no-opencode-config` (OpenCode then starts unauthenticated; see below) |
+| `~/.config/opencode` | `/root/.config/opencode` | opt-in with `--with-opencode-config` — host OpenCode profile/config; omitted by default for a fresh local profile |
 | `~/.ssh` | `/root/.ssh` | default on — `git push` over SSH. Skip with `--no-ssh` |
 | `~/.config/gh` | `/root/.config/gh` | default on — `gh` CLI host login. Skip with `--no-github` |
 | `GH_TOKEN` / `GITHUB_TOKEN` | env | default on — from `gh auth token` on the host. Skip with `--no-github` |
@@ -78,10 +80,12 @@ not touch GitHub, pass `--no-ssh --no-github` so `--auto` cannot push.
 mistake can travel.
 
 
-## Excluding OpenCode's own config (`--no-opencode-config`)
+## Selecting the OpenCode profile
 
-Every default run mounts `~/.config/opencode` so the container inherits the
-host's OpenCode setup. That directory contains more than preferences:
+The default run does **not** mount `~/.config/opencode`, so the container gets
+a fresh local OpenCode profile. Pass `--with-opencode-config` only when the
+container must inherit the host's setup. That directory contains more than
+preferences:
 
 | File | Contents |
 |---|---|
@@ -92,13 +96,18 @@ host's OpenCode setup. That directory contains more than preferences:
 The account key itself lives elsewhere — `~/.local/share/opencode/auth.json`
 (`opencode.key`) — and is never mounted by this script.
 
-Pass `--no-opencode-config` for a container that must **not** inherit the host's
-OpenCode identity, e.g. one meant to run on a separate account with its own
-usage allowance. OpenCode inside then starts unauthenticated and needs its own
-`opencode2 auth login` (`opencode auth login` on older images).
+`--fresh-profile` and `--no-opencode-config` explicitly select the default
+isolated behavior. The script does not mount `~/.local/share/opencode`, so a
+new container also gets fresh local OpenCode state. Anonymous/free models may work without login; authenticate only
+if the selected provider requires it. This isolates local profile state but
+cannot reset provider-, model-, network-, or service-side rate limits.
 
-Because that also drops the `skills/` wiring, `--no-opencode-config`
-`--with-agents` together re-mount just that subdirectory read-only:
+`opencode2 auth login` (`opencode auth login` on older images) is optional and
+only needed for providers that require authentication.
+
+Because that also drops the `skills/` wiring, `--fresh-profile` (or
+`--no-opencode-config`) with `--with-agents` together re-mounts just that
+subdirectory read-only:
 
 ```
 -v ~/.agents:/root/.agents:ro

--- a/skills/opencode-sandbox/references/troubleshooting.md
+++ b/skills/opencode-sandbox/references/troubleshooting.md
@@ -8,15 +8,13 @@ Error: No provider available
 
 Two distinct causes — check in this order:
 
-1. **`~/.config/opencode` wasn't mounted, or has no credentials at all.**
-   Confirm the host has a working OpenCode login: `opencode2 providers list`
-   (or `opencode providers list` on older installs) should show at least one
-   entry. If it shows none, the container can't have credentials either — log
-   in on the host first (`opencode2` → `/connect`), then retry.
-2. **Transient provider-side hiccup.** Observed directly during testing: a
-   run fails with this exact error, and an immediate retry of the identical
-   command succeeds. If `opencode2 providers list` (or the older `opencode providers list`) shows a
-   valid credential, retry once before treating this as a real failure.
+1. **`~/.config/opencode` wasn't mounted, or the selected provider needs auth.**
+   `opencode2 auth list` shows configured integrations (`opencode providers
+   list` on older installs). An empty list can be normal for anonymous/free
+   models; authenticate only if the selected provider requires it.
+2. **Transient provider-side hiccup.** A run can fail with this exact error and
+   an immediate retry may succeed. Retry once before treating it as a real
+   failure.
 
 ## Rate limit stalls (free-tier `OpenCode Zen`)
 
@@ -24,18 +22,17 @@ Two distinct causes — check in this order:
 Error from provider (Console): Provider rate limit exceeded [retrying in 6m 48s attempt #9]
 ```
 
-This is an account-level limit on OpenCode's free `OpenCode Zen` routing, not
-a docker-dev or container problem — it happens identically on the host. In
-testing, a **fresh container session avoided a stall that had already reached
-9 retries with minute-plus backoffs on the host** — but the credential is the
-same mounted `~/.config/opencode`, so this is not a reliable fix, only an
-observed mitigation. If a task stalls here for more than a couple of minutes:
+This is a provider/service limit, not a Docker image or local-profile
+problem. A new container or `--fresh-profile` only resets local OpenCode state;
+it does not reset provider-, model-, account-, network-, or service-side
+quotas. In a recent reproduction, both a host-configured container and a
+completely fresh profile stalled and recorded `provider.rate-limit` HTTP 429.
+If a task stalls here for more than a couple of minutes:
 
-- Retry once in a fresh container (new `docker run`, not a resumed session).
-- If it stalls again immediately, the account is genuinely rate-limited —
-  stop and tell the user rather than looping. Options: wait it out, or use
-  `--model provider/model` with a different configured provider if one is
-  authenticated (`opencode2 providers list`).
+- Stop the run instead of allowing an indefinite retry loop.
+- Wait for the provider window to reset, or use `--model provider/model` with
+  another authenticated/configured provider. Do not automatically rotate free
+  models or claim that a fresh profile bypasses the limit.
 
 ## `cdev run --help` is missing `--mount-opencode` / `--preset`
 

--- a/skills/opencode-sandbox/references/troubleshooting.md
+++ b/skills/opencode-sandbox/references/troubleshooting.md
@@ -9,14 +9,14 @@ Error: No provider available
 Two distinct causes — check in this order:
 
 1. **`~/.config/opencode` wasn't mounted, or has no credentials at all.**
-   Confirm the host has a working OpenCode login: `opencode providers list`
-   should show at least one entry. If it shows none, the container can't
-   have credentials either — log in on the host first (`opencode` →
-   `/connect`), then retry.
+   Confirm the host has a working OpenCode login: `opencode2 providers list`
+   (or `opencode providers list` on older installs) should show at least one
+   entry. If it shows none, the container can't have credentials either — log
+   in on the host first (`opencode2` → `/connect`), then retry.
 2. **Transient provider-side hiccup.** Observed directly during testing: a
    run fails with this exact error, and an immediate retry of the identical
-   command succeeds. If `opencode providers list` shows a valid credential,
-   retry once before treating this as a real failure.
+   command succeeds. If `opencode2 providers list` (or the older `opencode providers list`) shows a
+   valid credential, retry once before treating this as a real failure.
 
 ## Rate limit stalls (free-tier `OpenCode Zen`)
 
@@ -35,7 +35,7 @@ observed mitigation. If a task stalls here for more than a couple of minutes:
 - If it stalls again immediately, the account is genuinely rate-limited —
   stop and tell the user rather than looping. Options: wait it out, or use
   `--model provider/model` with a different configured provider if one is
-  authenticated (`opencode providers list`).
+  authenticated (`opencode2 providers list`).
 
 ## `cdev run --help` is missing `--mount-opencode` / `--preset`
 

--- a/skills/opencode-sandbox/scripts/preflight.sh
+++ b/skills/opencode-sandbox/scripts/preflight.sh
@@ -2,10 +2,10 @@
 # preflight.sh — ensure Docker is running and the docker-dev image is present.
 #
 # Usage: preflight.sh [image]
-#   image   defaults to ghcr.io/luongnv89/u2604dev:latest
+#   image   defaults to ghcr.io/luongnv89/devbox:latest
 set -euo pipefail
 
-IMAGE="${1:-ghcr.io/luongnv89/u2604dev:latest}"
+IMAGE="${1:-ghcr.io/luongnv89/devbox:latest}"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "Error: 'docker' is not on PATH. Install Docker Desktop (https://www.docker.com/products/docker-desktop/) or Docker Engine, then retry." >&2

--- a/skills/opencode-sandbox/scripts/run_opencode.sh
+++ b/skills/opencode-sandbox/scripts/run_opencode.sh
@@ -14,12 +14,13 @@
 #
 # Required:
 #   --project DIR          local directory to mount read-write at /workspace
-#   --message TEXT          prompt text passed to `opencode run`
+#   --message TEXT          prompt text passed to the OpenCode CLI
+#                           (`opencode2` when available, otherwise `opencode`)
 #                           (not required with --start-only)
 #
 # Optional:
 #   --file PATH              host file to copy to /scratch inside the
-#                             container, passed via opencode --file.
+#                             container, passed via the OpenCode CLI --file flag.
 #                             For long/complex tasks: write them to a file, pass --file, and give
 #                             a short --message like "Follow the attached file's instructions exactly."
 #   --with-claude-skills      mount ~/.claude (and ~/.agents, for symlinked skills) read-only
@@ -37,9 +38,9 @@
 #   --no-ssh                  do not mount ~/.ssh (default: mount it so git push works)
 #   --no-github               do not mount ~/.config/gh or inject GH_TOKEN
 #                             (default: both, so gh pr/push/merge work)
-#   --image IMAGE             docker image (default: ghcr.io/luongnv89/u2604dev:latest)
-#   --format FORMAT           opencode output format: default | json (default: default)
-#   --model MODEL             opencode model to use (e.g. opencode/muse-spark-1.2-contributor-free)
+#   --image IMAGE             docker image (default: ghcr.io/luongnv89/devbox:latest)
+#   --format FORMAT           OpenCode output format: default | json (default: default)
+#   --model MODEL             OpenCode model to use (e.g. opencode/muse-spark-1.2-contributor-free)
 #   --name NAME               container name (default: opencode-sandbox-<project>-<epoch>)
 #   --start-only              create the keep-alive container, print the attach
 #                             command, exit 0 (does not run OpenCode)
@@ -58,7 +59,7 @@ usage() {
   grep '^#' "${BASH_SOURCE[0]}" | sed -e '1d' -e 's/^# \{0,1\}//'
 }
 
-IMAGE="ghcr.io/luongnv89/u2604dev:latest"
+IMAGE="ghcr.io/luongnv89/devbox:latest"
 FORMAT="default"
 MODEL=""
 PROJECT_DIR=""
@@ -197,7 +198,19 @@ ensure_running() {
 
 run_opencode_in_container() {
   local oc_ec=0
+  local opencode_bin=""
   local opencode_args=(run "$MESSAGE")
+  opencode_bin="$(docker exec "$CONTAINER_NAME" sh -c '
+    if command -v opencode2 >/dev/null 2>&1; then
+      command -v opencode2
+    elif command -v opencode >/dev/null 2>&1; then
+      command -v opencode
+    fi
+  ' 2>/dev/null || true)"
+  if [ -z "$opencode_bin" ]; then
+    echo "Error: neither 'opencode2' nor 'opencode' is available in container '$CONTAINER_NAME'. Use an image with the OpenCode CLI installed." >&2
+    exit 127
+  fi
   RAN_OPENCODE=1
   if [ -n "$TASK_FILE" ]; then
     local basename
@@ -217,7 +230,7 @@ run_opencode_in_container() {
     opencode_args+=(--model "$MODEL")
   fi
   set +e
-  docker exec -w /workspace "$CONTAINER_NAME" opencode "${opencode_args[@]}"
+  docker exec -w /workspace "$CONTAINER_NAME" "$opencode_bin" "${opencode_args[@]}"
   oc_ec=$?
   set -e
   if [ "$REMOVE_ON_EXIT" != "1" ]; then
@@ -255,7 +268,7 @@ if [ "$WITH_OPENCODE_CONFIG" = "1" ]; then
   if [ -d "$HOME/.config/opencode" ]; then
     MOUNTS+=(-v "$HOME/.config/opencode:/root/.config/opencode")
   else
-    echo "Warning: $HOME/.config/opencode not found — the container will have no OpenCode auth/config and may prompt to log in. Run 'opencode' once on the host first if this task needs a real provider." >&2
+    echo "Warning: $HOME/.config/opencode not found — the container will have no OpenCode auth/config and may prompt to log in. Run 'opencode2' (or 'opencode') once on the host first if this task needs a real provider." >&2
   fi
 else
   echo "OpenCode config: not mounted (--no-opencode-config). OpenCode in this container starts unauthenticated and will need its own login." >&2

--- a/skills/opencode-sandbox/scripts/run_opencode.sh
+++ b/skills/opencode-sandbox/scripts/run_opencode.sh
@@ -26,13 +26,16 @@
 #   --with-claude-skills      mount ~/.claude (and ~/.agents, for symlinked skills) read-only
 #   --with-agents             mount ~/.agents read-only (global agent/skill library)
 #                             WITHOUT ~/.claude. When combined with
-#                             --no-opencode-config, also mounts
+#                             --fresh-profile/--no-opencode-config, also mounts
 #                             ~/.config/opencode/skills read-only so the relative
 #                             skill symlinks still resolve inside the container.
-#   --no-opencode-config      do not mount ~/.config/opencode (default: mount it).
-#                             Use for a container that must NOT inherit the host's
-#                             OpenCode config/credentials — e.g. a fresh usage
-#                             allowance. OpenCode inside will need its own login.
+#   --fresh-profile           do not mount the host's OpenCode config; create a
+#                             fresh local profile (alias: --no-opencode-config)
+#   --with-opencode-config    mount ~/.config/opencode (default: do not mount it)
+#                             to reuse the host's OpenCode profile/credentials
+#   --no-opencode-config      do not mount ~/.config/opencode
+#                             Anonymous/free models may work without login;
+#                             authenticate only if the selected provider requires it.
 #   --with-git-identity       mount ~/.gitconfig read-only (default: on)
 #   --no-git-identity         do not mount ~/.gitconfig
 #   --no-ssh                  do not mount ~/.ssh (default: mount it so git push works)
@@ -67,7 +70,7 @@ MESSAGE=""
 TASK_FILE=""
 WITH_CLAUDE_SKILLS=0
 WITH_AGENTS=0
-WITH_OPENCODE_CONFIG=1
+WITH_OPENCODE_CONFIG=0
 WITH_GIT_IDENTITY=1
 WITH_SSH=1
 WITH_GITHUB=1
@@ -92,7 +95,8 @@ while [ $# -gt 0 ]; do
     --file) TASK_FILE="$2"; shift 2 ;;
     --with-claude-skills) WITH_CLAUDE_SKILLS=1; shift ;;
     --with-agents) WITH_AGENTS=1; shift ;;
-    --no-opencode-config) WITH_OPENCODE_CONFIG=0; shift ;;
+    --fresh-profile|--no-opencode-config) WITH_OPENCODE_CONFIG=0; shift ;;
+    --with-opencode-config) WITH_OPENCODE_CONFIG=1; shift ;;
     --with-git-identity) WITH_GIT_IDENTITY=1; shift ;;
     --no-git-identity) WITH_GIT_IDENTITY=0; shift ;;
     --no-ssh) WITH_SSH=0; shift ;;
@@ -268,10 +272,10 @@ if [ "$WITH_OPENCODE_CONFIG" = "1" ]; then
   if [ -d "$HOME/.config/opencode" ]; then
     MOUNTS+=(-v "$HOME/.config/opencode:/root/.config/opencode")
   else
-    echo "Warning: $HOME/.config/opencode not found — the container will have no OpenCode auth/config and may prompt to log in. Run 'opencode2' (or 'opencode') once on the host first if this task needs a real provider." >&2
+    echo "Warning: $HOME/.config/opencode not found — --with-opencode-config was requested, but the container will have no OpenCode host profile/config. Anonymous/free models may still work without login." >&2
   fi
 else
-  echo "OpenCode config: not mounted (--no-opencode-config). OpenCode in this container starts unauthenticated and will need its own login." >&2
+  echo "OpenCode config: not mounted (default; use --with-opencode-config to reuse the host profile). A new local profile is used; anonymous/free models may work without login. Provider-side limits are unchanged." >&2
 fi
 
 if [ "$WITH_AGENTS" = "1" ]; then


### PR DESCRIPTION
Closes #181

## Summary

- Switch `opencode-sandbox` defaults and examples to `ghcr.io/luongnv89/devbox:latest`.
- Prefer the image's `opencode2` CLI, with fallback support for older images exposing `opencode`.
- Start containers with a fresh local OpenCode profile by default; `--with-opencode-config` is now an explicit opt-in for the host profile.
- Keep `opencode-handoff` isolated from the host profile and document that provider-side limits may still apply.

## Testing

- `bash -n` passes for all shell scripts.
- `quick_validate.py` passes for both skills.
- Verified default containers omit `/root/.config/opencode` and create a local profile.
- Verified `--with-opencode-config` mounts the host profile only when requested.
- Fresh-profile and host-profile smoke tests both reproduced provider `429 Rate limit exceeded` responses; this is an external provider/service limit, not profile reuse or Docker image state.